### PR TITLE
Steps 1 and 2 in issue #269 (armtype points)

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1270,7 +1270,9 @@ use namespace kGAMECLASS;
 				lizardCounter++;
 			if (countCocksOfType(CockTypesEnum.LIZARD) > 0)
 				lizardCounter++;
-			if (horns > 0 && (hornType == 3 || hornType == 4))
+			if ((horns > 0 && hornType == HORNS_DRACONIC_X2) || hornType == HORNS_DRACONIC_X4_12_INCH_LONG)
+				lizardCounter++;
+			if (armType == ARM_TYPE_PREDATOR && clawType == CLAW_TYPE_LIZARD)
 				lizardCounter++;
 			if (skinType == 2)
 				lizardCounter++;
@@ -1388,13 +1390,13 @@ use namespace kGAMECLASS;
 				dragonCounter++;
 			if (lowerBody == 18)
 				dragonCounter++;
-			if (horns > 0 && (hornType == 3 || hornType == 4))
-				dragonCounter++;
 			if (skinType == 2 && dragonCounter > 0)
 				dragonCounter++;
-			if (hornType == HORNS_DRACONIC_X4_12_INCH_LONG || hornType == HORNS_DRACONIC_X2)
-				dragonCounter++;
+			if ((horns > 0 && hornType == HORNS_DRACONIC_X2) || hornType == HORNS_DRACONIC_X4_12_INCH_LONG)
+				dragonCounter += 2;
 			if (findPerk(PerkLib.Dragonfire) >= 0)
+				dragonCounter++;
+			if (armType == ARM_TYPE_PREDATOR && clawType == CLAW_TYPE_DRAGON)
 				dragonCounter++;
 			return dragonCounter;
 		}

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -375,7 +375,7 @@ package classes
 					outputText("  Two huge horns erupt from your forehead, curving outward at first, then forwards.  The weight of them is heavy, and they end in dangerous looking points.", false);
 			}
 			//Lizard horns
-			if (player.hornType == HORNS_DRACONIC_X2) 
+			if (player.horns > 0 && player.hornType == HORNS_DRACONIC_X2) 
 			{
 				if (flags[kFLAGS.USE_METRICS] > 0) outputText("  A pair of " + num2Text(int(player.horns*2.54)) + " centimetre horns grow from the sides of your head, sweeping backwards and adding to your imposing visage.", false);
 				else outputText("  A pair of " + num2Text(int(player.horns)) + " inch horns grow from the sides of your head, sweeping backwards and adding to your imposing visage.", false);


### PR DESCRIPTION
Applies to step 1 and 2 in issue #269
- Merged the hornType checks in dragonScore() to make it clearer, that they add 2 points (should leave these 2 points for ascension as a dragon and to grant dragon stat-bonuses to lizans with dragon-features aka dragonfire and wings)
- Two draconic horns have to be > 0 inches to appear in the player appearance tab. Two 0 inch horns don't make sense, although this case should be quite rare.
- Two draconic horns have to be > 0 inches to grant points now. (Reason: horns not appearing in the appearance tab but granting points could be confusing).
- Four horns now always grant points, since their length is fixed and hardcoded (See note).
- Predator arms with their respective claws now grant dragonScore respectively lizardScore points.

**Notes:**
----------
Transformatives, that reduce player.horns to 0 should remove them, when they hit 0.
I haven't looked at the code if there is any and reducto reduces them to 2.
I debugged it and kept an eye on dragonScore() and lizanScore(). Should work without any flaws or regressions.