### PR TITLE
Revert non-human arms and claws when your skin TFs to goo skin

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -3851,6 +3851,7 @@
 					else if (blaht <= 8) player.skinTone = "cerulean";
 					else player.skinTone = "emerald";
 					outputText(player.skinTone + "!");
+					restoreArms(0, 1, [], RESTOREARMS_FROMGOOSKINTF);
 				}
 				return;
 			}
@@ -5305,39 +5306,13 @@
 			if (player.skinType != SKIN_TYPE_SCALES && player.earType == EARS_LIZARD && player.tailType == TAIL_TYPE_LIZARD && player.lowerBody == LOWER_BODY_TYPE_LIZARD && changes < changeLimit && rand(5) == 0) {
 				//(fur)
 				if (player.skinType == SKIN_TYPE_FUR) {
-					//set new skinTone
-					if (rand(10) == 0) {
-						if (rand(2) == 0) player.skinTone = "purple";
-						else player.skinTone = "silver";
-					}
-					//non rare skinTone
-					else {
-						temp = rand(5);
-						if (temp == 0) player.skinTone = "red";
-						else if (temp == 1) player.skinTone = "green";
-						else if (temp == 2) player.skinTone = "white";
-						else if (temp == 3) player.skinTone = "blue";
-						else player.skinTone = "black";
-					}
+					player.skinTone = newLizardSkinTone();
 					outputText("\n\nYou scratch yourself, and come away with a large clump of " + player.furColor + " fur.  Panicked, you look down and realize that your fur is falling out in huge clumps.  It itches like mad, and you scratch your body relentlessly, shedding the remaining fur with alarming speed.  Underneath the fur your skin feels incredibly smooth, and as more and more of the stuff comes off, you discover a seamless layer of " + player.skinTone + " scales covering most of your body.  The rest of the fur is easy to remove.  <b>You're now covered in scales from head to toe.</b>", false);
 				}
 				//(no fur)
 				else {
 					outputText("\n\nYou idly reach back to scratch yourself and nearly jump out of your " + player.armorName + " when you hit something hard.  A quick glance down reveals that scales are growing out of your " + player.skinTone + " skin with alarming speed.  As you watch, the surface of your skin is covered in smooth scales.  They interlink together so well that they may as well be seamless.  You peel back your " + player.armorName + " and the transformation has already finished on the rest of your body.  <b>You're covered from head to toe in shiny ", false);
-					//set new skinTone
-					if (rand(10) == 0) {
-						if (rand(2) == 0) player.skinTone = "purple";
-						else player.skinTone = "silver";
-					}
-					//non rare skinTone
-					else {
-						temp = rand(5);
-						if (temp == 0) player.skinTone = "red";
-						else if (temp == 1) player.skinTone = "green";
-						else if (temp == 2) player.skinTone = "white";
-						else if (temp == 3) player.skinTone = "blue";
-						else player.skinTone = "black";
-					}
+					player.skinTone = newLizardSkinTone();
 					outputText(player.skinTone + " scales.</b>", false);
 				}
 				player.skinType = SKIN_TYPE_SCALES;
@@ -6268,6 +6243,7 @@
 				outputText("\n\nYou smile impishly as you lick the last bits of the nut from your teeth, but when you go to wipe your mouth, instead of the usual texture of your " + player.skinDesc + " on your lips, you feel feathers! You look on in horror while more of the avian plumage sprouts from your " + player.skinDesc + ", covering your forearms until <b>your arms look vaguely like wings</b>. Your hands remain unchanged thankfully. It'd be impossible to be a champion without hands! The feathery limbs might help you maneuver if you were to fly, but there's no way they'd support you alone.", false);
 				changes++;
 				player.armType = ARM_TYPE_HARPY;
+				player.clawType = CLAW_TYPE_NORMAL;
 			}
 			//-Feathery Hair
 			if (player.hairType != 1 && changes < changeLimit && (type == 1 || player.faceType == FACE_HUMAN) && rand(4) == 0) {

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -10,39 +10,65 @@ package classes.Items
 	{
 		include "../../../includes/appearanceDefs.as";
 
+		// I tend to use bitfields rather than lots of optional boolean params.
+		// If I consider a method to be finalized and has only one option I'll refactor this to use a boolean value.
+		// I'll add more consts later if needed. This one is just here for the sake of being an example for starters (Stadler)
+
+		// restoreArms options
+		public static const RESTOREARMS_FROMGOOSKINTF:int = 1;
+
 		public function MutationsHelper() 
 		{
 		}
 
-		public function restoreArms(changes:Number, changeLimit:Number, keepArms:Array = null):Number
+		public function restoreArms(changes:Number, changeLimit:Number, keepArms:Array = null, options:int = 0):Number
 		{
 			var localChanges:Number = 0;
 			if (keepArms == null) keepArms = [];
-			if (keepArms.indexOf(player.armType) >= 0) return 0; // For future TFs. Tested and working, but I'm not using it so far (Stadler76)
+			if (keepArms.indexOf(player.armType) >= 0) return 0; // For future TFs. Tested and working, but I'm not using it so far (Stadler)
+
+			if (options & RESTOREARMS_FROMGOOSKINTF >= 0) {
+				// skin just turned gooey. Now lets fix unusual arms.
+				var hasClaws:Boolean = player.clawType != CLAW_TYPE_NORMAL;
+
+				if (hasClaws || player.armType == ARM_TYPE_HARPY) outputText("\n\n");
+				if (player.armType == ARM_TYPE_HARPY) {
+					outputText("The feathers on your arms melt back into your now gooey skin.");
+					if (hasClaws) outputText(" Additionally your ");
+				} else if (hasClaws) outputText("Your ");
+
+				if (hasClaws) outputText("now gooey claws melt back into your fingers. Well, who cares, gooey claws aren't very useful in combat to begin with.");
+				if (hasClaws || player.armType == ARM_TYPE_HARPY) outputText("  <b>You have normal human arms again.</b>");
+
+				player.clawType = CLAW_TYPE_NORMAL;
+				player.armType = ARM_TYPE_HUMAN;
+				return 0;
+			}
+
 
 			if (changes < changeLimit && player.armType != ARM_TYPE_HUMAN && rand(4) == 0) {
+				if ([ARM_TYPE_HARPY, ARM_TYPE_SPIDER, ARM_TYPE_SALAMANDER].indexOf(player.armType) >= 0)
+					outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
+
 				switch (player.armType) {
 					case ARM_TYPE_HARPY:
-						outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
 						outputText(" your feathery arms are shedding their feathery coating.  The wing-like shape your arms once had is gone in a matter of moments, leaving " + player.skinFurScales() + " behind.");
 						break;
 
 					case ARM_TYPE_SPIDER:
-						outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
 						outputText(" your arms' chitinous covering is flaking away.  The glossy black coating is soon gone, leaving " + player.skinFurScales() + " behind.");
 						break;
 
 					case ARM_TYPE_SALAMANDER:
-						outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
 						outputText(" your once scaly arms are shedding their scales and that your claws become normal human fingernails again.");
-						player.clawType = CLAW_TYPE_NORMAL;
 						break;
 
 					case ARM_TYPE_PREDATOR:
 						switch (player.skinType) {
 							case SKIN_TYPE_GOO:
-								outputText("\n\nYour gooey claws shift back to become more like fingernails again. Well, who cares, gooey claws aren't very useful in combat to begin with.");
-								//Gooey claws? Really?!? I'll take a look at goo TF later ...
+								if (player.clawType != CLAW_TYPE_NORMAL)
+									outputText("\n\nYour gooey claws melt into your fingers. Well, who cares, gooey claws aren't very useful in combat to begin with.");
+									//Gooey claws? Really?!? I'll take a look at goo TF later ...
 								break;
 
 							case SKIN_TYPE_PLAIN:
@@ -51,12 +77,13 @@ package classes.Items
 								outputText("\n\nYou feel a sudden tingle in your " + player.claws() + " and then you realize, that they have become normal human fingernails again.");
 								break;
 						}
-						player.clawType = CLAW_TYPE_NORMAL;
 						break;
 
 					default:
 						outputText(" your unusual arms change more and more until they are normal human arms, leaving " + player.skinFurScales() + " behind.");
 				}
+				outputText("  <b>You have normal human arms again.</b>");
+				player.clawType = CLAW_TYPE_NORMAL;
 				player.armType = ARM_TYPE_HUMAN;
 				localChanges++;
 			}
@@ -78,6 +105,25 @@ package classes.Items
 			}
 
 			return localChanges;
+		}
+
+		public function newLizardSkinTone():String
+		{
+			if (rand(10) == 0) {
+				//rare skinTone
+				return rand(2) == 0 ? "purple" : "silver";
+			}
+
+			//non rare skinTone
+			switch (rand(5)) {
+				case 0: return "red";
+				case 1: return "green";
+				case 2: return "white";
+				case 3: return "blue";
+				case 4: return "black";
+			}
+
+			return "invalid"; // Will never happen. Suppresses 'Error: Function does not return a value.'
 		}
 	}
 }


### PR DESCRIPTION
Implemented the new helper method newLizardSkinTone()
Your arms now properly revert if your skin becomes gooey skin.
Silently discard your claws, when your arms TF to those of a harpy.
I playtested this by TFing around a bit using Drakes Heart, Goblin Ale, Reptilum, Wet Cloth and Golden Seed in debug mode. Looks fine now.