### PR TITLE
[Fix] Disable equipping specific armor types on undergarment

### DIFF
--- a/classes/classes/Items/Armor.as
+++ b/classes/classes/Items/Armor.as
@@ -22,6 +22,15 @@ package classes.Items
 			_supportsBulge = supportsBulge;
 		}
 		
+		override public function canUse():Boolean {
+			if ((this == game.armors.LMARMOR || this == game.armors.R_BDYST || this == game.armors.BONSTRP || this == game.armors.RBBRCLT || this == game.armors.S_SWMWR) &&
+				(game.player.upperGarment != UndergarmentLib.NOTHING || game.player.lowerGarment != UndergarmentLib.NOTHING)) {
+				outputText("It would be awkward to put on " + longName + " when you're currently wearing undergarments. You should consider removing them. You put it back into your inventory.");
+				return false;
+			}
+			return super.canUse();
+		}
+
 		public function get def():Number { return _def; }
 		
 		public function get perk():String { return _perk; }


### PR DESCRIPTION
When character wears Lusty Maiden's Armor, Red Bodysuit, Bondage straps, Rubber clothes or Slutty Swimwear, he's not able to equip any undergarment. If undergarment is already equipped, character shouldn't be able to equip any of the listed armors.

Tested by myself on desktop only.