### PR TITLE
New reptilic eyes for dragons and lizans

### DIFF
--- a/classes/classes/Appearance.as
+++ b/classes/classes/Appearance.as
@@ -2253,7 +2253,9 @@
 				[
 					[EYES_HUMAN, "human"],
 					[EYES_FOUR_SPIDER_EYES, "4 spider"],
-					[EYES_BLACK_EYES_SAND_TRAP, "sandtrap black"]
+					[EYES_BLACK_EYES_SAND_TRAP, "sandtrap black"],
+					[EYES_LIZARD, "lizard"],
+					[EYES_DRAGON, "dragon"],
 				]
 		);
 		public static const DEFAULT_EARS_NAMES:Object = createMapFromPairs(

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -5251,7 +5251,7 @@
 				changes++;
 			}
 			//Remove odd eyes
-			if (changes < changeLimit && rand(5) == 0 && player.eyeType != EYES_HUMAN) {
+			if (changes < changeLimit && rand(5) == 0 && player.eyeType != EYES_HUMAN && !player.hasReptileEyes()) {
 				if (player.eyeType == EYES_BLACK_EYES_SAND_TRAP) {
 					outputText("\n\nYou feel a twinge in your eyes and you blink.  It feels like black cataracts have just fallen away from you, and you know without needing to see your reflection that your eyes have gone back to looking human.");
 				}
@@ -5305,6 +5305,21 @@
 				player.gills = false;
 				changes++;
 			}
+			//<mod name="Reptile eyes" author="Stadler76">
+			//-Lizard eyes
+			if (player.eyeType != EYES_LIZARD && player.faceType == FACE_LIZARD && player.hasScales() && player.earType == EARS_LIZARD && changes < changeLimit && rand(4) == 0) {
+				if (player.hasReptileEyes())
+					outputText("\n\nYour eyes change slightly in their appearance.  ");
+				else
+				{
+					outputText("\n\nYou feel a sudden surge of pain in your eyes as they begin to reshape. Your pupils begin to elongate becoming vertically slitted and your irises change their color, too.");
+					outputText("\nAs the pain passes, you examine your eyes in a nearby puddle. You look into your new eyes with vertically slitted pupils surrounded by green-yellowish irises. With a few tears remaining, the look is a bit blurry. Wanting to get a clearer look at them, you blink your remaining tears away and suddenly you realize, that you just did that with your second set of eyelids.\n");
+				}
+				outputText("<b>You now have lizard eyes.</b>");
+				player.eyeType = EYES_LIZARD;
+				changes++;
+			}
+			//</mod>
 			//FAILSAFE CHANGE
 			if (changes == 0) {
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n", false);

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1261,21 +1261,25 @@ use namespace kGAMECLASS;
 		public function lizardScore():Number
 		{
 			var lizardCounter:Number = 0;
-			if (faceType == 7)
+			if (faceType == FACE_LIZARD)
 				lizardCounter++;
-			if (earType == 6)
+			if (earType == EARS_LIZARD)
 				lizardCounter++;
-			if (tailType == 9)
+			if (tailType == TAIL_TYPE_LIZARD)
 				lizardCounter++;
-			if (lowerBody == 10)
+			if (tongueType == TONGUE_SNAKE)
+				lizardCounter++;
+			if (lowerBody == LOWER_BODY_TYPE_LIZARD)
 				lizardCounter++;
 			if (countCocksOfType(CockTypesEnum.LIZARD) > 0)
 				lizardCounter++;
-			if ((horns > 0 && hornType == HORNS_DRACONIC_X2) || hornType == HORNS_DRACONIC_X4_12_INCH_LONG)
+			if (hasDragonHorns())
 				lizardCounter++;
 			if (armType == ARM_TYPE_PREDATOR && clawType == CLAW_TYPE_LIZARD)
 				lizardCounter++;
 			if (hasScales())
+				lizardCounter++;
+			if (hasReptileEyes() && eyeType != EYES_DRAGON) // Maybe I'll write a different function for that later. e. g. hasLizardEyes() (Stadler76)
 				lizardCounter++;
 			return lizardCounter;
 		}
@@ -1393,11 +1397,13 @@ use namespace kGAMECLASS;
 				dragonCounter++;
 			if (skinType == SKIN_TYPE_DRACONIC && dragonCounter > 0)
 				dragonCounter++;
-			if ((horns > 0 && hornType == HORNS_DRACONIC_X2) || hornType == HORNS_DRACONIC_X4_12_INCH_LONG)
+			if (hasDragonHorns())
 				dragonCounter += 2;
 			if (findPerk(PerkLib.Dragonfire) >= 0)
 				dragonCounter++;
 			if (armType == ARM_TYPE_PREDATOR && clawType == CLAW_TYPE_DRAGON)
+				dragonCounter++;
+			if (eyeType == EYES_DRAGON)
 				dragonCounter++;
 			return dragonCounter;
 		}

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -145,8 +145,11 @@ package classes
 					outputText("  You have a cat-like face, complete with moist nose and whiskers.  Your " + player.skinDesc + " is " + player.furColor + ", hiding your " + player.skin(true,false) + " underneath.", false);
 				if (player.hasScales()) 
 					outputText("  Your facial structure blends humanoid features with those of a cat.  A moist nose and whiskers are included, but overlaid with glittering " + player.skinFurScales() + ".", false);
-				if (player.eyeType != EYES_BLACK_EYES_SAND_TRAP) 
-					outputText("  Of course, no feline face would be complete without vertically slit eyes.");
+				if (player.eyeType != EYES_BLACK_EYES_SAND_TRAP)
+				{
+					outputText("  Of course, no feline face would be complete without vertically slit eyes");
+					outputText(!player.hasReptileEyes() ? "." : ", although they come with a second set of eyelids, which is somewhat unusual for a cats face.");
+				}
 			}
 			//Minotaaaauuuur-face
 			if (player.faceType == FACE_COW_MINOTAUR) 
@@ -228,6 +231,16 @@ package classes
 				outputText("  In addition to your primary two eyes, you have a second, smaller pair on your forehead.", false);
 			else if (player.eyeType == EYES_BLACK_EYES_SAND_TRAP) 
 				outputText("  Your eyes are solid spheres of inky, alien darkness.");
+			else if (player.faceType != FACE_CAT && player.hasReptileEyes())
+			{
+				outputText("Your eyes are");
+				switch (player.eyeType)
+				{
+					case EYES_DRAGON: outputText(" prideful, fierce dragon eyes with vertically slitted pupils and burning orange irises. They glitter even in the darkness and they"); break;
+					case EYES_LIZARD: outputText(" those of a lizard with vertically slitted pupils and green-yellowish irises. They"); break;
+				}
+				outputText(" come with the typical second set of eyelids, allowing you to blink twice as much as others.");
+			}
 
 			//Hair
 			//if bald

--- a/classes/classes/PlayerHelper.as
+++ b/classes/classes/PlayerHelper.as
@@ -16,10 +16,19 @@ package classes
 			return [SKIN_TYPE_SCALES, SKIN_TYPE_DRACONIC].indexOf(skinType) != -1;
 		}
 
-		// used more than once, so I wrote a helper method for it
 		public function hasFurOrScales():Boolean
 		{
 			return skinType == SKIN_TYPE_FUR || hasScales();
+		}
+
+		public function hasDragonHorns():Boolean
+		{
+			return (horns > 0 && hornType == HORNS_DRACONIC_X2) || hornType == HORNS_DRACONIC_X4_12_INCH_LONG;
+		}
+
+		public function hasReptileEyes():Boolean
+		{
+			return [EYES_LIZARD, EYES_DRAGON, EYES_BASILISK].indexOf(eyeType) != -1;
 		}
 	}
 }

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -952,6 +952,7 @@ package classes.Scenes.NPCs
 				}
 				outputText("\n\nThe dragon scorns clothing and exposes " + emberMF("him", "her") + "self to both you and the elements with equal indifference, claiming " + emberMF("his", "her") + " scales are all the covering " + emberMF("he", "she") + " needs... and yet when you admire " + emberMF("his", "her") + " body, " + emberMF("he", "she") + " is quick to hide it from your wandering gaze.");
 				outputText("\n\n" + emberMF("His", "Her") + " head is reptilian, with sharp teeth fit for a predator and strong ridges on the underside of the jaw.  At the sides of " + emberMF("his", "her") + " head are strange, fin-like growths concealing small holes; you presume these to be the dragon equivalent of ears.  Atop " + emberMF("his", "her") + " head sit two pairs of ebony horns that curve backwards elegantly; despite being as tough as steel, their shape is not fit for use in combat, instead it is simply aesthetical, giving Ember a majestic look.  A long tongue occasionally slips out, to lick at " + emberMF("his", "her") + " jaws and teeth.  Prideful, fierce eyes, with slit pupils and burning orange irises, glitter even in the darkness.");
+				outputText("  They come with the typical second set of eyelids, allowing " + emberMF("him", "her") + " to blink twice as much as others.");
 				//(if Ember has any hair)
 				if (flags[kFLAGS.EMBER_HAIR] == 1) {
 					if (flags[kFLAGS.EMBER_GENDER] == 1) outputText("  Short ");
@@ -1658,7 +1659,7 @@ package classes.Scenes.NPCs
 						//maxxed out, new row
 						else {
 							//--Next horn growth adds second row and brings length up to 12\"
-							outputText("\n\nA second row of horns erupts under the first, and though they are narrower, they grow nearly as long as your first row before they stop.  A sense of finality settles over you.  <b>You have as many horns as a lizan can grow.</b>", false);
+							outputText("\n\nA second row of horns erupts under the first, and though they are narrower, they grow nearly as long as your first row before they stop.  A sense of finality settles over you.  <b>You have as many horns as a dragon can grow.</b>", false);
 							player.hornType = HORNS_DRACONIC_X4_12_INCH_LONG;
 							changes++;
 						}
@@ -1687,6 +1688,22 @@ package classes.Scenes.NPCs
 				player.skinDesc = "scales";
 				//def bonus of scales
 			}
+			//<mod name="Reptile eyes" author="Stadler76">
+			//Gain Dragon Eyes
+			if (player.eyeType != EYES_DRAGON && player.skinType == SKIN_TYPE_DRACONIC && player.earType == EARS_DRAGON && player.hasDragonHorns() && changes < changeLimit && rand(4) == 0) {
+				if (player.hasReptileEyes())
+					outputText("\n\nYour eyes change slightly in their appearance.");
+				else
+				{
+					outputText("\n\nYou feel a sudden surge of pain in your eyes as they begin to reshape. Your pupils begin to elongate becoming vertically slitted and your irises change their color, too.");
+					outputText("\nAs the pain passes, you examine your eyes in a nearby puddle. You look into your new prideful, fierce dragon eyes with vertically slitted pupils and burning orange irises.");
+					outputText("  They glitter even in the darkness. With a few tears remaining, the look is a bit blurry. Wanting to get a clearer look at them, you blink your remaining tears away and suddenly you realize, that you just did that with your second set of eyelids.");
+				}
+				outputText("  <b>You now have fierce dragon eyes.</b>");
+				player.eyeType = EYES_DRAGON;
+				changes++;
+			}
+			//</mod>
 			//Gain Dragon Legs
 			if (player.lowerBody != LOWER_BODY_TYPE_DRAGON && changes < changeLimit && rand(3) == 0) {
 				//(if drider)

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -69,6 +69,9 @@ public static const TONGUE_ECHIDNA:int                                          
 public static const EYES_HUMAN:int                                                  =   0;
 public static const EYES_FOUR_SPIDER_EYES:int                                       =   1;
 public static const EYES_BLACK_EYES_SAND_TRAP:int                                   =   2;
+public static const EYES_LIZARD:int                                                 =   3;
+public static const EYES_DRAGON:int                                                 =   4; // Slightly different description/TF and *maybe* in the future(!) grant different perks/combat abilities
+public static const EYES_BASILISK:int                                               =   5; // NYI! Example for now!!! Maybe later and granted from Benoit.
 
 // earType
 public static const EARS_HUMAN:int                                                  =   0;


### PR DESCRIPTION
**Step 5 of issue #269**
- I prefer to use the body part constants rather than their hardcoded numeric values, so I replaced some of them in dragonScore() and lizardScore()
- TONGUE_SNAKE now grants points towards your lizardScore()
- Tiny fix in emberTFs: "[...]You have as many horns as a <del>lizan</del><ins>dragon</ins> can grow."
- new PlayerHelper-methods: hasDragonHorns() and hasReptileEyes()
- And business as usual: I tested/debugged it with hummanus, reptilum and drakes flower.