### PR TITLE
Fix HORNS_UNICORN not being handled in the appearance tab

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -821,10 +821,17 @@ use namespace kGAMECLASS;
 				if (isTaur())
 					race = "centaur-morph";
 				else
-					if (hornType == HORNS_UNICORN)
-						race = "unicorn-morph";
-					else
-						race = "equine-morph";
+					if (hornType == HORNS_UNICORN) {
+						if (wingType == WING_TYPE_FEATHERED_LARGE)
+							race = "alicorn";
+						else
+							race = "unicorn-morph";
+					} else {
+						if (wingType == WING_TYPE_FEATHERED_LARGE)
+							race = "pegasus";
+						else
+							race = "equine-morph";
+					}
 			}
 			if (mutantScore() >= 5 && race == "human")
 				race = "corrupted mutant";
@@ -933,12 +940,25 @@ use namespace kGAMECLASS;
 			//</mod>
 			if (lowerBody == 3)
 				race = "naga";
-				
+
 			if (lowerBody == LOWER_BODY_TYPE_HOOFED && isTaur()) {
-				if (wingType == WING_TYPE_FEATHERED_LARGE) race = "pegataur";
-				else race = "centaur";
+				if (wingType == WING_TYPE_FEATHERED_LARGE) {
+					if (hornType == HORNS_UNICORN)
+						race = "alicorn-taur";
+					else
+						race = "pegataur";
+				} else {
+					if (hornType == HORNS_UNICORN)
+						race = "unicorn-taur";
+					else {
+						if (horseScore() >= 5)
+							race = "equitaur";
+						else
+							race = "centaur";
+					}
+				}
 			}
-			
+
 			if (lowerBody == LOWER_BODY_TYPE_PONY)
 				race = "pony-kin";
 

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -408,7 +408,14 @@ package classes
 				else {
 					outputText("  A single horn sprouts from your forehead.  It is conical and resembles a rhino's horn.  You estimate it to be about six inches long.");
 				}
-
+			}
+			if (player.hornType == HORNS_UNICORN)
+			{
+				outputText("  A single sharp nub of a horn sprouts from the center of your forehead.");
+				if (player.horns < 12)
+					outputText("  You estimate it to be about six inches long.");
+				else
+					outputText("  It has developed its own cute little spiral. You estimate it to be about a foot long, two inches thick and very sturdy. A very useful natural weapon.");
 			}
 			//BODY PG HERE
 			outputText("\n\nYou have a humanoid shape with the usual torso, arms, hands, and fingers.", false);


### PR DESCRIPTION
I've found, that HORNS_UNICORN didn't show up in the appearance tab. So
I did some copy&paste from rhino TF to get this running.
While I'm at it, I had the (great *cough*) idea to add some more
horse-ish races to player.race():
equitaur, pegasus, unicorn-taur, alicorn and alicorn-taur. Yay,
if-cascades ...