### PR TITLE
[FIX] D3 Lethice Dialogue (1.3.21)

### DIFF
--- a/classes/classes/Scenes/Dungeons/D3/LethiceScenes.as
+++ b/classes/classes/Scenes/Dungeons/D3/LethiceScenes.as
@@ -630,7 +630,7 @@ package classes.Scenes.Dungeons.D3
 			outputText("\n\nThe sight of such a magnificent, victorious orgy sends shivers of delight through you almost as sexual as the wet, tight hug of your consort’s sex around your");
 			if(player.hasCock())
 			{
-				outputText(" [cock]");
+				outputText(" [cock].");
 			}
 			else
 			{


### PR DESCRIPTION
For those already with a cock, there was a lacking period, producing a run-on sentence from Line 633 continuing at 639 in classes/classes/Scenes/Dungeons/D3/LethiceScenes.as.