### PR TITLE
Fix for leftover player.hasScales() causing a compile error.

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -5664,7 +5664,7 @@
 			//Change skin to normal
 			if (player.skinType != SKIN_TYPE_PLAIN && player.earType == EARS_HUMAN && rand(3) == 0 && changes < changeLimit) {
 				outputText("\n\nA slowly-building itch spreads over your whole body, and as you idly scratch yourself, you find that your " + player.skinFurScales());
-				outputText(" " + (player.hasScales() ? "are" : "is") + " falling to the ground, revealing flawless skin below.  <b>You now have normal skin.</b>");
+				outputText(" " + (player.skinType == SKIN_TYPE_SCALES ? "are" : "is") + " falling to the ground, revealing flawless skin below.  <b>You now have normal skin.</b>");
 				player.skinType = SKIN_TYPE_PLAIN;
 				player.skinDesc = "skin";
 				player.skinAdj  = "";


### PR DESCRIPTION
In PR #256 I missed to replace one of my helper functions with the
hardcoded skinType check.
Im my patch it checks for SKIN_TYPE_SCALES and SKIN_TYPE_DRACONIC (added
to my patch by me)
Replaced with player.skinType == SKIN_TYPE_SCALES
After a short debugging session this seems to work now.