### PR TITLE
Deprecation of SKIN_TYPE_UNDEFINED

### DIFF
--- a/classes/classes/Items/Consumables/RizzaRoot.as
+++ b/classes/classes/Items/Consumables/RizzaRoot.as
@@ -27,7 +27,7 @@ package classes.Items.Consumables
 					outputText("\n\nYour fur itches incessantly, so you start scratching it.  It starts coming off in big clumps before the whole mess begins sloughing off your body.  In seconds, your skin is hairless, or nearly so. <b>You've lost your fur!</b>");
 				else if (player.skinType == 2)
 					outputText("\n\nYour scales itch incessantly, so you scratch at them.  They start falling off wholesale, leaving you standing in a pile of scales after only a few moments. <b>You've lost your scales!</b>");
-				else if (player.skinType > 2)
+				else if (player.skinType == 3)
 					outputText("\n\nYour " + player.skinDesc + " itches incessantly, and as you scratch it shifts and changes, becoming normal human-like skin. <b>Your skin is once again normal!</b>");
 				player.skinDesc = "skin";
 				player.skinType = 0;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -2881,7 +2881,7 @@
 					if (player.skinType == SKIN_TYPE_PLAIN) outputText(" loses its blemishes, becoming flawless smooth skin.", false);
 					if (player.skinType == SKIN_TYPE_FUR) outputText(" falls out in clumps, revealing smooth skin underneath.", false);
 					if (player.skinType == SKIN_TYPE_SCALES) outputText(" begins dropping to the ground in a pile around you, revealing smooth skin underneath.", false);
-					if (player.skinType > SKIN_TYPE_SCALES) outputText(" shifts and changes into flawless smooth skin.", false);
+					if (player.skinType == SKIN_TYPE_GOO) outputText(" shifts and changes into flawless smooth skin.", false);
 					player.skinDesc = "skin";
 					player.skinAdj = "smooth";
 					if (player.skinTone == "rough gray") player.skinTone = "gray";
@@ -2934,7 +2934,7 @@
 					if (player.skinType == SKIN_TYPE_PLAIN) outputText(" loses its blemishes, becoming flawless smooth skin.", false);
 					if (player.skinType == SKIN_TYPE_FUR) outputText(" falls out in clumps, revealing smooth skin underneath.", false);
 					if (player.skinType == SKIN_TYPE_SCALES) outputText(" begins dropping to the ground in a pile around you, revealing smooth skin underneath.", false);
-					if (player.skinType > SKIN_TYPE_SCALES) outputText(" shifts and changes into flawless smooth skin.", false);
+					if (player.skinType == SKIN_TYPE_GOO) outputText(" shifts and changes into flawless smooth skin.", false);
 					player.skinDesc = "skin";
 					player.skinAdj = "smooth";
 					if (player.skinTone == "rough gray") player.skinTone = "gray";
@@ -3771,7 +3771,7 @@
 			if (player.skinType != SKIN_TYPE_PLAIN && changes < changeLimit && rand(4) == 0 && player.faceType == FACE_HUMAN) {
 				if (player.skinType == SKIN_TYPE_FUR) outputText("\n\nYour fur itches incessantly, so you start scratching it.  It starts coming off in big clumps before the whole mess begins sloughing off your body.  In seconds, your skin is nude.  <b>You've lost your fur!</b>", false);
 				if (player.skinType == SKIN_TYPE_SCALES) outputText("\n\nYour scales itch incessantly, so you scratch at them.  They start falling off wholesale, leaving you standing in a pile of scales after only a few moments.  <b>You've lost your scales!</b>", false);
-				if (player.skinType > SKIN_TYPE_SCALES) outputText("\n\nYour " + player.skinDesc + " itches incessantly, and as you scratch it shifts and changes, becoming normal human-like skin.  <b>Your skin is once again normal!</b>", false);
+				if (player.skinType == SKIN_TYPE_GOO) outputText("\n\nYour " + player.skinDesc + " itches incessantly, and as you scratch it shifts and changes, becoming normal human-like skin.  <b>Your skin is once again normal!</b>", false);
 				player.skinAdj = "";
 				player.skinDesc = "skin";
 				player.skinType = SKIN_TYPE_PLAIN;
@@ -3902,7 +3902,6 @@
 				if (player.skinType == SKIN_TYPE_PLAIN) outputText("\n\nYou sigh, feeling your " + player.armorName + " sink into you as your skin becomes less solid, gooey even.  You realize your entire body has become semi-solid and partly liquid!", false);
 				else if (player.skinType == SKIN_TYPE_FUR) outputText("\n\nYou sigh, suddenly feeling your fur become hot and wet.  You look down as your " + player.armorName + " sinks partway into you.  With a start you realize your fur has melted away, melding into the slime-like coating that now serves as your skin.  You've become partly liquid and incredibly gooey!", false);
 				else if (player.skinType == SKIN_TYPE_SCALES) outputText("\n\nYou sigh, feeling slippery wetness over your scales.  You reach to scratch it and come away with a slippery wet coating.  Your scales have transformed into a slimy goop!  Looking closer, you realize your entire body has become far more liquid in nature, and is semi-solid.  Your " + player.armorName + " has even sunk partway into you.", false);
-				else if (player.skinType > SKIN_TYPE_GOO) outputText("\n\nYou sigh, feeling your " + player.armorName + " sink into you as your " + player.skinDesc + " becomes less solid, gooey even.  You realize your entire body has become semi-solid and partly liquid!", false);
 				player.skinType = SKIN_TYPE_GOO;
 				player.skinDesc = "skin";
 				player.skinAdj = "slimy";
@@ -5765,7 +5764,7 @@
 				//Libido over 60? FUCK YEAH!
 				else if (player.lib < 80) {
 					outputText("\n\nYou fan your neck and start to pant as your " + player.skinTone + " skin begins to flush red with heat", false);
-					if (player.skinType > SKIN_TYPE_PLAIN) outputText(" through your " + player.skinDesc, false);
+					if (player.skinType != SKIN_TYPE_PLAIN) outputText(" through your " + player.skinDesc, false);
 					outputText(".  ", false);
 					if (player.gender == 1) outputText("Compression tightens down on " + player.sMultiCockDesc() + " as it strains against your " + player.armorName + ".  You struggle to fight down your heightened libido, but it's hard – so very hard.", false);
 					else if (player.gender == 0) outputText("Sexual hunger seems to gnaw at your " + player.assholeDescript() + ", demanding it be filled, but you try to resist your heightened libido.  It's so very, very hard.", false);
@@ -6008,7 +6007,7 @@
 				//Libido over 60? FUCK YEAH!
 				else if (player.lib < 80) {
 					outputText("\n\nYou fan your neck and start to pant as your " + player.skinTone + " skin begins to flush red with heat", false);
-					if (player.skinType > SKIN_TYPE_PLAIN) outputText(" through your " + player.skinDesc, false);
+					if (player.skinType != SKIN_TYPE_PLAIN) outputText(" through your " + player.skinDesc, false);
 					outputText(".  ", false);
 					if (player.gender == 1) outputText("Compression tightens down on " + player.sMultiCockDesc() + " as it strains against your " + player.armorName + ".  You struggle to fight down your heightened libido, but it's hard – so very hard.", false);
 					else if (player.gender == 0) outputText("Sexual hunger seems to gnaw at your " + player.assholeDescript() + ", demanding it be filled, but you try to resist your heightened libido.  It's so very, very hard.", false);
@@ -8941,7 +8940,7 @@
 				//from skinscales
 				if (player.skinType != SKIN_TYPE_FUR) {
 					outputText("\n\nYour " + player.skinFurScales() + " itch");
-					if (player.skinType > SKIN_TYPE_PLAIN) outputText("es");
+					if (player.skinType != SKIN_TYPE_PLAIN) outputText("es");
 					outputText(" all over");
 					if (player.tailType > TAIL_TYPE_NONE) outputText(", except on your tail");
 					outputText(".  Alarmed and suspicious, you tuck in your hands, trying to will yourself not to scratch, but it doesn't make much difference.  Tufts of ");

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1272,7 +1272,7 @@ use namespace kGAMECLASS;
 				score--;
 			if (tailType == 5)
 				score += 2;
-			if (skinType > 0 && score > 0)
+			if (skinType != SKIN_TYPE_PLAIN && score > 0)
 				score--;
 			return score;
 		}
@@ -1329,8 +1329,10 @@ use namespace kGAMECLASS;
 			//If the character has fur, scales, or gooey skin, -1
 			if (skinType == SKIN_TYPE_FUR && !InCollection(furColor, KitsuneScene.basicKitsuneFur) && !InCollection(furColor, KitsuneScene.elderKitsuneColors))
 				kitsuneCounter--;
-			if (skinType > SKIN_TYPE_FUR)
-				kitsuneCounter -= skinType; // -2 sor scales, -3 for goo
+			if (skinType == SKIN_TYPE_SCALES)
+				kitsuneCounter -= 2;
+			if (skinType == SKIN_TYPE_GOO)
+				kitsuneCounter -= 3;
 			//If the character has abnormal legs, -1
 			if (lowerBody != LOWER_BODY_TYPE_HUMAN && lowerBody != LOWER_BODY_TYPE_FOX)
 				kitsuneCounter--;
@@ -1519,7 +1521,7 @@ use namespace kGAMECLASS;
 			var mutantCounter:Number = 0;
 			if (faceType > 0)
 				mutantCounter++;
-			if (skinType > 0)
+			if (skinType != SKIN_TYPE_PLAIN)
 				mutantCounter++;
 			if (tailType > 0)
 				mutantCounter++;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1647,6 +1647,13 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			player.skinAdj = saveFile.data.skinAdj;
 		player.skinTone = saveFile.data.skinTone;
 		player.skinDesc = saveFile.data.skinDesc;
+		//Silently discard SKIN_TYPE_UNDEFINED
+		if (player.skinType == SKIN_TYPE_UNDEFINED)
+		{
+			player.skinAdj = "";
+			player.skinDesc = "skin";
+			player.skinType = SKIN_TYPE_PLAIN;
+		}
 		//Convert from old skinDesc to new skinAdj + skinDesc!
 		if (player.skinDesc.indexOf("smooth") != -1)
 		{

--- a/classes/classes/Scenes/NPCs/CeraphScene.as
+++ b/classes/classes/Scenes/NPCs/CeraphScene.as
@@ -866,7 +866,7 @@ package classes.Scenes.NPCs
 			else if (player.cor > 33) outputText("and you squirm and writhe within your " + player.armorName + ", the material itching on your skin.  Ultimately, you manage to resist.", false);
 			else outputText("and you stifle a laugh at the ridiculous thought, ignoring your fingers while they scratch at the itch under your gear.", false);
 			outputText("  Your ", false);
-			if (player.skinType <= SKIN_TYPE_FUR) outputText("skin burns", false);
+			if ([SKIN_TYPE_PLAIN, SKIN_TYPE_FUR].indexOf(player.skinType) >= 0) outputText("skin burns", false);
 			else if (player.skinType == SKIN_TYPE_SCALES) outputText("scales burn", false);
 			else outputText(player.skinDesc + " burns", false);
 			outputText(" hot, raging from fetish-enhanced lust and daydreams, but you shake your head in time to see a pair of inky black orbs rising from behind a nearby boulder.\n\n", false);

--- a/classes/classes/Scenes/NPCs/Exgartuan.as
+++ b/classes/classes/Scenes/NPCs/Exgartuan.as
@@ -370,7 +370,7 @@ public function exgartuanMasturbation():void {
 			outputText("You shrug off your top eagerly, ready to cooperate with the demon inside your " + player.allBreastsDescript() + " and enjoy a relaxing tit-massage.  You slide the offending material to the side and marvel at the wondrously large orbs on your chest.  Truly any place that can give you such wonderful endowments can't be evil.  You lean back, enjoying the warmth in the air as it flows over every extra-sensitive inch of your mounds, more than ready to get started.\n\n", false);
 		}
 		outputText("Both hands rise unbidden and begin to caress your " + player.breastDescript(0) + ".  They slide over every sensitive inch of ", false);
-		if (player.skinType == SKIN_TYPE_PLAIN || player.skinType >= SKIN_TYPE_UNDEFINED) outputText("flesh", false);
+		if (player.skinType == SKIN_TYPE_PLAIN) outputText("flesh", false);
 		else if (player.skinType == SKIN_TYPE_FUR) outputText("furry-covered flesh", false);
 		else if (player.skinType == SKIN_TYPE_SCALES) outputText("soft scaley flesh", false);
 		else outputText("gooey surface", false);

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -15,7 +15,7 @@ public static const SKIN_TYPE_PLAIN:int                                         
 public static const SKIN_TYPE_FUR:int                                               =    1;
 public static const SKIN_TYPE_SCALES:int                                            =    2;
 public static const SKIN_TYPE_GOO:int                                               =    3;
-public static const SKIN_TYPE_UNDEFINED:int                                         =    4;
+public static const SKIN_TYPE_UNDEFINED:int                                         =    4; // DEPRECATED, silently discarded upon loading a saved game
 
 // hairType
 public static const HAIR_NORMAL:int                                                =     0;


### PR DESCRIPTION
* Your skin never becomes `SKIN_TYPE_UNDEFINED`
* Probably a relic from older versions of the game
* Now silently discarded, when loading a savegame
* I've modified all inequations
  (skinType <= ..., skinType > ... and so on), to use equations
* I'll leave it in Appearance.as and appearanceDefs.as for now.