### PR TITLE
Rathazul Taurinum craft

### DIFF
--- a/classes/classes/Scenes/NPCs/Rathazul.as
+++ b/classes/classes/Scenes/NPCs/Rathazul.as
@@ -844,7 +844,7 @@ private function buyDyeNevermind():void {
 private function makeTaurPotion():void {
 	spriteSelect(49);
 	clearOutput();
-	player.destroyItems(consumables.TAURICO, 2);
+	player.destroyItems(consumables.EQUINUM, 2);
 	player.destroyItems(consumables.MINOBLO, 1);
 	player.gems -= 100;
 	statScreenRefresh();


### PR DESCRIPTION
Rathazul is asking for two Equinum and one Minotaur blood. When crafted, Equinum is left in inventory and if player had Taurinum, it's removed now.