### PR TITLE
Issue 269 step 3 (snake-like tongue for lizans)

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -4127,13 +4127,7 @@
 				changes++;
 			}
 			//9c) II The tongue (sensitivity bonus, stored as a perk?)
-			if (changes == 0 && player.tongueType != TONGUE_SNAKE && rand(3) == 0 && changes < changeLimit) {
-				if (player.tongueType == TONGUE_HUMAN) outputText("\n\nYour taste-buds start aching as they swell to an uncomfortably large size. Trying to understand what in the world could have provoked such a reaction, you bring your hands up to your mouth, your tongue feeling like it's trying to push its way past your lips. The soreness stops and you stick out your tongue to try and see what would have made it feel the way it did. As soon as you stick your tongue out you realize that it sticks out much further than it did before, and now appears to have split at the end, creating a forked tip. The scents in the air are much more noticeable to you with your snake-like tongue.", false);
-				else outputText("\n\nYour inhuman tongue shortens, pulling tight in the very back of your throat.  After a moment the bunched-up tongue-flesh begins to flatten out, then extend forwards.  By the time the transformation has finished, your tongue has changed into a long, forked snake-tongue.", false);
-				player.tongueType = TONGUE_SNAKE;
-				dynStats("sen", 5);
-				changes++;
-			}
+			if (changes == 0 && rand(3) == 0) changes += gainSnakeTongue(changes, changeLimit);
 			//9c) III The fangs
 			if (changes == 0 && player.tongueType == TONGUE_SNAKE && player.faceType != FACE_SNAKE_FANGS && rand(3) == 0 && changes < changeLimit) {
 				outputText("\n\nWithout warning, you feel your canine teeth jump almost an inch in size, clashing on your gums, cutting yourself quite badly. As you attempt to find a new way to close your mouth without dislocating your jaw, you notice that they are dripping with a bitter, khaki liquid.  Watch out, and <b>try not to bite your tongue with your poisonous fangs!</b>", false);
@@ -5325,6 +5319,9 @@
 				outputText("\n\nTerrible agony wracks your " + player.face() + " as bones crack and shift.  Your jawbone rearranges while your cranium shortens.  The changes seem to last forever; once they've finished, no time seems to have passed.  Your fingers brush against your toothy snout as you get used to your new face.  It seems <b>you have a toothy, reptilian visage now.</b>", false);
 				player.faceType = FACE_LIZARD;
 			}
+			//-Snake tongue
+			if (player.faceType == FACE_LIZARD && rand(3) == 0) changes += gainSnakeTongue(changes, changeLimit);
+			//-Remove Gills
 			if (rand(4) == 0 && player.gills && changes < changeLimit) {
 				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
 				player.gills = false;

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -3,7 +3,7 @@ package classes.Items
 	import classes.*;
 	
 	/**
-	 * Helper class to get rid of the copy&paste-mess from classes.Items.Mutations
+	 * Helper class to get rid of the copy&paste-mess in classes.Items.Mutations
 	 * @author Stadler76
 	 */
 	public class MutationsHelper extends BaseContent 
@@ -125,5 +125,32 @@ package classes.Items
 
 			return "invalid"; // Will never happen. Suppresses 'Error: Function does not return a value.'
 		}
+
+		public function gainSnakeTongue(changes:Number, changeLimit:Number):Number
+		{
+			var localChanges:Number = 0;
+
+			if (player.tongueType != TONGUE_SNAKE && changes < changeLimit) {
+				if (player.tongueType == TONGUE_HUMAN) {
+					outputText("\n\nYour taste-buds start aching as they swell to an uncomfortably large size. "
+					          +"Trying to understand what in the world could have provoked such a reaction, you bring your hands up to your mouth, "
+					          +"your tongue feeling like it's trying to push its way past your lips.");
+					outputText("  The soreness stops and you stick out your tongue to try and see what would have made it feel the way it did. "
+					          +"As soon as you stick your tongue out you realize that it sticks out much further than it did before, "
+					          +"and now appears to have split at the end, creating a forked tip.");
+					outputText("  <b>The scents in the air are much more noticeable to you with your snake-like tongue.</b>");
+				} else {
+					outputText("\n\nYour inhuman tongue shortens, pulling tight in the very back of your throat.");
+					outputText("  After a moment the bunched-up tongue-flesh begins to flatten out, then extend forwards.");
+					outputText("  By the time the transformation has finished, <b>your tongue has changed into a long, forked snake-tongue.</b>");
+				}
+				player.tongueType = TONGUE_SNAKE;
+				dynStats("sen", 5);
+				localChanges++;
+			}
+
+			return localChanges;
+		}
+
 	}
 }

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -770,7 +770,7 @@ use namespace kGAMECLASS;
 			{
 				race = "lizan";
 			}
-			if (dragonScore() >= 7)
+			if (dragonScore() >= 6)
 			{
 				race = "dragon-morph";
 				if (faceType == 0)


### PR DESCRIPTION
Applies to issue #269 step 3

- lizans now get a snake-like tongue, too (Look closely at their pic)
- dragonScore()-requirement to be considered dragon-morph reduced to >= 6 (See notes)
- Added bold-tags to the text to make it more visible, when you gain a snake-like tongue.

**Notes:**
----------
- With PR #270 accepted: This fixes ascending with a high or maxed out dragonScore() (Tested and working :)).
- No need to update lizardScore() to take snake-tongues into account for now.
- Tested with Snake Oil and Reptilum and looks good :)
- Since I start hating those overlong outputText-lines more and more I made them multiline in gainSnakeTongue only for now. Maybe occasionally I'll do this for other overlong outputText-lines, but I won't do them all at once. Would be horrible to debug ;)