### PR TITLE
Some fixes for evasion and 4 new perks from approved list.

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -3709,6 +3709,7 @@ package classes
 		   // speed
 		   if (useMonster && game.monster != null && attackSpeed == int.MIN_VALUE) attackSpeed = game.monster.spe;
 		   if (attackSpeed != int.MIN_VALUE && spe - attackSpeed > 0 && int(Math.random() * (((spe - attackSpeed) / 4) + 80)) > 80) return "Speed";
+		   //note, Player.speedDodge is still used, since this function can't return how close it was
 		   
 		   var roll:Number = rand(100);
 		   

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -51,15 +51,6 @@
 		protected final function combatMiss():Boolean {
 			return game.combatMiss();
 		}
-		protected final function combatEvade():Boolean {
-			return game.combatEvade();
-		}
-		protected final function combatFlexibility():Boolean {
-			return game.combatFlexibility();
-		}
-		protected final function combatMisdirect():Boolean {
-			return game.combatMisdirect();
-		}
 		protected final function combatParry():Boolean {
 			return game.combatParry();
 		}
@@ -722,23 +713,28 @@
 				outputPlayerDodged(dodge);
 				return true;
 			}
+			var evasionResult:String = player.getEvasionReason(false); // use separate function for speed dodge for expanded dodge description
 			//Determine if evaded
-			if (combatEvade()) {
+			if (evasionResult == EVASION_EVADE) {
 				outputText("Using your skills at evading attacks, you anticipate and sidestep " + a + short + "'");
 				if (!plural) outputText("s");
 				outputText(" attack.\n", false);
 				return true;
 			}
 			//("Misdirection"
-			if (combatMisdirect()) {
+			if (evasionResult == EVASION_MISDIRECTION) {
 				outputText("Using Raphael's teachings, you anticipate and sidestep " + a + short + "' attacks.\n", false);
 				return true;
 			}
 			//Determine if cat'ed
-			if (combatFlexibility()) {
+			if (evasionResult == EVASION_FLEXIBILITY) {
 				outputText("With your incredible flexibility, you squeeze out of the way of " + a + short + "", false);
 				if (plural) outputText("' attacks.\n", false);
 				else outputText("'s attack.\n", false);
+				return true;
+			}
+			if (evasionResult != null) { // Failsafe fur unhandled
+				outputText("Using your superior combat skills you manage to avoid attack completely.\n", false);
 				return true;
 			}
 			//Parry with weapon

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -105,6 +105,9 @@ package classes
 		public static const ArousingAura:PerkType = mk("Arousing Aura", "Arousing Aura",
 				"Exude a lust-inducing aura (Req's corruption of 70 or more)",
 				"You choose the 'Arousing Aura' perk, causing you to radiate an aura of lust when your corruption is over 70.");
+		public static const Battlemage:PerkType = mk("Battlemage", "Battlemage",
+				"Start every battle with Might enabled, if you meet Black Magic requirements before it starts.",
+				"You choose the 'Battlemage' perk. You start every battle with Might effect, as long as your Lust is sufficient to cast it before battle.");
 		public static const Berzerker:PerkType = mk("Berzerker", "Berserker",
 				"[if(player.str>=75)" +
 						"Grants 'Berserk' ability." +
@@ -149,6 +152,9 @@ package classes
 		public static const FertilityPlus:PerkType = mk("Fertility+", "Fertility+",
 				"Increases fertility rating by 15 and cum volume by up to 50%.",
 				"You choose the 'Fertility+' perk, making it easier to get pregnant.  It also increases your cum volume by up to 50% (if appropriate)!");
+		public static const FocusedMind:PerkType = mk("Focused Mind", "Focused Mind",
+				"Black Magic is less likely to backfire and White Magic thresold is increased.",
+				"You choose the 'Focused Mind' perk. Black Magic is less likely to backfire and White Magic thresold is increased.");
 		public static const HoldWithBothHands:PerkType = mk("Hold With Both Hands", "Hold With Both Hands",
 				"Gain +20% strength modifier with melee weapons when not using a shield.",
 				"You choose the 'Hold With Both Hands' perk.  As long as you're wielding a melee weapon and you're not using a shield, you gain 20% strength modifier to damage.");
@@ -210,6 +216,9 @@ package classes
 		public static const Precision:PerkType = mk("Precision", "Precision",
 				"Reduces enemy armor by 10. (Req's 25+ Intelligence)",
 				"You've chosen the 'Precision' perk.  Thanks to your intelligence, you're now more adept at finding and striking an enemy's weak points, reducing their damage resistance from armor by 10.  If your intelligence ever drops below 25 you'll no longer be smart enough to benefit from this perk.");
+		public static const RagingInferno:PerkType = mk("Raging Inferno", "Raging Inferno",
+				"Cumulative 20% damage increase for every subsequent fire spell without interruption.",
+				"You choose the 'Raging Inferno' perk. Cumulative 20% damage increase for every subsequent fire spell without interruption.");
 		public static const Regeneration:RegenerationPerk = new RegenerationPerk();
 		public static const Regeneration2:Regeneration2Perk = new Regeneration2Perk();
 		public static const Resistance:PerkType = mk("Resistance", "Resistance",
@@ -247,6 +256,9 @@ package classes
 		public static const Spellpower:PerkType = mk("Spellpower", "Spellpower",
 				"Increases base spell strength by 50%.",
 				"You choose the 'Spellpower' perk.  Thanks to your sizeable intellect and willpower, you are able to more effectively use magic, boosting base spell effects by 50%.");
+		public static const Spellsword:PerkType = mk("Spellsword", "Spellsword",
+				"Start every battle with Charge Weapon enabled, if you meet White Magic requirements before it starts.",
+				"You choose the 'Spellsword' perk. You start every battle with Charge Weapon effect, as long as your Lust is not preventing you from casting it before battle.");
 		public static const Survivalist:PerkType = mk("Survivalist", "Survivalist",
 				"Slows hunger rate by 20%.",
 				"You choose the 'Survivalist' perk.  With this perk, your hunger rate is reduced by 20%.");

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -634,6 +634,15 @@ public function buildPerkList():Array {
 	if(player.findPerk(PerkLib.Spellpower) >= 0 && player.inte >= 50) {
 			_add(new PerkClass(PerkLib.Mage));
 	}
+	// Spell-boosting perks
+	// Battlemage: auto-use Might
+	if(player.findPerk(PerkLib.Channeling) >= 0 && player.findStatusAffect(StatusAffects.KnowsMight) >= 0 && player.inte >= 60) {
+			_add(new PerkClass(PerkLib.Battlemage));
+	}
+	// Spellsword: auto-use Charge Weapon
+	if(player.findPerk(PerkLib.Channeling) >= 0 && player.findStatusAffect(StatusAffects.KnowsCharge) >= 0 && player.inte >= 60) {
+			_add(new PerkClass(PerkLib.Spellsword));
+	}
 	//Tier 1 Intelligence Perks
 	if(player.level >= 6) {
 		if(player.inte >= 50)
@@ -649,6 +658,18 @@ public function buildPerkList():Array {
 	if(player.level >= 12) {
 		if(player.findPerk(PerkLib.Mage) >= 0 && player.inte >= 75) {
 			_add(new PerkClass(PerkLib.Archmage));
+		}
+		if(player.inte >= 75) {
+				if(player.findPerk(PerkLib.Mage) >= 0)
+					_add(new PerkClass(PerkLib.FocusedMind));
+				
+				if (player.findPerk(PerkLib.Archmage) >= 0 && player.findPerk(PerkLib.Channeling) >= 0  &&
+				(player.findStatusAffect(StatusAffects.KnowsWhitefire) >= 0
+				|| player.findPerk(PerkLib.FireLord) >= 0 
+				|| player.findPerk(PerkLib.Hellfire) >= 0 
+				|| player.findPerk(PerkLib.EnlightenedNinetails) >= 0
+				|| player.findPerk(PerkLib.CorruptedNinetails) >= 0))
+					_add(new PerkClass(PerkLib.RagingInferno));
 		}
 	}
 	//------------


### PR DESCRIPTION
4 new perks from approved list:

Battlemage:
Start every battle with Might enabled, if you meet Black Magic requirements before it starts.
Requirements: Might spell, Channeling, 60 int.

Spellsword:
Start every battle with Charge Weapon enabled, if you meet White Magic requirements before it starts.
Requirements: Charge Weapon spell, Channeling, 60 int.

Focused Mind:
Black Magic is less likely to backfire (-10%) and White Magic thresold is increased (+10%).
Requirements: Mage, 75 int.

Raging Inferno:
Cumulative 20% damage increase for every subsequent fire spell without interruption.
Requirements: Whitefire spell or fire special, Archmage, Channeling, 75 int.
Note: no cap, but it is really unnecessary, since targets strong enough to survive 5 steps of combo are likely bosses, and they have their own means to interrupt combo.