### PR TITLE
Fixed #280 Hummus removes Incorporeality even if its made permanent

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -612,6 +612,11 @@ package classes
 			{
 				return false;
 			}
+			if (perkv4(ptype) > 0)
+			{
+				// trace('ERROR! Attempted to remove permanent "' + ptype.name + '" perk.');
+				return false;
+			}
 			while (counter > 0)
 			{
 				counter--;
@@ -741,7 +746,7 @@ package classes
 		var counter:Number = findPerk(ptype);
 		if (counter < 0)
 		{
-			trace("ERROR? Looking for perk '" + ptype + "', but player does not have it.");
+			// trace("ERROR? Looking for perk '" + ptype + "', but player does not have it.");
 			return 0;
 		}
 		return perk(counter).value4;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -4335,9 +4335,10 @@
 			if (rand(4) == 0) restoreLegs(null, RESTORELEGS_FIX_BIPED);
 			//Remove Incorporeality Perk
 			if (player.findPerk(PerkLib.Incorporeality) >= 0 && changes < changeLimit && rand(10) == 0) {
-				outputText("\n\nYou feel a strange sensation in your [legs] as they start to feel more solid. They become more opaque until finally, you can no longer see through your [legs]. \n<b>(Perk Lost: Incorporeality!)</b>", false);
-				player.removePerk(PerkLib.Incorporeality);
-				changes++;
+				if (player.removePerk(PerkLib.Incorporeality)) {
+					outputText("\n\nYou feel a strange sensation in your [legs] as they start to feel more solid. They become more opaque until finally, you can no longer see through your [legs]. \n<b>(Perk Lost: Incorporeality!)</b>");
+					changes++;
+				}
 			}
 			//-Skin color change – tan, olive, dark, light
 			if ((player.skinTone != "tan" && player.skinTone != "olive" && player.skinTone != "dark" && player.skinTone != "light") && changes < changeLimit && rand(5) == 0) {

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -4334,11 +4334,10 @@
 			//1st priority: Change lower body to bipedal.
 			if (rand(4) == 0) restoreLegs(null, RESTORELEGS_FIX_BIPED);
 			//Remove Incorporeality Perk
-			if (player.findPerk(PerkLib.Incorporeality) >= 0 && changes < changeLimit && rand(10) == 0) {
-				if (player.removePerk(PerkLib.Incorporeality)) {
-					outputText("\n\nYou feel a strange sensation in your [legs] as they start to feel more solid. They become more opaque until finally, you can no longer see through your [legs]. \n<b>(Perk Lost: Incorporeality!)</b>");
-					changes++;
-				}
+			if (player.findPerk(PerkLib.Incorporeality) >= 0 && player.perkv4(PerkLib.Incorporeality) == 0 && changes < changeLimit && rand(10) == 0) {
+				outputText("\n\nYou feel a strange sensation in your [legs] as they start to feel more solid. They become more opaque until finally, you can no longer see through your [legs]. \n<b>(Perk Lost: Incorporeality!)</b>");
+				player.removePerk(PerkLib.Incorporeality);
+				changes++;
 			}
 			//-Skin color change – tan, olive, dark, light
 			if ((player.skinTone != "tan" && player.skinTone != "olive" && player.skinTone != "dark" && player.skinTone != "light") && changes < changeLimit && rand(5) == 0) {


### PR DESCRIPTION
Fixes issue #280: Hummus removes Incorporeality even if its made permanent.
Creature.as: removePerk() now returns false, if a perk to be removed is permanent.