### PR TITLE
Relocate arms restoring copy&paste mess to a new method in the new class classes.items.MutationsHelper

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -4,10 +4,8 @@
 	import classes.GlobalFlags.kFLAGS;
 	import classes.Scenes.Areas.Forest.KitsuneScene;
 
-	public final class Mutations extends BaseContent
+	public final class Mutations extends MutationsHelper
 	{
-		include "../../../includes/appearanceDefs.as";
-
 		public function Mutations()
 		{
 		}
@@ -511,18 +509,8 @@
 				}
 				changes++;
 			}
-			//-Remove feather-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_HARPY && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your feathery arms are shedding their feathery coating.  The wing-like shape your arms once had is gone in a matter of moments, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
-			//-Remove chitin-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_SPIDER && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your arms' chitinous covering is flaking away.  The glossy black coating is soon gone, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
+			//Restore arms to become human arms again
+			changes += restoreArms(changes, changeLimit);
 			//+hooves
 			if (player.lowerBody != LOWER_BODY_TYPE_HOOFED) {
 				if (changes < changeLimit && rand(3) == 0) {
@@ -973,18 +961,8 @@
 					changes++;
 				}
 			}
-			//-Remove feather-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_HARPY && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your feathery arms are shedding their feathery coating.  The wing-like shape your arms once had is gone in a matter of moments, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
-			//-Remove chitin-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_SPIDER && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your arms' chitinous covering is flaking away.  The glossy black coating is soon gone, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
+			//Restore arms to become human arms again
+			changes += restoreArms(changes, changeLimit);
 			//-Remove feathery hair (copy for equinum, canine peppers, Labova)
 			if (changes < changeLimit && player.hairType == 1 && rand(4) == 0) {
 				//(long):
@@ -1690,18 +1668,8 @@
 				outputText("dumber.", false);
 				changes++;
 			}
-			//-Remove feather-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_HARPY && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your feathery arms are shedding their feathery coating.  The wing-like shape your arms once had is gone in a matter of moments, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
-			//-Remove chitin-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_SPIDER && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your arms' chitinous covering is flaking away.  The glossy black coating is soon gone, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
+			//Restore arms to become human arms again
+			changes += restoreArms(changes, changeLimit);
 			//-Remove feathery hair (copy for equinum, canine peppers, Labova)
 			if (changes < changeLimit && player.hairType == 1 && rand(4) == 0) {
 				//(long):
@@ -3679,18 +3647,8 @@
 				outputText("\n\nYou feel like dancing, and stumble as your legs react more quickly than you'd think.  Is the alcohol slowing you down or are you really faster?  You take a step and nearly faceplant as you go off balance.  It's definitely both.", false);
 				changes++;
 			}
-			//-Remove feather-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_HARPY && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your feathery arms are shedding their feathery coating.  The wing-like shape your arms once had is gone in a matter of moments, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
-			//-Remove chitin-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_SPIDER && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your arms' chitinous covering is flaking away.  The glossy black coating is soon gone, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
+			//Restore arms to become human arms again
+			changes += restoreArms(changes, changeLimit);
 			//SEXYTIEMS
 			//Multidick killa!
 			if (player.cocks.length > 1 && rand(3) == 0 && changes < changeLimit) {
@@ -4459,18 +4417,8 @@
 				player.skinDesc = "skin";
 				changes++;
 			}
-			//-Remove feather-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_HARPY && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your feathery arms are shedding their feathery coating.  The wing-like shape your arms once had is gone in a matter of moments, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
-			//-Remove chitin-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_SPIDER && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your arms' chitinous covering is flaking away.  The glossy black coating is soon gone, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
+			//Restore arms to become human arms again
+			changes += restoreArms(changes, changeLimit);
 			//-----------------------
 			// MINOR TRANSFORMATIONS
 			//-----------------------
@@ -6390,7 +6338,6 @@
 
 		 Appearance Effects:
 		 -Hip widening funtimes
-		 -Remove feather-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
 		 -Remove feathery hair (copy for equinum, canine peppers, Labova)
 
 		 Sexual:
@@ -6462,18 +6409,8 @@
 				player.hipRating++;
 				changes++;
 			}
-			//-Remove feather-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_HARPY && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your feathery arms are shedding their feathery coating.  The wing-like shape your arms once had is gone in a matter of moments, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
-			//-Remove chitin-arms (copy this for goblin ale, mino blood, equinum, canine pepps, demon items)
-			if (changes < changeLimit && player.armType == ARM_TYPE_SPIDER && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that your arms' chitinous covering is flaking away.  The glossy black coating is soon gone, leaving " + player.skinDesc + " behind.", false);
-				player.armType = ARM_TYPE_HUMAN;
-				changes++;
-			}
+			//-Restore arms to become human arms again
+			changes += restoreArms(changes, changeLimit);
 			//-Remove feathery hair (copy for equinum, canine peppers, Labova)
 			if (changes < changeLimit && player.hairType == 1 && rand(4) == 0) {
 				//(long):

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -1,0 +1,48 @@
+package classes.Items 
+{
+	import classes.*;
+	
+	/**
+	 * Helper class to get rid of the copy&paste-mess from classes.Items.Mutations
+	 * @author Stadler76
+	 */
+	public class MutationsHelper extends BaseContent 
+	{
+		include "../../../includes/appearanceDefs.as";
+
+		public function MutationsHelper() 
+		{
+		}
+
+		public function restoreArms(changes:Number, changeLimit:Number, keepArms:Array = null):Number
+		{
+			var localChanges:Number = 0;
+			if (keepArms == null) keepArms = [];
+			if (keepArms.indexOf(player.armType) >= 0) return 0; // For future TFs. Tested and working, but I'm not using it so far (Stadler76)
+
+			if (changes < changeLimit && player.armType != ARM_TYPE_HUMAN && rand(4) == 0) {
+				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
+				switch (player.armType) {
+					case ARM_TYPE_HARPY:
+						outputText(" your feathery arms are shedding their feathery coating.  The wing-like shape your arms once had is gone in a matter of moments, leaving " + player.skinFurScales() + " behind.");
+						break;
+
+					case ARM_TYPE_SPIDER:
+						outputText(" your arms' chitinous covering is flaking away.  The glossy black coating is soon gone, leaving " + player.skinFurScales() + " behind.");
+						break;
+
+					case ARM_TYPE_SALAMANDER:
+						outputText(" your once scaly arms are shedding their scales and that your claws become normal human fingernails again.");
+						break;
+
+					default:
+						outputText(" your unusual arms change more and more until they are normal human arms, leaving " + player.skinFurScales() + " behind.");
+				}
+				player.armType = ARM_TYPE_HUMAN;
+				localChanges++;
+			}
+
+			return localChanges;
+		}
+	}
+}


### PR DESCRIPTION
I've found, that the code snippets for restoring arms only handles
feather and chitin arms and ignores other arms. This is being used
multiple times in Mutations.as and can be a pita to fix, when new
armType are being added to the code (e. g. ARM_TYPE_PREDATOR, for which
I plan to file a PR later).
Even ARM_TYPE_SALAMANDER is missing in that part. I have included this
into restoreArms(...), since I see that as a bug/being unintended. I
assume that this goes without asking Savin. To be precise: I doubt that
Savin wants, that several races would keep salamander arms, while other
arms are being restored.
If this is accepted I plan to file more PRs for other non-DRY-coding
parts of Mutations.as (starting with feather hair removal)
I have relocated this into a new class to keep Mutations.as mostly clean
of these helper methods and because IMHO its easier to keep track of
them instead of bloating Mutations.as with more and more of these
functions.

Testing has been done for hummanus, goblin ale and kanga fruit.
The param keepArms plays nicely, too although I'm not using it atm

TL;DR: slowly change Mutations.as towards more following the DRY(Don't
Repeat Yourself)-coding-principle, so future mutations will be easier to
implement.