### PR TITLE
Stone mining ants + missing point for shark score

### DIFF
--- a/classes/classes/GlobalFlags/kACHIEVEMENTS.as
+++ b/classes/classes/GlobalFlags/kACHIEVEMENTS.as
@@ -59,7 +59,7 @@ package classes.GlobalFlags
 		public static const POPULATION_METROPOLIS:int				= 045; //Population 250
 		public static const POPULATION_MEGALOPOLIS:int				= 046; //Population 500
 		public static const POPULATION_CITY_STATE:int				= 047; //Population 1,000 (shadow achievement)
-		public static const POPULATION_KINGDOMN:int				= 048; //Population 2,500 (shadow achievement)
+		public static const POPULATION_KINGDOM:int				= 048; //Population 2,500 (shadow achievement)
 		public static const POPULATION_EMPIRE:int				= 049; //Population 5,000 (shadow achievement)
 		
 		//Time Achievements (050-059)

--- a/classes/classes/GlobalFlags/kACHIEVEMENTS.as
+++ b/classes/classes/GlobalFlags/kACHIEVEMENTS.as
@@ -83,8 +83,8 @@ package classes.GlobalFlags
 		public static const DUNGEON_PHOENIX_FALL:int			= 065;
 		public static const DUNGEON_ACCOMPLICE:int				= 066; //shadow achievement
 		public static const DUNGEON_EXTREMELY_CHASTE_DELVER:int	= 067; //shadow achievement
-		public static const UNKNOWN_ACHIEVEMENT_068:int			= 068;
-		public static const UNKNOWN_ACHIEVEMENT_069:int			= 069;
+		public static const DUNGEON_DELVER_APPRENTICE:int			= 068;
+		public static const DUNGEON_END_OF_REIGN:int			= 069;
 		
 		//Fashion and Wealth Achievements (070-074)(075-079)
 		public static const FASHION_WANNABE_WIZARD:int			= 070;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1489,6 +1489,9 @@ use namespace kGAMECLASS;
 				sharkCounter++;
 			if (tailType == 7)
 				sharkCounter++;
+			//skin counting only if PC got any other shark traits
+			if (skinType == 0 && sharkCounter > 0)
+				sharkCounter++;
 			return sharkCounter;
 		}
 

--- a/classes/classes/Scenes/Achievements.as
+++ b/classes/classes/Scenes/Achievements.as
@@ -194,7 +194,7 @@ package classes.Scenes
 			addAchievement("I'm No Lumberjack", kACHIEVEMENTS.GENERAL_IM_NO_LUMBERJACK, "Buy a total of 100 wood.");
 			addAchievement("Deforester", kACHIEVEMENTS.GENERAL_DEFORESTER, "Cut down 100 wood pieces.");
 			addAchievement("Yabba Dabba Doo", kACHIEVEMENTS.GENERAL_YABBA_DABBA_DOO, "Buy a total of 100 stones.");
-			//addAchievement("AntWorks", kACHIEVEMENTS.GENERAL_ANTWORKS, "Gather a total of 200 stones with Phylla help.");
+			addAchievement("AntWorks", kACHIEVEMENTS.GENERAL_ANTWORKS, "Gather a total of 200 stones with Phylla help.");
 			addAchievement("Home Sweet Home", kACHIEVEMENTS.GENERAL_HOME_SWEET_HOME, "Finish the cabin and complete it with furnishings.");
 			addAchievement("Getaway", kACHIEVEMENTS.GENERAL_GETAWAY, "Spend the night outside your camp.");
 			addAchievement("My Tent's (not) Better Than Yours", kACHIEVEMENTS.GENERAL_MY_TENT_NOT_BETTER, "Sleep in Arian's tent.");

--- a/classes/classes/Scenes/Achievements.as
+++ b/classes/classes/Scenes/Achievements.as
@@ -101,11 +101,13 @@ package classes.Scenes
 			addAchievement("Century", kACHIEVEMENTS.TIME_CENTURY, "Get to day 36,500. (100 years)", "Get to day 36,500. (100 years | It's time to stop playing. Go outside.)", true);
 			addAchievement("Time Traveller", kACHIEVEMENTS.TIME_TRAVELLER, "Get to day 36,500+ by tampering with save", "", true);
 			
-			titleAchievementSection("Dungeons"); //8 achievements
-			addAchievement("Delver", kACHIEVEMENTS.DUNGEON_DELVER, "Clear 3 dungeons.");
+			titleAchievementSection("Dungeons"); //10 achievements
+			addAchievement("Delver", kACHIEVEMENTS.DUNGEON_DELVER, "Clear any dungeon.");
+			addAchievement("Delver Apprentice", kACHIEVEMENTS.DUNGEON_DELVER, "Clear 3 dungeons.");
 			addAchievement("Delver Master", kACHIEVEMENTS.DUNGEON_DELVER_MASTER, "Clear every dungeon in the game.");
 			addAchievement("Shut Down Everything", kACHIEVEMENTS.DUNGEON_SHUT_DOWN_EVERYTHING, "Clear the Factory.");
 			addAchievement("You're in Deep", kACHIEVEMENTS.DUNGEON_YOURE_IN_DEEP, "Fully clear the Deep Cave.");
+			addAchievement("End of Reign", kACHIEVEMENTS.DUNGEON_END_OF_REIGN, "Fully clear the Lethice Stronghold.");
 			addAchievement("Friend of the Sand Witches", kACHIEVEMENTS.DUNGEON_SAND_WITCH_FRIEND, "Fully clear the Desert Cave.");
 			addAchievement("Fall of the Phoenix", kACHIEVEMENTS.DUNGEON_PHOENIX_FALL, "Clear the Tower of the Phoenix.");
 			addAchievement("Accomplice", kACHIEVEMENTS.DUNGEON_ACCOMPLICE, "Watch Helia kill the Harpy Queen.", "", true);

--- a/classes/classes/Scenes/Achievements.as
+++ b/classes/classes/Scenes/Achievements.as
@@ -87,7 +87,7 @@ package classes.Scenes
 			addAchievement("Metropolis", kACHIEVEMENTS.POPULATION_METROPOLIS, "Have a camp population of 250.");
 			addAchievement("Megalopolis", kACHIEVEMENTS.POPULATION_MEGALOPOLIS, "Have a camp population of 500.");
 			addAchievement("City-State", kACHIEVEMENTS.POPULATION_CITY_STATE, "Have a camp population of 1,000.", "", true);
-			addAchievement("Kingdomn", kACHIEVEMENTS.POPULATION_KINGDOMN, "Have a camp population of 2,500.", "", true);
+			addAchievement("Kingdom", kACHIEVEMENTS.POPULATION_KINGDOM, "Have a camp population of 2,500.", "", true);
 			addAchievement("Empire", kACHIEVEMENTS.POPULATION_EMPIRE, "Have a camp population of 5,000.", "", true);
 			
 			titleAchievementSection("Time"); //9 achievements

--- a/classes/classes/Scenes/Areas/Desert/AntsScene.as
+++ b/classes/classes/Scenes/Areas/Desert/AntsScene.as
@@ -1070,7 +1070,7 @@ package classes.Scenes.Areas.Desert
 				outputText("\n\nThe second your eyes lock onto her back, you feel something in your mind twitch.  You see the same thing happen to her as her whole body twitches.  She quickly turns around and runs over to you.");
 				outputText("\n\n\"<i>You came back! I mean... I hope you like it. I mean welcome... What do you want to talk about?</i>\"");
 			}
-			//[Talk] [Sex] [Lay Eggs / Don't Lay Eggs] [Children] [Appearance] [Gems]
+			//[Talk] [Sex] [Lay Eggs / Don't Lay Eggs] [Children] [Appearance] [Gems] [Stones]
 			menu();
 			addButton(0, "Talk", phyllaTalkChoices);
 			if (player.lust >= 33) addButton(1, "Sex", phyllaSexMenu);
@@ -1079,7 +1079,7 @@ package classes.Scenes.Areas.Desert
 			if (flags[kFLAGS.ANT_KIDS] > 0) addButton(3, "Children", phyllasKidsChildren);
 			addButton(4, "Appearance", phyllaPearance);
 			addButton(5, "Find Gems", phyllaDigsForGems);
-			//addButton(6, "Stones", phyllaStones);
+			addButton(6, "Take Stones", phyllaStones);
 			addButton(14, "Back", camp.campLoversMenu);
 
 			flags[kFLAGS.PHYLLA_CAMP_VISITS]++;
@@ -2644,43 +2644,32 @@ package classes.Scenes.Areas.Desert
 		}
 
 //[Stones]
-		//private function phyllaStones():void
-		//{
-			//clearOutput();
-			//var kidsMod:int = 0;
-			//if (flags[kFLAGS.ANT_KIDS] > 10) kidsMod++;
-			//if (flags[kFLAGS.ANT_KIDS] > 50) kidsMod++;
-			//if (flags[kFLAGS.ANT_KIDS] > 150) kidsMod++;
-			//if (flags[kFLAGS.ANT_KIDS] > 300) kidsMod++;
-			//if (flags[kFLAGS.ANT_KIDS] > 600) kidsMod++;
-			//if (flags[kFLAGS.ANT_KIDS] > 1000) kidsMod++;
-			//if (flags[kFLAGS.ANT_KIDS] > 2000) kidsMod++;
-			
-				//var stones:int = 0;
-				//stones = 10 + rand(10) + kidsMod * 2;
-				//player.stones += stones;
-				//statScreenRefresh();
-				//If Phylla IS NOT Laying Eggs
-				//if (flags[kFLAGS.PHYLLA_EGG_LAYING] == 0) {
-					//outputText("You ask Phylla is she's found any gems while digging out her colony.  She nods happily and runs over to a small stone chest and rifles though it.  After a moment, she runs back over to you and holds up all four of her hands.");
-					//outputText("\n\n\"<i>I hope... this is enough, I mean... they're rare, even down here.</i>\"  You mess up her hair with your hand, laughing. Telling her it's enough, you advise her to keep looking.  She gives you a playful salute as you place the gems into your pouch.");
-					//outputText("\n\nYou gain " + gems + " gems.");
-					//outputText("\n\n\"<i>Is there anything else you wanted to do while you're down here?</i>\"  She asks excitedly.");
-				}
-				//If Phylla IS Laying Eggs
-				//else {
-					//outputText("You ask Phylla if she or her children have found any gems while digging.  She nods happily and closes her eyes, tilting her head back slightly.  After a moment one your children scampers in. He runs overs to a small stone chest in the corner of Phylla's room and after a moment of rifling through it he finds what he's looking for.  Walking over to you, he presents his findings.  You accept the gems he's retrieved.");
-					//if corruption under 50
-					//if (player.cor < 50) outputText("\n\nYou pat him on the head for a job well done as he walks deeper into the colony leaving you alone with Phylla.");
-					//If corruption over 50
-					//else outputText("\n\nYou count the gems, and give both him and Phylla a look of disappointment.  Sighing heavily, you point decisively at the exit and your child hangs his head in shame as he heads back into the tunnels.  Phylla looks just as depressed and just stares at the ground, unable to really move due to her 'pregnancy.'");
-					//outputText("\n\n\"<i>Is there anything else you wanted to do while you're down here?</i>\"");
-					//outputText("\n\nYou gain " + gems + " gems.");
-				}
+		private function phyllaStones():void
+		{
+			stone = 2 + rand(10);
+			flags[kFLAGS.ACHIEVEMENT_PROGRESS_ANTWORKS] += stone;
+			if (flags[kFLAGS.ACHIEVEMENT_PROGRESS_ANTWORKS] >= 200) awardAchievement("AntWorks", kACHIEVEMENTS.GENERAL_ANTWORKS);
+			flags[kFLAGS.CAMP_CABIN_STONE_RESOURCES] += stone;
+			statScreenRefresh();
+			//If Phylla IS NOT Laying Eggs
+			if (flags[kFLAGS.PHYLLA_EGG_LAYING] == 0) {
+				outputText("You ask Phylla is she's got any spare stones from digging, which you can take.  She nods happily and runs over to a small stone pile and rifles though it.  After a moment, she runs back over to you and holds up all four of her hands.");
+				outputText("\n\n\"<i>I hope... this is enough, I mean... we almost always digging, so there will be more of them soon.</i>\"  You mess up her hair with your hand, laughing. Telling her it's enough, you advise her to keep some of them instead throwing outside.  She gives you a playful salute as you taking the stones from her hands.");
+				outputText("\n\nYou gain " + stone + " stones.");
+				outputText("\n\n\"<i>Is there anything else you wanted to do while you're down here?</i>\"  She asks excitedly.");
 			}
-			//flags[kFLAGS.PHYLLA_GEMS_HUNTED_TODAY] = 1;
-			//doNext(camp.returnToCampUseOneHour);
-		//}
+			//If Phylla IS Laying Eggs
+			else {
+				outputText("You ask Phylla if she allow take you few of the stones that her or her children have gathered while digging.  She nods happily and closes her eyes, tilting her head back slightly.  After a moment one your children scampers in. He runs overs to a stone pile in the corner of Phylla's room and after a moment of gathering walking over to you, he giving you few stones.  You accept them.");
+				//if corruption under 50
+				if (player.cor < 50) outputText("\n\nYou pat him on the head for a job well done as he walks deeper into the colony leaving you alone with Phylla.");
+				//If corruption over 50
+				else outputText("\n\nYou count the stones, and give both him and Phylla a look of disappointment.  Sighing heavily, you point decisively at the exit and your child hangs his head in shame as he heads back into the tunnels.  Phylla looks just as depressed and just stares at the ground, unable to really move due to her 'pregnancy.'");
+				outputText("\n\n\"<i>Is there anything else you wanted to do while you're down here?</i>\"");
+				outputText("\n\nYou gain " + stone + " stones.");
+			}
+			doNext(camp.returnToCampUseOneHour);
+		}
 
 //Drider/Bee impregnation scene for Phylla (universal unless otherwise specified, which will include varied intros and stuff.
 //Sex > [Egg Phylla]

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -625,7 +625,7 @@ private function doCamp():void { //Only called by playerMenu
 		}
 	}
 	else outputText("You have a number of traps surrounding your makeshift home, but they are fairly simple and may not do much to deter a demon.  ", false);
-	if(flags[kFLAGS.ANT_KIDS] > 1,000) outputText("The portal shimmers in the background as it always does, looking menacing and reminding you of why you came.  Really close to it there is a small entrance to the underground maze created by your ant chilren.  And due to Phylla wish from time to time one of your children comming out this entrance to check on the situation near portal.  You feel a little safe now knowing that it will be harder for anyone to goes near portal without been noticed or...if someone came out of the portal.\n\n", false);
+	if(flags[kFLAGS.ANT_KIDS] > 1000) outputText("The portal shimmers in the background as it always does, looking menacing and reminding you of why you came.  Really close to it there is a small entrance to the underground maze created by your ant children.  And due to Phylla wish from time to time one of your children comming out this entrance to check on the situation near portal.  You feel a little more safe now knowing that it will be harder for anyone to go near the portal without been noticed or...if someone came out of the portal.\n\n", false);
 	else outputText("The portal shimmers in the background as it always does, looking menacing and reminding you of why you came.\n\n", false);
 
 	//Ember's anti-minotaur crusade!
@@ -1092,8 +1092,8 @@ public function campLoversMenu(descOnly:Boolean = false):void {
 		outputText("You see Phylla's anthill in the distance.  Every now and then you see");
 		//If PC has children w/ Phylla:
 		if(flags[kFLAGS.ANT_KIDS] > 0 && flags[kFLAGS.ANT_KIDS] <= 250) outputText(" one of your children exit the anthill to unload some dirt before continuing back down into the colony.  It makes you feel good knowing your offspring are so productive.");
-		if(flags[kFLAGS.ANT_KIDS] > 250 && flags[kFLAGS.ANT_KIDS] <= 1,000) outputText(" few of your many children exit the anthill to unload some dirt before vanishing back inside.  It makes you feel good knowing your offspring are so productive.");
-		if(flags[kFLAGS.ANT_KIDS] > 1,000) outputText(" some of your chilren exit the anthill using main or one of the additionaly entrances to unload some dirt. Some of them instead of unloading dirt comming out to fullfill some other task that their mother gave them.  You feel a little nostalgic seeing how this former small colony grown to such a magnificent size.");
+		if(flags[kFLAGS.ANT_KIDS] > 250 && flags[kFLAGS.ANT_KIDS] <= 1000) outputText(" few of your many children exit the anthill to unload some dirt before vanishing back inside.  It makes you feel good knowing your offspring are so productive.");
+		if(flags[kFLAGS.ANT_KIDS] > 1000) outputText(" some of your children exit the anthill using main or one of the additionaly entrances to unload some dirt. Some of them instead of unloading dirt comming out to fullfill some other task that their mother gave them.  You feel a little nostalgic seeing how this former small colony grown to such a magnificent size.");
 		else outputText(" Phylla appear out of the anthill to unload some dirt.  She looks over to your campsite and gives you an excited wave before heading back into the colony.  It makes you feel good to know she's so close.");
 		outputText("\n\n");
 		addButton(8,"Phylla", getGame().desert.antsScene.introductionToPhyllaFollower);

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -1091,8 +1091,8 @@ public function campLoversMenu(descOnly:Boolean = false):void {
 	if (flags[kFLAGS.ANT_WAIFU] > 0) {
 		outputText("You see Phylla's anthill in the distance.  Every now and then you see");
 		//If PC has children w/ Phylla:
-		if(flags[kFLAGS.ANT_KIDS] > 0 && flags[kFLAGS.ANT_KIDS] < 250) outputText(" one of your children exit the anthill to unload some dirt before continuing back down into the colony.  It makes you feel good knowing your offspring are so productive.");
-		if(flags[kFLAGS.ANT_KIDS] > 250 && flags[kFLAGS.ANT_KIDS] < 1,000) outputText(" few of your many children exit the anthill to unload some dirt before vanishing back inside.  It makes you feel good knowing your offspring are so productive.");
+		if(flags[kFLAGS.ANT_KIDS] > 0 && flags[kFLAGS.ANT_KIDS] <= 250) outputText(" one of your children exit the anthill to unload some dirt before continuing back down into the colony.  It makes you feel good knowing your offspring are so productive.");
+		if(flags[kFLAGS.ANT_KIDS] > 250 && flags[kFLAGS.ANT_KIDS] <= 1,000) outputText(" few of your many children exit the anthill to unload some dirt before vanishing back inside.  It makes you feel good knowing your offspring are so productive.");
 		if(flags[kFLAGS.ANT_KIDS] > 1,000) outputText(" some of your chilren exit the anthill using main or one of the additionaly entrances to unload some dirt. Some of them instead of unloading dirt comming out to fullfill some other task that their mother gave them.  You feel a little nostalgic seeing how this former small colony grown to such a magnificent size.");
 		else outputText(" Phylla appear out of the anthill to unload some dirt.  She looks over to your campsite and gives you an excited wave before heading back into the colony.  It makes you feel good to know she's so close.");
 		outputText("\n\n");

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2743,9 +2743,11 @@ private function updateAchievements():void {
 		if (flags[kFLAGS.TIMES_ORGASMED] <= 0 && flags[kFLAGS.MOD_SAVE_VERSION] == kGAMECLASS.modSaveVersion) awardAchievement("Extremely Chaste Delver", kACHIEVEMENTS.DUNGEON_EXTREMELY_CHASTE_DELVER);
 	}
 	if (kGAMECLASS.dungeons.checkLethiceStrongholdClear()) {
+		awardAchievement("End of Reign", kACHIEVEMENTS.DUNGEON_END_OF_REIGN);
 		dungeonsCleared++;
 	}
-	if (dungeonsCleared >= 3) awardAchievement("Delver", kACHIEVEMENTS.DUNGEON_DELVER);
+	if (dungeonsCleared >= 1) awardAchievement("Delver", kACHIEVEMENTS.DUNGEON_DELVER);
+	if (dungeonsCleared >= 3) awardAchievement("Delver Apprentice", kACHIEVEMENTS.DUNGEON_DELVER_APPRENTICE);
 	if (dungeonsCleared >= 5) awardAchievement("Delver Master", kACHIEVEMENTS.DUNGEON_DELVER_MASTER);
 	
 	//Fashion

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2709,9 +2709,9 @@ private function updateAchievements():void {
 	if (getCampPopulation() >= 100) awardAchievement("City", kACHIEVEMENTS.POPULATION_CITY);
 	if (getCampPopulation() >= 250) awardAchievement("Metropolis", kACHIEVEMENTS.POPULATION_METROPOLIS);
 	if (getCampPopulation() >= 500) awardAchievement("Megalopolis", kACHIEVEMENTS.POPULATION_MEGALOPOLIS);
-	if (getCampPopulation() >= 1,000) awardAchievement("City-State", kACHIEVEMENTS.POPULATION_CITY_STATE);
-	if (getCampPopulation() >= 2,500) awardAchievement("Kingdomn", kACHIEVEMENTS.POPULATION_KINGDOMN);
-	if (getCampPopulation() >= 5,000) awardAchievement("Empire", kACHIEVEMENTS.POPULATION_EMPIRE);
+	if (getCampPopulation() >= 1000) awardAchievement("City-State", kACHIEVEMENTS.POPULATION_CITY_STATE);
+	if (getCampPopulation() >= 2500) awardAchievement("Kingdomn", kACHIEVEMENTS.POPULATION_KINGDOMN);
+	if (getCampPopulation() >= 5000) awardAchievement("Empire", kACHIEVEMENTS.POPULATION_EMPIRE);
 	
 	//Time
 	if (model.time.days >= 30) awardAchievement("It's been a month", kACHIEVEMENTS.TIME_MONTH);

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2710,7 +2710,7 @@ private function updateAchievements():void {
 	if (getCampPopulation() >= 250) awardAchievement("Metropolis", kACHIEVEMENTS.POPULATION_METROPOLIS);
 	if (getCampPopulation() >= 500) awardAchievement("Megalopolis", kACHIEVEMENTS.POPULATION_MEGALOPOLIS);
 	if (getCampPopulation() >= 1000) awardAchievement("City-State", kACHIEVEMENTS.POPULATION_CITY_STATE);
-	if (getCampPopulation() >= 2500) awardAchievement("Kingdomn", kACHIEVEMENTS.POPULATION_KINGDOMN);
+	if (getCampPopulation() >= 2500) awardAchievement("Kingdom", kACHIEVEMENTS.POPULATION_KINGDOM);
 	if (getCampPopulation() >= 5000) awardAchievement("Empire", kACHIEVEMENTS.POPULATION_EMPIRE);
 	
 	//Time

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -625,7 +625,8 @@ private function doCamp():void { //Only called by playerMenu
 		}
 	}
 	else outputText("You have a number of traps surrounding your makeshift home, but they are fairly simple and may not do much to deter a demon.  ", false);
-	outputText("The portal shimmers in the background as it always does, looking menacing and reminding you of why you came.\n\n", false);
+	if(flags[kFLAGS.ANT_KIDS] > 1,000) outputText("The portal shimmers in the background as it always does, looking menacing and reminding you of why you came.  Really close to it there is a small entrance to the underground maze created by your ant chilren.  And due to Phylla wish from time to time one of your children comming out this entrance to check on the situation near portal.  You feel a little safe now knowing that it will be harder for anyone to goes near portal without been noticed or...if someone came out of the portal.\n\n", false);
+	else outputText("The portal shimmers in the background as it always does, looking menacing and reminding you of why you came.\n\n", false);
 
 	//Ember's anti-minotaur crusade!
 	if(flags[kFLAGS.EMBER_CURRENTLY_FREAKING_ABOUT_MINOCUM] == 1) {
@@ -1090,7 +1091,9 @@ public function campLoversMenu(descOnly:Boolean = false):void {
 	if (flags[kFLAGS.ANT_WAIFU] > 0) {
 		outputText("You see Phylla's anthill in the distance.  Every now and then you see");
 		//If PC has children w/ Phylla:
-		if(flags[kFLAGS.ANT_KIDS] > 0) outputText(" one of your many children exit the anthill to unload some dirt before continuing back down into the colony.  It makes you feel good knowing your offspring are so productive.");
+		if(flags[kFLAGS.ANT_KIDS] > 0 && flags[kFLAGS.ANT_KIDS] < 250) outputText(" one of your children exit the anthill to unload some dirt before continuing back down into the colony.  It makes you feel good knowing your offspring are so productive.");
+		if(flags[kFLAGS.ANT_KIDS] > 250 && flags[kFLAGS.ANT_KIDS] < 1,000) outputText(" few of your many children exit the anthill to unload some dirt before vanishing back inside.  It makes you feel good knowing your offspring are so productive.");
+		if(flags[kFLAGS.ANT_KIDS] > 1,000) outputText(" some of your chilren exit the anthill using main or one of the additionaly entrances to unload some dirt. Some of them instead of unloading dirt comming out to fullfill some other task that their mother gave them.  You feel a little nostalgic seeing how this former small colony grown to such a magnificent size.");
 		else outputText(" Phylla appear out of the anthill to unload some dirt.  She looks over to your campsite and gives you an excited wave before heading back into the colony.  It makes you feel good to know she's so close.");
 		outputText("\n\n");
 		addButton(8,"Phylla", getGame().desert.antsScene.introductionToPhyllaFollower);


### PR DESCRIPTION
**Added**
-Option to get stones with Phylla help (plus connected to this achievement)
-Few flavor changes in description of camp depending on amount of ant children (now it depend how much we got not only if we got any of them)
-Now clearing final dungoen is rewarded with achievement too
-Clearing any dungeon also giving something now ;)
**Changes**
-Shark-morph bonus stats was unable to be attained ingame due to missing one point in sharkScore (but now it should be possible to enjoy bonuses of this type of morph)
-Fixed few typo from previous pull req