### PR TITLE
Claw tones for certain claw types

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -198,6 +198,7 @@
 			player.wingDesc = "non-existant";
 			//Default
 			player.skinTone = "light";
+			player.clawTone = "";
 			player.hairColor = "brown";
 			player.hairType = HAIR_NORMAL;
 			player.beardLength = 0;
@@ -729,6 +730,7 @@
 
 		private function setComplexion(choice:String):void { //And choose hair
 			player.skinTone = choice;
+			player.clawTone = "";
 			clearOutput();
 			outputText("You selected a " + choice + " complexion.\n\nWhat color is your hair?");
 			menu();

--- a/classes/classes/Items/Consumable.as
+++ b/classes/classes/Items/Consumable.as
@@ -3,6 +3,7 @@
  */
 package classes.Items
 {
+	import classes.GlobalFlags.*;
 	import classes.CoC_Settings;
 	import classes.Player;
 
@@ -10,8 +11,17 @@ package classes.Items
 	 * An item, that is consumed by player, and disappears after use. Direct subclasses should override "doEffect" method
 	 * and NOT "useItem" method.
 	 */
-	public class Consumable extends Useable {
-		
+	public class Consumable extends Useable
+	{
+		include "../../../includes/appearanceDefs.as";
+
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return mutations.changes; }
+		protected function set changes(val:int):void { mutations.changes = val; }
+		protected function get changeLimit():int { return mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
+
 		public function Consumable(id:String, shortName:String = null, longName:String = null, value:Number = 0, description:String = null) {
 			super(id, shortName, longName, value, description);
 		}

--- a/classes/classes/Items/Consumables/SkinOil.as
+++ b/classes/classes/Items/Consumables/SkinOil.as
@@ -29,18 +29,22 @@ package classes.Items.Consumables
 				game.player.changeFatigue(-10);
 			}
 			else {
-				if (game.player.skinType != 3) game.player.skinTone = _color;
+				if (game.player.skinType != SKIN_TYPE_GOO) {
+					game.player.skinTone = _color;
+					mutations.updateClaws(game.player.clawType);
+				}
 				switch(game.player.skinType) {
-					case 0: //Plain
+					case SKIN_TYPE_PLAIN: //Plain
 						outputText("You " + game.player.clothedOrNaked("take a second to disrobe before uncorking the bottle of oil and rubbing", "uncork the bottle of oil and rub") + " the smooth liquid across your body. Even before you’ve covered your arms and [chest] your skin begins to tingle pleasantly all over. After your skin darkens a little, it begins to change until you have " + _color + " skin.");
 						break;
-					case 1: //Fur
+					case SKIN_TYPE_FUR: //Fur
 						outputText("" + game.player.clothedOrNaked("Once you’ve disrobed you take the oil and", "You take the oil and") + " begin massaging it into your skin despite yourself being covered with fur. Once you’ve finished... nothing happens. Then your skin begins to tingle and soon you part your fur to reveal " + _color + " skin.");
 						break;
-					case 2: //Scales
+					case SKIN_TYPE_SCALES: //Scales
+					case SKIN_TYPE_DRACONIC: //Dragon scales
 						outputText("You " + game.player.clothedOrNaked("take a second to disrobe before uncorking the bottle of oil and rubbing", "uncork the bottle of oil and rub") + " the smooth liquid across your body. Even before you’ve covered your arms and [chest] your scaly skin begins to tingle pleasantly all over. After your skin darkens a little, it begins to change until you have " + _color + " skin.");
 						break;
-					case 3: //Goo
+					case SKIN_TYPE_GOO: //Goo
 						outputText("You take the oil and pour the contents into your skin. The clear liquid dissolves, leaving your gooey skin unchanged. You do feel a little less thirsty though.");
 						game.player.slimeFeed();
 						break;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -4235,6 +4235,7 @@
 				outputText("\n\nYou cry out as the world spins around you.  You're aware of your entire body sliding and slipping, changing and morphing, but in the sea of sensation you have no idea exactly what's changing.  You nearly black out, and then it's over.  Maybe you had best have a look at yourself and see what changed?", false);
 			}
 			player.armType = ARM_TYPE_HUMAN;
+			updateClaws();
 			player.eyeType = EYES_HUMAN;
 			player.antennae = ANTENNAE_NONE;
 			player.faceType = FACE_HUMAN;
@@ -4251,7 +4252,6 @@
 			player.skinType = SKIN_TYPE_PLAIN;
 			player.skinDesc = "skin";
 			player.skinAdj = "";
-			player.armType = ARM_TYPE_HUMAN;
 			player.tongueType = TONGUE_HUMAN;
 			player.eyeType = EYES_HUMAN;
 			if (player.fertility > 15) player.fertility = 15;
@@ -5234,16 +5234,16 @@
 			// <mod name="Predator arms" author="Stadler76">
 			//Gain predator arms
 			if (player.armType != ARM_TYPE_PREDATOR && player.hasScales() && player.lowerBody == LOWER_BODY_TYPE_LIZARD && changes < changeLimit && rand(3) == 0) {
-				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with " + player.skinFurScales() + " and short claws replacing your fingernails.");
-				outputText("\n<b>You now have reptilian arms.</b>", false);
 				player.armType = ARM_TYPE_PREDATOR;
-				player.clawType = CLAW_TYPE_LIZARD;
+				updateClaws(CLAW_TYPE_LIZARD);
+				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with " + player.skinFurScales() + " and short " + player.clawTone + " claws replacing your fingernails.");
+				outputText("\n<b>You now have reptilian arms.</b>");
 				changes++
 			}
 			//Claw transition
 			if (player.armType == ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_SCALES && player.clawType != CLAW_TYPE_LIZARD && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nYour " + player.claws() + " change a little to become reptilian.");
-				player.clawType = CLAW_TYPE_LIZARD;
+				updateClaws(CLAW_TYPE_LIZARD);
 				outputText(" <b>You now have " + player.claws() + ".</b>");
 				changes++
 			}
@@ -5534,7 +5534,7 @@
 			if (player.armType != ARM_TYPE_SALAMANDER && player.lowerBody == LOWER_BODY_TYPE_SALAMANDER && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  After longer moment of ignoring it you finaly glancing down in irritation, only to discover that your arms former appearance changed into this of salamander one with leathery, red scales and short claws replacing your fingernails.  <b>You now have a salamander arms.</b>", false);
 				player.armType = ARM_TYPE_SALAMANDER;
-				player.clawType = CLAW_TYPE_SALAMANDER;
+				updateClaws(CLAW_TYPE_SALAMANDER);
 				changes++;
 			}
 			//Remove odd eyes
@@ -6240,7 +6240,7 @@
 				outputText("\n\nYou smile impishly as you lick the last bits of the nut from your teeth, but when you go to wipe your mouth, instead of the usual texture of your " + player.skinDesc + " on your lips, you feel feathers! You look on in horror while more of the avian plumage sprouts from your " + player.skinDesc + ", covering your forearms until <b>your arms look vaguely like wings</b>. Your hands remain unchanged thankfully. It'd be impossible to be a champion without hands! The feathery limbs might help you maneuver if you were to fly, but there's no way they'd support you alone.", false);
 				changes++;
 				player.armType = ARM_TYPE_HARPY;
-				player.clawType = CLAW_TYPE_NORMAL;
+				updateClaws();
 			}
 			//-Feathery Hair
 			if (player.hairType != 1 && changes < changeLimit && (type == 1 || player.faceType == FACE_HUMAN) && rand(4) == 0) {
@@ -6730,6 +6730,7 @@
 				if (player.armType == ARM_TYPE_HARPY) outputText("The feathers covering your arms fall away, leaving them to return to a far more human appearance.  ", false);
 				outputText("You watch, spellbound, while your forearms gradually become shiny.  The entire outer structure of your arms tingles while it divides into segments, <b>turning the " + player.skinFurScales() + " into a shiny black carapace</b>.  You touch the onyx exoskeleton and discover to your delight that you can still feel through it as naturally as your own skin.", false);
 				player.armType = ARM_TYPE_SPIDER;
+				updateClaws();
 				changes++;
 			}
 			if (rand(4) == 0) restoreLegs(null, RESTORELEGS_EXCLUDE_DRIDER);

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -1547,6 +1547,7 @@
 					if (temp == 3 || temp == 4 || temp == 5) player.skinTone = "purple";
 					if (temp > 5) player.skinTone = "blue";
 					outputText("\n\nA tingling sensation runs across your skin in waves, growing stronger as <b>your skin's tone slowly shifts, darkening to become " + player.skinTone + " in color.</b>", false);
+					updateClaws(player.clawType);
 					if (tainted) dynStats("cor", 1);
 					else dynStats("cor", 0);
 				}
@@ -2260,6 +2261,7 @@
 					if (rand(2) == 0) player.skinTone = "red";
 					else player.skinTone = "orange";
 					outputText("begins to lose its color, fading until you're as white as an albino.  Then, starting at the crown of your head, a reddish hue rolls down your body in a wave, turning you completely " + player.skinTone + ".", false);
+					updateClaws(player.clawType);
 				}
 				return;
 			}
@@ -2276,6 +2278,7 @@
 				if (rand(2) == 0) player.skinTone = "red";
 				else player.skinTone = "orange";
 				outputText("begins to lose its color, fading until you're as white as an albino.  Then, starting at the crown of your head, a reddish hue rolls down your body in a wave, turning you completely " + player.skinTone + ".", false);
+				updateClaws(player.clawType);
 			}
 
 			//Shrinkage!
@@ -2840,6 +2843,7 @@
 					player.skinAdj = "smooth";
 					if (player.skinTone == "rough gray") player.skinTone = "gray";
 					player.skinType = SKIN_TYPE_PLAIN;
+					updateClaws(player.clawType);
 				}
 				//chance of hair change
 				else {
@@ -2893,6 +2897,7 @@
 					player.skinAdj = "smooth";
 					if (player.skinTone == "rough gray") player.skinTone = "gray";
 					player.skinType = SKIN_TYPE_PLAIN;
+					updateClaws(player.clawType);
 				}
 				//chance of hair change
 				else {
@@ -3721,6 +3726,7 @@
 					if (rand(2) == 0) player.skinTone = "pale yellow";
 					else player.skinTone = "grayish-blue";
 				}
+				updateClaws(player.clawType);
 				changes++;
 				outputText("\n\nWhoah, that was weird.  You just hallucinated that your ", false);
 				if (player.skinType == SKIN_TYPE_FUR) outputText("skin", false);
@@ -4042,6 +4048,7 @@
 					player.skinType = SKIN_TYPE_PLAIN;
 					player.skinDesc = "skin";
 					player.skinTone = "rough gray";
+					updateClaws(player.clawType);
 					changes++;
 				}
 				else {
@@ -4049,6 +4056,7 @@
 					player.skinType = SKIN_TYPE_PLAIN;
 					player.skinDesc = "skin";
 					player.skinTone = "orange and black striped";
+					updateClaws(player.clawType);
 					changes++;
 				}
 			}
@@ -4352,6 +4360,7 @@
 				else if (temp == 2) player.skinTone = "dark";
 				else if (temp == 3) player.skinTone = "light";
 				outputText(player.skinTone + " colored.</b>", false);
+				updateClaws(player.clawType);
 			}
 			//Change skin to normal
 			if (player.skinType != SKIN_TYPE_PLAIN && (player.earType == EARS_HUMAN || player.earType == EARS_ELFIN) && rand(4) == 0 && changes < changeLimit) {
@@ -5281,17 +5290,20 @@
 				//(fur)
 				if (player.skinType == SKIN_TYPE_FUR) {
 					player.skinTone = newLizardSkinTone();
+					updateClaws(player.clawType);
 					outputText("\n\nYou scratch yourself, and come away with a large clump of " + player.furColor + " fur.  Panicked, you look down and realize that your fur is falling out in huge clumps.  It itches like mad, and you scratch your body relentlessly, shedding the remaining fur with alarming speed.  Underneath the fur your skin feels incredibly smooth, and as more and more of the stuff comes off, you discover a seamless layer of " + player.skinTone + " scales covering most of your body.  The rest of the fur is easy to remove.  <b>You're now covered in scales from head to toe.</b>", false);
 				}
 				else if (player.skinType == SKIN_TYPE_DRACONIC) {
 					outputText("\n\nPrickling discomfort suddenly erupts all over your body, like every last inch of your skin has suddenly developed pins and needles.  You scratch yourself, hoping for relief; and when you look at your hands you notice small fragments of your " + player.skinFurScales() + " hanging from your fingers.  Nevertheless you continue to scratch yourself, and when you're finally done, you look yourself over. New scales have grown to replace your peeled off " + player.skinFurScales() + ".  <b>You're covered from head to toe in shiny ");
 					player.skinTone = newLizardSkinTone();
+					updateClaws(player.clawType);
 					outputText(player.skinTone + " scales.</b>", false);
 				}
 				//(no fur)
 				else {
 					outputText("\n\nYou idly reach back to scratch yourself and nearly jump out of your " + player.armorName + " when you hit something hard.  A quick glance down reveals that scales are growing out of your " + player.skinTone + " skin with alarming speed.  As you watch, the surface of your skin is covered in smooth scales.  They interlink together so well that they may as well be seamless.  You peel back your " + player.armorName + " and the transformation has already finished on the rest of your body.  <b>You're covered from head to toe in shiny ", false);
 					player.skinTone = newLizardSkinTone();
+					updateClaws(player.clawType);
 					outputText(player.skinTone + " scales.</b>", false);
 				}
 				player.skinType = SKIN_TYPE_SCALES;
@@ -5570,6 +5582,7 @@
 				if (player.skinType == SKIN_TYPE_FUR) outputText("the skin under your " + player.furColor + " " + player.skinDesc + " has ");
 				else outputText("your " + player.skinDesc + (player.skinDesc.indexOf("scales") != -1 ? " have " : " has "));
 				player.skinTone = randomChoice(humanSkinColors);
+				updateClaws(player.clawType);
 				outputText("changed to become " + player.skinTone + " colored.</b>");
 			}
 			//Change skin to normal
@@ -6153,6 +6166,7 @@
 				else if (temp == 2) player.skinTone = "dark";
 				else if (temp == 3) player.skinTone = "light";
 				outputText(player.skinTone + " colored.</b>", false);
+				updateClaws(player.clawType);
 			}
 			//-Grow hips out if narrow.
 			if (player.hipRating < 10 && changes < changeLimit && rand(3) == 0) {
@@ -6672,6 +6686,7 @@
 				player.skinAdj = "";
 				player.skinType = SKIN_TYPE_PLAIN;
 				player.skinDesc = "skin";
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//(Gain human face)
@@ -7049,6 +7064,7 @@
 					player.skinDesc = "skin";
 					player.skinType = SKIN_TYPE_PLAIN;
 				}
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//Legs
@@ -7157,6 +7173,7 @@
 			if (rand(5) == 0 && changes < changeLimit && player.skinTone != "aphotic blue-black") {
 				outputText("\n\nYou absently bite down on the last of the tentacle, then pull your hand away, wincing in pain.  How did you bite your finger so hard?  Looking down, the answer becomes obvious; <b>your hand, along with the rest of your skin, is now the same aphotic color as the dormant tentacle was!</b>", false);
 				player.skinTone = "aphotic blue-black";
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//-eat more, grow more 'hair':
@@ -7933,6 +7950,7 @@
 				if (!InCollection(player.skinTone, tone)) player.skinTone = randomChoice(tone);
 				outputText(player.skinTone + " complexion.");
 				outputText("  <b>You now have " + player.skin() + "!</b>");
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//Change skin tone if not changed you!
@@ -7940,6 +7958,7 @@
 				outputText("\n\nYou feel a crawling sensation on the surface of your skin, starting at the small of your back and spreading to your extremities, ultimately reaching your face.  Holding an arm up to your face, you discover that <b>you now have ");
 				player.skinTone = randomChoice(tone);
 				outputText(player.skin() + "!</b>");
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//[Change Skin Color: add "Tattoos"]
@@ -9482,6 +9501,7 @@
 				}
 				outputText("\n\nYour skin tingles ever so slightly as you skin’s color changes before your eyes. As the tingling diminishes, you find that your skin has turned " + skinToBeChosen + ".");
 				player.skinTone = skinToBeChosen;
+				updateClaws(player.clawType);
 				changes++;
 			}
 			if (changes == 0) {

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -47,8 +47,7 @@ package classes.Items
 				if (hasClaws) outputText("now gooey claws melt back into your fingers. Well, who cares, gooey claws aren't very useful in combat to begin with.");
 				if (hasClaws || player.armType == ARM_TYPE_HARPY) outputText("  <b>You have normal human arms again.</b>");
 
-				player.clawType = CLAW_TYPE_NORMAL;
-				player.clawTone = "";
+				updateClaws();
 				player.armType = ARM_TYPE_HUMAN;
 				return true;
 			}
@@ -91,8 +90,7 @@ package classes.Items
 						outputText(" your unusual arms change more and more until they are normal human arms, leaving " + player.skinFurScales() + " behind.");
 				}
 				outputText("  <b>You have normal human arms again.</b>");
-				player.clawType = CLAW_TYPE_NORMAL;
-				player.clawTone = "";
+				updateClaws();
 				player.armType = ARM_TYPE_HUMAN;
 				changes++;
 				return true;
@@ -188,6 +186,43 @@ package classes.Items
 			}
 
 			return "invalid"; // Will never happen. Suppresses 'Error: Function does not return a value.'
+		}
+
+		public function updateClaws(clawType:int = CLAW_TYPE_NORMAL):String
+		{
+			var clawTone:String = "";
+			var oldClawTone:String = player.clawTone;
+
+			switch (clawType) {
+				case CLAW_TYPE_DRAGON:       clawTone = "steel-gray";   break;
+				case CLAW_TYPE_SALAMANDER:   clawTone = "fiery-red";    break;
+				case CLAW_TYPE_LIZARD:
+					// See http://www.bergenbattingcenter.com/lizard-skins-bat-grip/ for all those NYI! lizard skin colors
+					// I'm still not that happy with these claw tones. Any suggestion would be nice.
+					switch (player.skinTone) {
+						case "red":          clawTone = "reddish";      break;
+						case "green":        clawTone = "greenish";     break;
+						case "white":        clawTone = "light-gray";   break;
+						case "blue":         clawTone = "bluish";       break;
+						case "black":        clawTone = "dark-gray";    break;
+						case "purple":       clawTone = "purplish";     break;
+						case "silver":       clawTone = "silvery";      break;
+						case "pink":         clawTone = "pink";         break; // NYI! Maybe only with a new Skin Oil?
+						case "orange":       clawTone = "orangey";      break; // NYI!
+						case "yellow":       clawTone = "yellowish";    break; // NYI!
+						case "desert-camo":  clawTone = "pale-yellow";  break; // NYI!
+						case "gray-camo":    clawTone = "gray";         break; // NYI!
+						default:             clawTone = "gray";         break;
+					}
+					break;
+				default:
+					clawTone = "";
+			}
+
+			player.clawType = clawType;
+			player.clawTone = clawTone;
+
+			return oldClawTone;
 		}
 
 		public function gainSnakeTongue():Boolean

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -5,6 +5,7 @@ package classes.Scenes.NPCs
 {
 	import classes.*;
 	import classes.GlobalFlags.*;
+	import classes.Items.Mutations;
 
 	public class EmberScene extends NPCAwareContent implements TimeAwareInterface
 	{
@@ -57,6 +58,12 @@ package classes.Scenes.NPCs
 // TIMES_EMBER_LUSTY_FUCKED:int = 824;
 
 		public var pregnancy:PregnancyStore;
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return kGAMECLASS.mutations.changes; }
+		protected function set changes(val:int):void { kGAMECLASS.mutations.changes = val; }
+		protected function get changeLimit():int { return kGAMECLASS.mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { kGAMECLASS.mutations.changeLimit = val; }
 
 		public function EmberScene()
 		{
@@ -1574,8 +1581,8 @@ package classes.Scenes.NPCs
 //TF messages (Z)
 		public function emberTFs(drakesHeart:Boolean = false):void
 		{
-			var changes:int = 0;
-			var changeLimit:int = 2;
+			changes = 0;
+			changeLimit = 2;
 			if (player.findPerk(PerkLib.HistoryAlchemist) >= 0) changeLimit++;
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
 			//Gain Dragon Dick
@@ -1782,20 +1789,21 @@ package classes.Scenes.NPCs
 			// <mod name="Predator arms" author="Stadler76">
 			//Gain Dragon Arms (Derived from ARM_TYPE_SALAMANDER)
 			if (player.armType != ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_DRACONIC && player.lowerBody == LOWER_BODY_TYPE_DRAGON && changes < changeLimit && rand(3) == 0) {
-				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with shield-shaped " + player.skinTone + " scales and powerful, thick curved claws replacing your fingernails.");
+				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with shield-shaped " + player.skinTone + " scales and powerful, thick, curved steel-gray claws replacing your fingernails.");
 				outputText("\n<b>You now have dragon arms.</b>", false);
 				player.armType = ARM_TYPE_PREDATOR;
-				player.clawType = CLAW_TYPE_DRAGON;
+				mutations.updateClaws(CLAW_TYPE_DRAGON);
 				changes++
 			}
 			//Claw transition
 			if (player.armType == ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_DRACONIC && player.clawType != CLAW_TYPE_DRAGON && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nYour " + player.claws() + " change  a little to become more dragon-like.");
-				player.clawType = CLAW_TYPE_DRAGON;
+				mutations.updateClaws(CLAW_TYPE_DRAGON);
 				outputText(" <b>You now have " + player.claws() + ".</b>");
 				changes++
 			}
 			// </mod>
+			trace("emberTFs changeLimit: ", changeLimit);
 			//Get Dragon Breath (Tainted version)
 			//Can only be obtained if you are considered a dragon-morph, once you do get it though, it won't just go away even if you aren't a dragon-morph anymore.
 
@@ -1831,13 +1839,13 @@ package classes.Scenes.NPCs
 					outputText("rut");
 					
 					player.goIntoRut(false);
-					changes++;
+					changes++; // is this really worth incrementing the changes? It even ignores the changeLimit
 				}
 				else {
 					outputText("heat");
 					
 					player.goIntoHeat(false);
-					changes++;
+					changes++; // is this really worth incrementing the changes? It even ignores the changeLimit
 				}
 				outputText("</b>.");
 			}

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -1796,7 +1796,6 @@ package classes.Scenes.NPCs
 				changes++
 			}
 			// </mod>
-			trace("emberTFs changeLimit: ", changeLimit);
 			//Get Dragon Breath (Tainted version)
 			//Can only be obtained if you are considered a dragon-morph, once you do get it though, it won't just go away even if you aren't a dragon-morph anymore.
 

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -5,7 +5,6 @@ package classes.Scenes.NPCs
 {
 	import classes.*;
 	import classes.GlobalFlags.*;
-	import classes.Items.Mutations;
 
 	public class EmberScene extends NPCAwareContent implements TimeAwareInterface
 	{
@@ -58,12 +57,6 @@ package classes.Scenes.NPCs
 // TIMES_EMBER_LUSTY_FUCKED:int = 824;
 
 		public var pregnancy:PregnancyStore;
-		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
-		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
-		protected function get changes():int { return kGAMECLASS.mutations.changes; }
-		protected function set changes(val:int):void { kGAMECLASS.mutations.changes = val; }
-		protected function get changeLimit():int { return kGAMECLASS.mutations.changeLimit; }
-		protected function set changeLimit(val:int):void { kGAMECLASS.mutations.changeLimit = val; }
 
 		public function EmberScene()
 		{

--- a/classes/classes/Scenes/NPCs/NPCAwareContent.as
+++ b/classes/classes/Scenes/NPCs/NPCAwareContent.as
@@ -7,6 +7,7 @@ package classes.Scenes.NPCs
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Scenes.FollowerInteractions;
 	import classes.Scenes.Places.TelAdre;
+	import classes.Items.Mutations;
 
 	/**
 	 * Contains handy references to scenes and methods
@@ -17,6 +18,14 @@ package classes.Scenes.NPCs
 		{
 
 		}
+
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return mutations.changes; }
+		protected function set changes(val:int):void { mutations.changes = val; }
+		protected function get changeLimit():int { return mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
+
 		// Common scenes
 		protected function get telAdre():TelAdre
 		{

--- a/classes/classes/Scenes/NPCs/Urta.as
+++ b/classes/classes/Scenes/NPCs/Urta.as
@@ -4678,6 +4678,7 @@ private function urtasRuinedOrgasmsFromGooPartII():void {
 	if (player.skinTone != "milky white") {
 		outputText("\n\nThen you catch sight of your body...  You hold up a hand in surprise.  Your skin has changed color!  Your time inside Urta's balls has taken its toll, it seems.  <b>You now have milky white skin!</b>");
 		player.skinTone = "milky white";
+		mutations.updateClaws(player.clawType);
 		player.cumMultiplier += 10;
 	}
 	outputText("\n\nUrta and ");

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -1,6 +1,7 @@
 package classes.Scenes.Places.Bazaar 
 {
 	import classes.GlobalFlags.*;
+	import classes.Items.Mutations;
 	import classes.*;
 	/**
 	 * The Black Cock by Foxxling
@@ -8,12 +9,15 @@ package classes.Scenes.Places.Bazaar
 	 */
 	public class BlackCock extends BazaarAbstractContent
 	{
-		
-		public function BlackCock() 
-		{
-			
-		}
-		
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; } 
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; } 
+		protected function get changes():int { return mutations.changes; } 
+		protected function set changes(val:int):void { mutations.changes = val; } 
+		protected function get changeLimit():int { return mutations.changeLimit; } 
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; } 
+
+		public function BlackCock() {} 
+
 		//Will eventually be used to display sprites.
 		public function displayAnitaSprite():void {
 			//Anita's sprite code goes here
@@ -1616,6 +1620,7 @@ package classes.Scenes.Places.Bazaar
 				player.skinAdj = "tough";
 				player.skinType = SKIN_TYPE_PLAIN;
 				player.skinDesc = "skin";
+				mutations.updateClaws(player.clawType);
 				changes++;
 			}
 			//Arms change to regular
@@ -1630,6 +1635,7 @@ package classes.Scenes.Places.Bazaar
 					default:
 				}
 				player.armType = ARM_TYPE_HUMAN;
+				mutations.updateClaws();
 				changes++;
 			}
 			//Change legs to normal


### PR DESCRIPTION
# Claw tones for certain claw types
### Gameplay changes
- Always update your clawTone when your skinTone changes
- In Player:race(): Reverted the dragonscore requirement to be considered dragon morph to its old value. Without it, ascending as a lizan would probably require to have most body parts to be lizan. aka maximum lizardScore()

### Changes behind the scenes
- Added updateClaws() to MutationsHelper which now updates your claws along with their clawTone.

### Notes:
- I've searched for pictures of reptile claws and in many cases they are similar to the color of their scales.
  Since I found a picture of a yellow lizard I've added those NYI lizard skin colors in updateClaws() just in case.
- One of the lizard skin colors I found on the page I've mentioned in the code was pink.
  I don't like my lizan/dragon to be pink, so I suggest a new Skin Oil for Rathazul, for those who want to be a pink reptile ;)
- I've left CharSpecial.as untouched, since I leave the decision about the arms and the claws to those, who desinged these predefined characters