### PR TITLE
dragonScore() has to be **above** 6 to be considered a dragon-morph

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -770,7 +770,6 @@ use namespace kGAMECLASS;
 			{
 				race = "lizan";
 			}
-			if (dragonScore() >= 6)
 			{
 				race = "dragon-morph";
 				if (faceType == 0)


### PR DESCRIPTION
Finally fixes issue #241

With this fix you can go from all dragon to all lizan without the need to get rid of your dragon tongue or wings to be considerd being a lizan in player appearance tab.