### PR TITLE
Lizan to dragon dragonscore fix

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -770,6 +770,7 @@ use namespace kGAMECLASS;
 			{
 				race = "lizan";
 			}
+			if (dragonScore() >= 7)
 			{
 				race = "dragon-morph";
 				if (faceType == 0)

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -770,7 +770,6 @@ use namespace kGAMECLASS;
 			{
 				race = "lizan";
 			}
-			if (dragonScore() >= 6)
 			{
 				race = "dragon-morph";
 				if (faceType == 0)


### PR DESCRIPTION
Finally fixes issue #241

With this fix you can go from all dragon to all lizan without the need to get rid of your dragon tongue or wings to be considerd being a lizan in player appearance tab.
