### PR TITLE
Implementation of ARM_TYPE_PREDATOR and the claw propertys

### DIFF
--- a/classes/classes/Appearance.as
+++ b/classes/classes/Appearance.as
@@ -2299,6 +2299,7 @@
 					[ARM_TYPE_HUMAN, "human"],
 					[ARM_TYPE_HARPY, "harpy"],
 					[ARM_TYPE_SPIDER, "spider"],
+					[ARM_TYPE_PREDATOR, "predator"],
 					[ARM_TYPE_SALAMANDER, "salamander"]
 				]
 		);

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -200,6 +200,11 @@ package classes
 		16 - fullmouse*/
 		public var faceType:Number = FACE_HUMAN;
 
+		// <mod name="Predator arms" author="Stadler">
+		public var clawTone:String = "";
+		public var clawType:Number = CLAW_TYPE_NORMAL;
+		// </mod>
+
 		/*EarType
 		-1 - none!
 		0 - human
@@ -2515,6 +2520,21 @@ package classes
 			skinzilla += skinDesc;
 			return skinzilla;
 		}
+
+		// <mod name="Predator arms" author="Stadler">
+		public function claws():String
+		{
+			var toneText:String = clawTone == "" ? " " : (", " + clawTone + " ");
+
+			switch (clawType) {
+				case CLAW_TYPE_NORMAL: return "fingernails";
+				case CLAW_TYPE_LIZARD: return "short curved" + toneText + "claws";
+				case CLAW_TYPE_DRAGON: return "powerful, thick curved" + toneText + "claws";
+				// Since mander arms are hardcoded and the others are NYI, we're done here for now
+			}
+			return "fingernails";
+		}
+		// </mod>
 
 		public function leg():String
 		{

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -5256,6 +5256,23 @@
 				player.legCount = 2;
 				changes++;
 			}
+			// <mod name="Predator arms" author="Stadler">
+			//Gain predator arms
+			if (player.armType != ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_SCALES && player.lowerBody == LOWER_BODY_TYPE_LIZARD && changes < changeLimit && rand(3) == 0) {
+				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with " + player.skinFurScales() + " and short claws replacing your fingernails.");
+				outputText("\n<b>You now have reptilian arms.</b>", false);
+				player.armType = ARM_TYPE_PREDATOR;
+				player.clawType = CLAW_TYPE_LIZARD;
+				changes++
+			}
+			//Claw transition
+			if (player.armType == ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_SCALES && player.clawType != CLAW_TYPE_LIZARD && changes < changeLimit && rand(3) == 0) {
+				outputText("\n\nYour " + player.claws() + " change a little to become reptilian.");
+				player.clawType = CLAW_TYPE_LIZARD;
+				outputText(" <b>You now have " + player.claws() + ".</b>");
+				changes++
+			}
+			// </mod>
 			//-Tail – sinuous lizard tail
 			if (player.tailType != TAIL_TYPE_LIZARD && player.lowerBody == LOWER_BODY_TYPE_LIZARD && changes < changeLimit && rand(5) == 0) {
 				//No tail
@@ -5324,6 +5341,7 @@
 					outputText(player.skinTone + " scales.</b>", false);
 				}
 				player.skinType = SKIN_TYPE_SCALES;
+				player.skinAdj = "";
 				player.skinDesc = "scales";
 				changes++;
 			}
@@ -5544,6 +5562,7 @@
 			if (player.armType != ARM_TYPE_SALAMANDER && player.lowerBody == LOWER_BODY_TYPE_SALAMANDER && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  After longer moment of ignoring it you finaly glancing down in irritation, only to discover that your arms former appearance changed into this of salamander one with leathery, red scales and short claws replacing your fingernails.  <b>You now have a salamander arms.</b>", false);
 				player.armType = ARM_TYPE_SALAMANDER;
+				player.clawType = CLAW_TYPE_SALAMANDER;
 				changes++;
 			}
 			//Remove odd eyes

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -21,18 +21,37 @@ package classes.Items
 			if (keepArms.indexOf(player.armType) >= 0) return 0; // For future TFs. Tested and working, but I'm not using it so far (Stadler76)
 
 			if (changes < changeLimit && player.armType != ARM_TYPE_HUMAN && rand(4) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
 				switch (player.armType) {
 					case ARM_TYPE_HARPY:
+						outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
 						outputText(" your feathery arms are shedding their feathery coating.  The wing-like shape your arms once had is gone in a matter of moments, leaving " + player.skinFurScales() + " behind.");
 						break;
 
 					case ARM_TYPE_SPIDER:
+						outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
 						outputText(" your arms' chitinous covering is flaking away.  The glossy black coating is soon gone, leaving " + player.skinFurScales() + " behind.");
 						break;
 
 					case ARM_TYPE_SALAMANDER:
+						outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
 						outputText(" your once scaly arms are shedding their scales and that your claws become normal human fingernails again.");
+						player.clawType = CLAW_TYPE_NORMAL;
+						break;
+
+					case ARM_TYPE_PREDATOR:
+						switch (player.skinType) {
+							case SKIN_TYPE_GOO:
+								outputText("\n\nYour gooey claws shift back to become more like fingernails again. Well, who cares, gooey claws aren't very useful in combat to begin with.");
+								//Gooey claws? Really?!? I'll take a look at goo TF later ...
+								break;
+
+							case SKIN_TYPE_PLAIN:
+							case SKIN_TYPE_FUR:
+							case SKIN_TYPE_SCALES:
+								outputText("\n\nYou feel a sudden tingle in your " + player.claws() + " and then you realize, that they have become normal human fingernails again.");
+								break;
+						}
+						player.clawType = CLAW_TYPE_NORMAL;
 						break;
 
 					default:

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -21,7 +21,7 @@ package classes
 			displayHeader("Appearance");
 			if (race != player.startingRace)	outputText("You began your journey as a " + player.startingRace+ ", but gave that up as you explored the dangers of this realm.  ", false);
 			//Height and race.
-			if (flags[kFLAGS.USE_METRICS] > 0) outputText("You are a " + Math.round(100 * (player.tallness * 2.54) / 100) + " centimetre tall " + player.maleFemaleHerm() + " " + race + ", with " + player.bodyType() + ".", false);
+			if (flags[kFLAGS.USE_METRICS] > 0) outputText("You are a " + (Math.round(player.tallness * 2.54) / 100).toFixed(2) + " metres tall " + player.maleFemaleHerm() + " " + race + ", with " + player.bodyType() + ".", false);
 			else outputText("You are a " + Math.floor(player.tallness / 12) + " foot " + player.tallness % 12 + " inch tall " + player.maleFemaleHerm() + " " + race + ", with " + player.bodyType() + ".", false);
 			
 			outputText("  <b>You are currently " + (player.armorDescript() != "gear" ? "wearing your " + player.armorDescript() : "naked") + "" + " and using your " + player.weaponName + " as a weapon.</b>", false);
@@ -444,8 +444,10 @@ package classes
 				outputText("  Feathers hang off your arms from shoulder to wrist, giving them a slightly wing-like look.", false);
 			else if (player.armType == ARM_TYPE_SPIDER) 
 				outputText("  Shining black exoskeleton  covers your arms from the biceps down, resembling a pair of long black gloves from a distance.", false);	
-			else if(player.armType == ARM_TYPE_SALAMANDER)
+			else if (player.armType == ARM_TYPE_SALAMANDER)
 				outputText("  Shining thick, leathery red scales covers your arms from the biceps down and your fingernails are now a short curved claws.", false);
+			else if (player.armType == ARM_TYPE_PREDATOR)
+				outputText("  Your arms are covered by " + player.skinFurScales() + " from the biceps down and your fingernails are now " + player.claws() + ".", false);
 			//Done with head bits. Move on to body stuff
 			//Horse lowerbody, other lowerbody texts appear lower
 			if (player.isTaur()) 

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -848,6 +848,10 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.antennae = player.antennae;
 		saveFile.data.horns = player.horns;
 		saveFile.data.hornType = player.hornType;
+		// <mod name="Predator arms" author="Stadler">
+		saveFile.data.clawTone = player.clawTone;
+		saveFile.data.clawType = player.clawType;
+		// </mod>
 		saveFile.data.wingDesc = player.wingDesc;
 		saveFile.data.wingType = player.wingType;
 		saveFile.data.lowerBody = player.lowerBody;
@@ -1737,7 +1741,12 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			player.hornType = HORNS_NONE;
 		else
 			player.hornType = saveFile.data.hornType;
-			
+
+		// <mod name="Predator arms" author="Stadler">
+		player.clawTone = (saveFile.data.clawTone == undefined) ? ""               : saveFile.data.clawTone;
+		player.clawType = (saveFile.data.clawType == undefined) ? CLAW_TYPE_NORMAL : saveFile.data.clawType;
+		// </mod>
+
 		player.wingDesc = saveFile.data.wingDesc;
 		player.wingType = saveFile.data.wingType;
 		player.lowerBody = saveFile.data.lowerBody;

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -951,7 +951,7 @@ package classes.Scenes.NPCs
 					outputText("\n\nEmber's body is a curvy thing, not rough like you'd expect from a reptilian creature, but rounded and almost soft-looking, with a taut belly and a perfect hourglass figure, giving " + emberMF("him", "her") + " the silhouette of an amazon from your village's histories: beautiful but powerful.  Excepting the wings and horns, of course.");
 				}
 				outputText("\n\nThe dragon scorns clothing and exposes " + emberMF("him", "her") + "self to both you and the elements with equal indifference, claiming " + emberMF("his", "her") + " scales are all the covering " + emberMF("he", "she") + " needs... and yet when you admire " + emberMF("his", "her") + " body, " + emberMF("he", "she") + " is quick to hide it from your wandering gaze.");
-				outputText("\n\n" + emberMF("His", "Her") + " head is reptilian, with sharp teeth fit for a predator and strong ridges on the underside of the jaw.  At the sides of " + emberMF("his", "her") + " head are strange, fin-like growths concealing small holes; you presume these to be the dragon equivalent of ears.  Atop " + emberMF("his", "her") + " head sit a pair of ebony horns that curve backwards elegantly; despite being as tough as steel, their shape is not fit for use in combat, instead it is simply aesthetical, giving Ember a majestic look.  A long tongue occasionally slips out, to lick at " + emberMF("his", "her") + " jaws and teeth.  Prideful, fierce eyes, with slit pupils and burning orange irises, glitter even in the darkness.");
+				outputText("\n\n" + emberMF("His", "Her") + " head is reptilian, with sharp teeth fit for a predator and strong ridges on the underside of the jaw.  At the sides of " + emberMF("his", "her") + " head are strange, fin-like growths concealing small holes; you presume these to be the dragon equivalent of ears.  Atop " + emberMF("his", "her") + " head sit two pairs of ebony horns that curve backwards elegantly; despite being as tough as steel, their shape is not fit for use in combat, instead it is simply aesthetical, giving Ember a majestic look.  A long tongue occasionally slips out, to lick at " + emberMF("his", "her") + " jaws and teeth.  Prideful, fierce eyes, with slit pupils and burning orange irises, glitter even in the darkness.");
 				//(if Ember has any hair)
 				if (flags[kFLAGS.EMBER_HAIR] == 1) {
 					if (flags[kFLAGS.EMBER_GENDER] == 1) outputText("  Short ");
@@ -1762,6 +1762,23 @@ package classes.Scenes.NPCs
 				}
 				changes++;
 			}
+			// <mod name="Predator arms" author="Stadler">
+			//Gain Dragon Arms (Derived from ARM_TYPE_SALAMANDER)
+			if (player.armType != ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_SCALES && player.lowerBody == LOWER_BODY_TYPE_DRAGON && changes < changeLimit && rand(3) == 0) {
+				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with shield-shaped " + player.skinTone + " scales and powerful, thick curved claws replacing your fingernails.");
+				outputText("\n<b>You now have dragon arms.</b>", false);
+				player.armType = ARM_TYPE_PREDATOR;
+				player.clawType = CLAW_TYPE_DRAGON;
+				changes++
+			}
+			//Claw transition
+			if (player.armType == ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_SCALES && player.clawType != CLAW_TYPE_DRAGON && changes < changeLimit && rand(3) == 0) {
+				outputText("\n\nYour " + player.claws() + " change  a little to become more dragon-like.");
+				player.clawType = CLAW_TYPE_DRAGON;
+				outputText(" <b>You now have " + player.claws() + ".</b>");
+				changes++
+			}
+			// </mod>
 			//Get Dragon Breath (Tainted version)
 			//Can only be obtained if you are considered a dragon-morph, once you do get it though, it won't just go away even if you aren't a dragon-morph anymore.
 

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -108,7 +108,18 @@ public static const ANTENNAE_BEE:int                                            
 public static const ARM_TYPE_HUMAN:int                                              =   0;
 public static const ARM_TYPE_HARPY:int                                              =   1;
 public static const ARM_TYPE_SPIDER:int                                             =   2;
-public static const ARM_TYPE_SALAMANDER:int									           		=   5;
+public static const ARM_TYPE_PREDATOR:int                                           =   4;
+public static const ARM_TYPE_SALAMANDER:int                                         =   5;
+
+// clawType
+public static const CLAW_TYPE_NORMAL:int                                            =   0;
+public static const CLAW_TYPE_LIZARD:int                                            =   1;
+public static const CLAW_TYPE_DRAGON:int                                            =   2;
+public static const CLAW_TYPE_SALAMANDER:int                                        =   3;
+public static const CLAW_TYPE_CAT:int                                               =   4; // NYI! Placeholder for now!! (See http://tiny.cc/coc-revamp-claws)
+public static const CLAW_TYPE_DOG:int                                               =   5; // NYI! Placeholder for now!! (See http://tiny.cc/coc-revamp-claws)
+public static const CLAW_TYPE_RAPTOR:int                                            =   6; // NYI! Placeholder for now!! (See http://tiny.cc/coc-revamp-claws) Giev teh Rapturs :-)
+public static const CLAW_TYPE_MANTIS:int                                            =   7; // NYI! Placeholder for Xianxia mod (See http://tiny.cc/coc-xianxia-mod)
 
 // tailType
 public static const TAIL_TYPE_NONE:int                                              =   0;


### PR DESCRIPTION
I've mainly implemented this by copying my files and reverting
everything, thats not related to ARM_TYPE_PREDATOR and the new
claw-property.
It compiles without problems for me and after a few testing sessions,
everything looks fine now.

I've decided to leave clawAdj and clawDesc out since these props are
perfectly replaced by clawType.

I have modified my code, so tallness is being displayed in metres
instead of centimetres with metrics on. I've decided not to edit is out.
And a small tweak for Ember's appearance: Ember has 2 pairs of horns
instead of just one, now.
I left that in my PR, too because it doen't make sense to me, to gain 4
horns from Ember's blood, when he/she only has 2 ...

PS: I'll file a seperate PR to fix gooey skin TF leaving **all**
armType's untouched.