### PR TITLE
Move Oviposition perk checks out of PlayerEvents.as

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -198,6 +198,7 @@
 			player.wingDesc = "non-existant";
 			//Default
 			player.skinTone = "light";
+			player.clawTone = "";
 			player.hairColor = "brown";
 			player.hairType = HAIR_NORMAL;
 			player.beardLength = 0;
@@ -729,6 +730,7 @@
 
 		private function setComplexion(choice:String):void { //And choose hair
 			player.skinTone = choice;
+			player.clawTone = "";
 			clearOutput();
 			outputText("You selected a " + choice + " complexion.\n\nWhat color is your hair?");
 			menu();

--- a/classes/classes/Items/Consumable.as
+++ b/classes/classes/Items/Consumable.as
@@ -3,6 +3,7 @@
  */
 package classes.Items
 {
+	import classes.GlobalFlags.*;
 	import classes.CoC_Settings;
 	import classes.Player;
 
@@ -10,8 +11,15 @@ package classes.Items
 	 * An item, that is consumed by player, and disappears after use. Direct subclasses should override "doEffect" method
 	 * and NOT "useItem" method.
 	 */
-	public class Consumable extends Useable {
-		
+	public class Consumable extends Useable
+	{
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return mutations.changes; }
+		protected function set changes(val:int):void { mutations.changes = val; }
+		protected function get changeLimit():int { return mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
+
 		public function Consumable(id:String, shortName:String = null, longName:String = null, value:Number = 0, description:String = null) {
 			super(id, shortName, longName, value, description);
 		}

--- a/classes/classes/Items/Consumable.as
+++ b/classes/classes/Items/Consumable.as
@@ -13,6 +13,8 @@ package classes.Items
 	 */
 	public class Consumable extends Useable
 	{
+		include "../../../includes/appearanceDefs.as";
+
 		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
 		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
 		protected function get changes():int { return mutations.changes; }

--- a/classes/classes/Items/Consumables/BeeHoney.as
+++ b/classes/classes/Items/Consumables/BeeHoney.as
@@ -4,6 +4,7 @@
 package classes.Items.Consumables
 {
 	import classes.GlobalFlags.*;
+	import classes.Items.Mutations;
 	import classes.internals.Utils;
 	import classes.Items.Consumable;
 	import classes.CoC;
@@ -13,12 +14,12 @@ package classes.Items.Consumables
 	import classes.PregnancyStore;
 	import classes.StatusEffects;
 
-    public class BeeHoney extends Consumable
-    {
-        private const PURE_HONEY_VALUE:int = 40;
-        private const SPECIAL_HONEY_VALUE:int = 20;
-		
-        public function BeeHoney(pure:Boolean, special:Boolean) {
+	public class BeeHoney extends Consumable
+	{
+		private const PURE_HONEY_VALUE:int = 40;
+		private const SPECIAL_HONEY_VALUE:int = 20;
+
+		public function BeeHoney(pure:Boolean, special:Boolean) {
 			var honeyName:String;
 			var honeyLong:String;
 			var honeyDesc:String;
@@ -46,12 +47,14 @@ package classes.Items.Consumables
 			return true;
 		}
 		
-		override public function useItem():Boolean {
+		override public function useItem():Boolean
+		{
+			var tfSource:String = "BeeHoney";
 			var player:Player = getGame().player;
 			var pure:Boolean = (value == PURE_HONEY_VALUE);
 			var special:Boolean = (value == SPECIAL_HONEY_VALUE);
-			var changes:Number = 0;
-			var changeLimit:Number = 1;
+			changes = 0;
+			changeLimit = 1;
 			clearOutput();
 			player.slimeFeed();
 			//Chances of boosting the change limit.
@@ -176,7 +179,9 @@ package classes.Items.Consumables
 					player.breastRows[temp].nipplesPerBreast = 1;
 				}
 			}
-			//Gain oviposition!
+			//Lose reptile oviposition!
+			if (Utils.rand(4) == 0) mutations.updateOvipositionPerk(tfSource);
+			//Gain bee oviposition!
 			if (changes < changeLimit && player.findPerk(PerkLib.BeeOvipositor) < 0 && player.tailType == CoC.TAIL_TYPE_BEE_ABDOMEN && Utils.rand(2) == 0) {
 				outputText("\n\nAn odd swelling starts in your insectile abdomen, somewhere along the underside.  Curling around, you reach back to your extended, bulbous bee part and run your fingers along the underside.  You gasp when you feel a tender, yielding slit near the stinger.  As you probe this new orifice, a shock of pleasure runs through you, and a tubular, black, semi-hard appendage drops out, pulsating as heavily as any sexual organ.  <b>The new organ is clearly an ovipositor!</b>  A few gentle prods confirm that it's just as sensitive; you can already feel your internals changing, adjusting to begin the production of unfertilized eggs.  You idly wonder what laying them with your new bee ovipositor will feel like...");
 				outputText("\n\n(<b>Perk Gained:  Bee Ovipositor - Allows you to lay eggs in your foes!</b>)");

--- a/classes/classes/Items/Consumables/RizzaRoot.as
+++ b/classes/classes/Items/Consumables/RizzaRoot.as
@@ -12,10 +12,11 @@ package classes.Items.Consumables
 
         private function rizzaRootEffect(player:Player):void
         {
-            clearOutput();
-			var changes:Number = 0;
-			var changeLimit:Number = 1;
+			var tfSource:String = "rizzaRootEffect";
 			var counter:Number = 0;
+			clearOutput();
+			changes = 0;
+			changeLimit = 1;
 			if (Utils.rand(2) == 0) changeLimit++;
 			if (Utils.rand(3) == 0) changeLimit++;
 			if (Utils.rand(4) == 0) changeLimit++;
@@ -38,6 +39,7 @@ package classes.Items.Consumables
 				changes++;
 				outputText("\n\nA weird tingling runs through your scalp as your " + player.hairDescript() + " shifts slightly.  You reach up and your hand bumps against <b>your new pointed elfin ears</b>.  You bet they look cute!");
 			}
+			if (Utils.rand(5) == 0) mutations.updateOvipositionPerk(tfSource); // I doubt, that this will ever be affected, but well ... just in case
 			if ((changes < changeLimit) && (player.tallness < 108)){
 				player.tallness += changeLimit - changes + Utils.rand(2); //Add remaining changes as additional height
 				if (player.tallness > 108) player.tallness = 108;

--- a/classes/classes/Items/Consumables/SkinOil.as
+++ b/classes/classes/Items/Consumables/SkinOil.as
@@ -29,18 +29,22 @@ package classes.Items.Consumables
 				game.player.changeFatigue(-10);
 			}
 			else {
-				if (game.player.skinType != 3) game.player.skinTone = _color;
+				if (game.player.skinType != SKIN_TYPE_GOO) {
+					game.player.skinTone = _color;
+					mutations.updateClaws(game.player.clawType);
+				}
 				switch(game.player.skinType) {
-					case 0: //Plain
+					case SKIN_TYPE_PLAIN: //Plain
 						outputText("You " + game.player.clothedOrNaked("take a second to disrobe before uncorking the bottle of oil and rubbing", "uncork the bottle of oil and rub") + " the smooth liquid across your body. Even before you’ve covered your arms and [chest] your skin begins to tingle pleasantly all over. After your skin darkens a little, it begins to change until you have " + _color + " skin.");
 						break;
-					case 1: //Fur
+					case SKIN_TYPE_FUR: //Fur
 						outputText("" + game.player.clothedOrNaked("Once you’ve disrobed you take the oil and", "You take the oil and") + " begin massaging it into your skin despite yourself being covered with fur. Once you’ve finished... nothing happens. Then your skin begins to tingle and soon you part your fur to reveal " + _color + " skin.");
 						break;
-					case 2: //Scales
+					case SKIN_TYPE_SCALES: //Scales
+					case SKIN_TYPE_DRACONIC: //Dragon scales
 						outputText("You " + game.player.clothedOrNaked("take a second to disrobe before uncorking the bottle of oil and rubbing", "uncork the bottle of oil and rub") + " the smooth liquid across your body. Even before you’ve covered your arms and [chest] your scaly skin begins to tingle pleasantly all over. After your skin darkens a little, it begins to change until you have " + _color + " skin.");
 						break;
-					case 3: //Goo
+					case SKIN_TYPE_GOO: //Goo
 						outputText("You take the oil and pour the contents into your skin. The clear liquid dissolves, leaving your gooey skin unchanged. You do feel a little less thirsty though.");
 						game.player.slimeFeed();
 						break;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -4259,6 +4259,7 @@
 				outputText("\n\nYou cry out as the world spins around you.  You're aware of your entire body sliding and slipping, changing and morphing, but in the sea of sensation you have no idea exactly what's changing.  You nearly black out, and then it's over.  Maybe you had best have a look at yourself and see what changed?", false);
 			}
 			player.armType = ARM_TYPE_HUMAN;
+			updateClaws();
 			player.eyeType = EYES_HUMAN;
 			player.antennae = ANTENNAE_NONE;
 			player.faceType = FACE_HUMAN;
@@ -4275,7 +4276,6 @@
 			player.skinType = SKIN_TYPE_PLAIN;
 			player.skinDesc = "skin";
 			player.skinAdj = "";
-			player.armType = ARM_TYPE_HUMAN;
 			player.tongueType = TONGUE_HUMAN;
 			player.eyeType = EYES_HUMAN;
 			if (player.fertility > 15) player.fertility = 15;
@@ -5263,16 +5263,16 @@
 			// <mod name="Predator arms" author="Stadler76">
 			//Gain predator arms
 			if (player.armType != ARM_TYPE_PREDATOR && player.hasScales() && player.lowerBody == LOWER_BODY_TYPE_LIZARD && changes < changeLimit && rand(3) == 0) {
-				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with " + player.skinFurScales() + " and short claws replacing your fingernails.");
-				outputText("\n<b>You now have reptilian arms.</b>", false);
 				player.armType = ARM_TYPE_PREDATOR;
-				player.clawType = CLAW_TYPE_LIZARD;
+				updateClaws(CLAW_TYPE_LIZARD);
+				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with " + player.skinFurScales() + " and short " + player.clawTone + " claws replacing your fingernails.");
+				outputText("\n<b>You now have reptilian arms.</b>");
 				changes++
 			}
 			//Claw transition
 			if (player.armType == ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_SCALES && player.clawType != CLAW_TYPE_LIZARD && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nYour " + player.claws() + " change a little to become reptilian.");
-				player.clawType = CLAW_TYPE_LIZARD;
+				updateClaws(CLAW_TYPE_LIZARD);
 				outputText(" <b>You now have " + player.claws() + ".</b>");
 				changes++
 			}
@@ -5564,7 +5564,7 @@
 			if (player.armType != ARM_TYPE_SALAMANDER && player.lowerBody == LOWER_BODY_TYPE_SALAMANDER && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  After longer moment of ignoring it you finaly glancing down in irritation, only to discover that your arms former appearance changed into this of salamander one with leathery, red scales and short claws replacing your fingernails.  <b>You now have a salamander arms.</b>", false);
 				player.armType = ARM_TYPE_SALAMANDER;
-				player.clawType = CLAW_TYPE_SALAMANDER;
+				updateClaws(CLAW_TYPE_SALAMANDER);
 				changes++;
 			}
 			//Remove odd eyes
@@ -6275,7 +6275,7 @@
 				outputText("\n\nYou smile impishly as you lick the last bits of the nut from your teeth, but when you go to wipe your mouth, instead of the usual texture of your " + player.skinDesc + " on your lips, you feel feathers! You look on in horror while more of the avian plumage sprouts from your " + player.skinDesc + ", covering your forearms until <b>your arms look vaguely like wings</b>. Your hands remain unchanged thankfully. It'd be impossible to be a champion without hands! The feathery limbs might help you maneuver if you were to fly, but there's no way they'd support you alone.", false);
 				changes++;
 				player.armType = ARM_TYPE_HARPY;
-				player.clawType = CLAW_TYPE_NORMAL;
+				updateClaws();
 			}
 			//-Feathery Hair
 			if (player.hairType != 1 && changes < changeLimit && (type == 1 || player.faceType == FACE_HUMAN) && rand(4) == 0) {
@@ -6769,6 +6769,7 @@
 				if (player.armType == ARM_TYPE_HARPY) outputText("The feathers covering your arms fall away, leaving them to return to a far more human appearance.  ", false);
 				outputText("You watch, spellbound, while your forearms gradually become shiny.  The entire outer structure of your arms tingles while it divides into segments, <b>turning the " + player.skinFurScales() + " into a shiny black carapace</b>.  You touch the onyx exoskeleton and discover to your delight that you can still feel through it as naturally as your own skin.", false);
 				player.armType = ARM_TYPE_SPIDER;
+				updateClaws();
 				changes++;
 			}
 			if (rand(4) == 0) restoreLegs(null, RESTORELEGS_EXCLUDE_DRIDER);

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -6008,6 +6008,7 @@
 		public function goldenSeed(type:Number,player:Player):void
 		{
 			var tfSource:String = "goldenSeed";
+			if (player.findPerk(PerkLib.HarpyWomb) >= 0) tfSource += "-HarpyWomb";
 			//'type' refers to the variety of seed.
 			//0 == standard.
 			//1 == enhanced - increase change limit and no pre-reqs for TF

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -1553,6 +1553,7 @@
 					if (temp == 3 || temp == 4 || temp == 5) player.skinTone = "purple";
 					if (temp > 5) player.skinTone = "blue";
 					outputText("\n\nA tingling sensation runs across your skin in waves, growing stronger as <b>your skin's tone slowly shifts, darkening to become " + player.skinTone + " in color.</b>", false);
+					updateClaws(player.clawType);
 					if (tainted) dynStats("cor", 1);
 					else dynStats("cor", 0);
 				}
@@ -2270,6 +2271,7 @@
 					if (rand(2) == 0) player.skinTone = "red";
 					else player.skinTone = "orange";
 					outputText("begins to lose its color, fading until you're as white as an albino.  Then, starting at the crown of your head, a reddish hue rolls down your body in a wave, turning you completely " + player.skinTone + ".", false);
+					updateClaws(player.clawType);
 				}
 				return;
 			}
@@ -2286,6 +2288,7 @@
 				if (rand(2) == 0) player.skinTone = "red";
 				else player.skinTone = "orange";
 				outputText("begins to lose its color, fading until you're as white as an albino.  Then, starting at the crown of your head, a reddish hue rolls down your body in a wave, turning you completely " + player.skinTone + ".", false);
+				updateClaws(player.clawType);
 			}
 
 			//Shrinkage!
@@ -2853,6 +2856,7 @@
 					player.skinAdj = "smooth";
 					if (player.skinTone == "rough gray") player.skinTone = "gray";
 					player.skinType = SKIN_TYPE_PLAIN;
+					updateClaws(player.clawType);
 				}
 				//chance of hair change
 				else {
@@ -2906,6 +2910,7 @@
 					player.skinAdj = "smooth";
 					if (player.skinTone == "rough gray") player.skinTone = "gray";
 					player.skinType = SKIN_TYPE_PLAIN;
+					updateClaws(player.clawType);
 				}
 				//chance of hair change
 				else {
@@ -3738,6 +3743,7 @@
 					if (rand(2) == 0) player.skinTone = "pale yellow";
 					else player.skinTone = "grayish-blue";
 				}
+				updateClaws(player.clawType);
 				changes++;
 				outputText("\n\nWhoah, that was weird.  You just hallucinated that your ", false);
 				if (player.skinType == SKIN_TYPE_FUR) outputText("skin", false);
@@ -4063,6 +4069,7 @@
 					player.skinType = SKIN_TYPE_PLAIN;
 					player.skinDesc = "skin";
 					player.skinTone = "rough gray";
+					updateClaws(player.clawType);
 					changes++;
 				}
 				else {
@@ -4070,6 +4077,7 @@
 					player.skinType = SKIN_TYPE_PLAIN;
 					player.skinDesc = "skin";
 					player.skinTone = "orange and black striped";
+					updateClaws(player.clawType);
 					changes++;
 				}
 			}
@@ -4380,6 +4388,7 @@
 				else if (temp == 2) player.skinTone = "dark";
 				else if (temp == 3) player.skinTone = "light";
 				outputText(player.skinTone + " colored.</b>", false);
+				updateClaws(player.clawType);
 			}
 			//Change skin to normal
 			if (player.skinType != SKIN_TYPE_PLAIN && (player.earType == EARS_HUMAN || player.earType == EARS_ELFIN) && rand(4) == 0 && changes < changeLimit) {
@@ -5310,17 +5319,20 @@
 				//(fur)
 				if (player.skinType == SKIN_TYPE_FUR) {
 					player.skinTone = newLizardSkinTone();
+					updateClaws(player.clawType);
 					outputText("\n\nYou scratch yourself, and come away with a large clump of " + player.furColor + " fur.  Panicked, you look down and realize that your fur is falling out in huge clumps.  It itches like mad, and you scratch your body relentlessly, shedding the remaining fur with alarming speed.  Underneath the fur your skin feels incredibly smooth, and as more and more of the stuff comes off, you discover a seamless layer of " + player.skinTone + " scales covering most of your body.  The rest of the fur is easy to remove.  <b>You're now covered in scales from head to toe.</b>", false);
 				}
 				else if (player.skinType == SKIN_TYPE_DRACONIC) {
 					outputText("\n\nPrickling discomfort suddenly erupts all over your body, like every last inch of your skin has suddenly developed pins and needles.  You scratch yourself, hoping for relief; and when you look at your hands you notice small fragments of your " + player.skinFurScales() + " hanging from your fingers.  Nevertheless you continue to scratch yourself, and when you're finally done, you look yourself over. New scales have grown to replace your peeled off " + player.skinFurScales() + ".  <b>You're covered from head to toe in shiny ");
 					player.skinTone = newLizardSkinTone();
+					updateClaws(player.clawType);
 					outputText(player.skinTone + " scales.</b>", false);
 				}
 				//(no fur)
 				else {
 					outputText("\n\nYou idly reach back to scratch yourself and nearly jump out of your " + player.armorName + " when you hit something hard.  A quick glance down reveals that scales are growing out of your " + player.skinTone + " skin with alarming speed.  As you watch, the surface of your skin is covered in smooth scales.  They interlink together so well that they may as well be seamless.  You peel back your " + player.armorName + " and the transformation has already finished on the rest of your body.  <b>You're covered from head to toe in shiny ", false);
 					player.skinTone = newLizardSkinTone();
+					updateClaws(player.clawType);
 					outputText(player.skinTone + " scales.</b>", false);
 				}
 				player.skinType = SKIN_TYPE_SCALES;
@@ -5600,6 +5612,7 @@
 				if (player.skinType == SKIN_TYPE_FUR) outputText("the skin under your " + player.furColor + " " + player.skinDesc + " has ");
 				else outputText("your " + player.skinDesc + (player.skinDesc.indexOf("scales") != -1 ? " have " : " has "));
 				player.skinTone = randomChoice(humanSkinColors);
+				updateClaws(player.clawType);
 				outputText("changed to become " + player.skinTone + " colored.</b>");
 			}
 			//Change skin to normal
@@ -6188,6 +6201,7 @@
 				else if (temp == 2) player.skinTone = "dark";
 				else if (temp == 3) player.skinTone = "light";
 				outputText(player.skinTone + " colored.</b>", false);
+				updateClaws(player.clawType);
 			}
 			//-Grow hips out if narrow.
 			if (player.hipRating < 10 && changes < changeLimit && rand(3) == 0) {
@@ -6711,6 +6725,7 @@
 				player.skinAdj = "";
 				player.skinType = SKIN_TYPE_PLAIN;
 				player.skinDesc = "skin";
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//(Gain human face)
@@ -7090,6 +7105,7 @@
 					player.skinDesc = "skin";
 					player.skinType = SKIN_TYPE_PLAIN;
 				}
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//Legs
@@ -7200,6 +7216,7 @@
 			if (rand(5) == 0 && changes < changeLimit && player.skinTone != "aphotic blue-black") {
 				outputText("\n\nYou absently bite down on the last of the tentacle, then pull your hand away, wincing in pain.  How did you bite your finger so hard?  Looking down, the answer becomes obvious; <b>your hand, along with the rest of your skin, is now the same aphotic color as the dormant tentacle was!</b>", false);
 				player.skinTone = "aphotic blue-black";
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//-eat more, grow more 'hair':
@@ -7981,6 +7998,7 @@
 				if (!InCollection(player.skinTone, tone)) player.skinTone = randomChoice(tone);
 				outputText(player.skinTone + " complexion.");
 				outputText("  <b>You now have " + player.skin() + "!</b>");
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//Change skin tone if not changed you!
@@ -7988,6 +8006,7 @@
 				outputText("\n\nYou feel a crawling sensation on the surface of your skin, starting at the small of your back and spreading to your extremities, ultimately reaching your face.  Holding an arm up to your face, you discover that <b>you now have ");
 				player.skinTone = randomChoice(tone);
 				outputText(player.skin() + "!</b>");
+				updateClaws(player.clawType);
 				changes++;
 			}
 			//[Change Skin Color: add "Tattoos"]
@@ -9545,6 +9564,7 @@
 				}
 				outputText("\n\nYour skin tingles ever so slightly as you skin’s color changes before your eyes. As the tingling diminishes, you find that your skin has turned " + skinToBeChosen + ".");
 				player.skinTone = skinToBeChosen;
+				updateClaws(player.clawType);
 				changes++;
 			}
 			if (changes == 0) {

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -8010,6 +8010,9 @@
 				player.vaginaType(0);
 				changes++;
 			}
+			// Kitsunes should have normal arms. exspecially skinny arms with claws are somewhat weird (Stadler76).
+			if (player.skinType == SKIN_TYPE_PLAIN) restoreArms();
+
 			if (changes == 0) {
 				outputText("\n\nOdd.  You don't feel any different.");
 			}

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -7778,6 +7778,7 @@
 		public function foxJewel(mystic:Boolean,player:Player):void
 		{
 			var tfSource:String = "foxJewel";
+			if (mystic) tfSource += "-mystic";
 			clearOutput();
 			changes = 0;
 			changeLimit = 1;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -87,7 +87,7 @@
 		/* ITEMZZZZZ FUNCTIONS GO HERE */
 		public function incubiDraft(tainted:Boolean,player:Player):void
 		{
-			
+			var tfSource:String = "incubiDraft";
 			player.slimeFeed();
 			var temp2:Number = 0;
 			var temp3:Number = 0;
@@ -247,6 +247,7 @@
 					player.shrinkTits();
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Demonic changes - higher chance with higher corruption.
 			if (rand(40) + player.cor / 3 > 35 && tainted) demonChanges(player);
 			player.genderCheck();
@@ -415,6 +416,7 @@
 
 		public function minotaurBlood(player:Player):void
 		{
+			var tfSource:String = "minotaurBlood";
 			player.slimeFeed();
 			//Changes done
 			changes = 0;
@@ -509,6 +511,7 @@
 				}
 				changes++;
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Restore arms to become human arms again
 			restoreArms();
 			//+hooves
@@ -826,6 +829,7 @@
 		
 		public function equinum(player:Player):void
 		{
+			var tfSource:String = "equinum";
 			player.slimeFeed();
 			//Changes done
 			changes = 0;
@@ -961,6 +965,7 @@
 					changes++;
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Restore arms to become human arms again
 			restoreArms();
 			//Remove feathery hair
@@ -1359,6 +1364,7 @@
 		
 		public function succubiMilk(tainted:Boolean,player:Player):void
 		{
+			var tfSource:String = "succubiMilk";
 			player.slimeFeed();
 			var temp2:Number = 0;
 			var temp3:Number = 0;
@@ -1551,6 +1557,7 @@
 					else dynStats("cor", 0);
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Demonic changes - higher chance with higher corruption.
 			if (rand(40) + player.cor / 3 > 35 && tainted) demonChanges(player);
 			if (tainted) {
@@ -1572,6 +1579,7 @@
 //5-Bulbous Pepper (+ball size or fresh balls)
 		public function caninePepper(type:Number,player:Player):void
 		{
+			var tfSource:String = "caninePepper";
 			var temp2:Number = 0;
 			var temp3:Number = 0;
 			var crit:Number = 1;
@@ -1661,6 +1669,7 @@
 				outputText("dumber.", false);
 				changes++;
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Restore arms to become human arms again
 			restoreArms();
 			//Remove feathery hair
@@ -2236,6 +2245,7 @@
 
 		public function impFood(player:Player):void
 		{
+			var tfSource:String = "impFood";
 			clearOutput();
 			if (player.cocks.length > 0) {
 				outputText("The food tastes strange and corrupt - you can't really think of a better word for it, but it's unclean.", false);
@@ -2283,6 +2293,9 @@
 				outputText("\n\nYour skin crawls, making you close your eyes and shiver.  When you open them again the world seems... different.  After a bit of investigation, you realize you've become shorter!", false);
 				player.tallness -= 1 + rand(3);
 			}
+			changes = 0;
+			changeLimit = 1;
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 		}
 	
 		//pureHoney moved to BeeHoney.as
@@ -3063,6 +3076,7 @@
 		 */
 		public function laBova(tainted:Boolean,enhanced:Boolean,player:Player):void
 		{
+			var tfSource:String = "laBova";
 			player.slimeFeed();
 			//Changes done
 			changes = 0;
@@ -3315,6 +3329,7 @@
 					dynStats("lus", 10);
 				}
 			}
+			if (tainted && rand(5) == 0) updateOvipositionPerk(tfSource);
 			//General Appearance (Tail -> Ears -> Paws(fur stripper) -> Face -> Horns
 			//Give the player a bovine tail, same as the minotaur
 			if (tainted && player.tailType != TAIL_TYPE_COW && changes < changeLimit && rand(3) == 0) {
@@ -3582,6 +3597,7 @@
 
 		public function goblinAle(player:Player):void
 		{
+			var tfSource:String = "goblinAle";
 			player.slimeFeed();
 			changes = 0;
 			changeLimit = 1;
@@ -3626,6 +3642,7 @@
 				outputText("\n\nYou feel like dancing, and stumble as your legs react more quickly than you'd think.  Is the alcohol slowing you down or are you really faster?  You take a step and nearly faceplant as you go off balance.  It's definitely both.", false);
 				changes++;
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Restore arms to become human arms again
 			restoreArms();
 			//SEXYTIEMS
@@ -3772,6 +3789,7 @@
 
 		public function gooGasmic(player:Player):void
 		{
+			var tfSource:String = "gooGasmic";
 			outputText("You take the wet cloth in hand and rub it over your body, smearing the strange slime over your " + player.skinDesc + " slowly.", true);
 			//Stat changes
 			//libido up to 80
@@ -3796,6 +3814,7 @@
 			 if (player.vaginalCapacity() >= 9000) goopiness++;
 			 }*/
 			//Cosmetic changes based on 'goopyness'
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Remove wings
 			if (player.wingType > WING_TYPE_NONE) {
 				if (player.wingType == WING_TYPE_SHARK_FIN) outputText("\n\nYou sigh, feeling a hot wet tingling down your back.  It tickles slightly as you feel your fin slowly turn to sludge, dripping to the ground as your body becomes more goo-like.", false);
@@ -3911,6 +3930,7 @@
 
 		public function sharkTooth(type:Number,player:Player):void
 		{
+			var tfSource:String = "sharkTooth";
 			changes = 0;
 			changeLimit = 2;
 			if (rand(2) == 0) changeLimit++;
@@ -3996,6 +4016,7 @@
 				dynStats("lib", 2, "sen", 3, "lus", 10);
 				changes++;
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Transformations:
 			//Mouth TF
 			if (player.faceType != FACE_SHARK_TEETH && rand(3) == 0 && changes < changeLimit) {
@@ -4094,6 +4115,7 @@
 
 		public function snakeOil(player:Player):void
 		{
+			var tfSource:String = "snakeOil";
 			player.slimeFeed();
 			clearOutput();
 			changes = 0;
@@ -4113,6 +4135,7 @@
 				if (player.spe < 40) outputText("  Of course, you're nowhere near as fast as that.", false);
 				changes++;
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Removes wings
 			if (player.wingType > WING_TYPE_NONE && rand(3) == 0 && changes < changeLimit) {
 				if (player.wingType == WING_TYPE_SHARK_FIN) outputText("\n\nA wave of tightness spreads through your back, and it feels as if someone is stabbing a dagger into your spine.  After a moment the pain passes, though your fin is gone!", false);
@@ -4211,6 +4234,7 @@
 
 		public function superHummus(player:Player):void
 		{
+			var tfSource:String = "superHummus";
 			clearOutput();
 			if (debug) {
 				outputText("You're about to eat the humus when you see it has bugs in it. Not wanting to eat bugged humus or try to debug it you throw it into the portal and find something else to eat.", false);
@@ -4306,11 +4330,13 @@
 			player.removeStatusEffect(StatusEffects.Uniball);
 			player.removeStatusEffect(StatusEffects.BlackNipples);
 			player.vaginaType(0);
-		}		
+			updateOvipositionPerk(tfSource);
+		}
 		
 		//Normal hummus
 		public function regularHummus(player:Player):void
 		{
+			var tfSource:String = "regularHummus";
 			player.slimeFeed();
 			clearOutput();
 			changes = 0;
@@ -4333,6 +4359,8 @@
 			//-----------------------
 			//1st priority: Change lower body to bipedal.
 			if (rand(4) == 0) restoreLegs(null, RESTORELEGS_FIX_BIPED);
+			//Remove Oviposition Perk
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Remove Incorporeality Perk
 			if (player.findPerk(PerkLib.Incorporeality) >= 0 && player.perkv4(PerkLib.Incorporeality) == 0 && changes < changeLimit && rand(10) == 0) {
 				outputText("\n\nYou feel a strange sensation in your [legs] as they start to feel more solid. They become more opaque until finally, you can no longer see through your [legs]. \n<b>(Perk Lost: Incorporeality!)</b>");
@@ -4638,6 +4666,9 @@
 
 		public function catTransformation(player:Player):void
 		{
+			var tfSource:String = "catTransformation";
+			if (player.hasScales() && player.dragonneScore() >= 4)
+				tfSource = "catTransformation-dragonne";
 			changes = 0;
 			changeLimit = 1;
 			var temp2:Number = 0;
@@ -4852,6 +4883,7 @@
 					changes++;
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Body type changes.  Teh rarest of the rare.
 			//DA EARZ
 			if (player.earType != EARS_CAT && rand(5) == 0 && changes < changeLimit) {
@@ -4939,6 +4971,7 @@
 
 		public function reptilum(player:Player):void
 		{
+			var tfSource:String = "reptilum";
 			player.slimeFeed();
 			//init variables
 			changes = 0;
@@ -5135,12 +5168,8 @@
 				}
 			}
 			//-VAGs
-			if (player.hasVagina() && player.findPerk(PerkLib.Oviposition) < 0 && changes < changeLimit && rand(5) == 0 && player.lizardScore() > 3) {
-				outputText("\n\nDeep inside yourself there is a change.  It makes you feel a little woozy, but passes quickly.  Beyond that, you aren't sure exactly what just happened, but you are sure it originated from your womb.\n", false);
-				outputText("(<b>Perk Gained: Oviposition</b>)", false);
-				player.createPerk(PerkLib.Oviposition, 0, 0, 0, 0);
-				changes++;
-			}
+			if (player.hasVagina() && rand(5) == 0 && player.lizardScore() > 3)
+				updateOvipositionPerk(tfSource); // does all the magic, nuff said!
 
 			//Physical changes:
 			//-Existing horns become draconic, max of 4, max length of 1'
@@ -5339,6 +5368,7 @@
 
 		public function salamanderfirewater(player:Player):void
 		{
+			var tfSource:String = "salamanderfirewater";
 			player.slimeFeed();
 			//init variables
 			changes = 0;
@@ -5499,7 +5529,7 @@
 				player.breastRows[player.smallestTitRow()].breastRating++;
 				changes++;
 			}
-			
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Physical changes:
 			//Tail - 1st gain reptilian tail, 2nd unlocks enhanced with fire tail whip attack
 			if (player.tailType != TAIL_TYPE_LIZARD && player.tailType != TAIL_TYPE_SALAMANDER && changes < changeLimit && rand(3) == 0) {
@@ -5622,6 +5652,7 @@
 
 		public function neonPinkEgg(pregnantChange:Boolean,player:Player):void
 		{
+			var tfSource:String = "neonPinkEgg";
 			changes = 0;
 			changeLimit = 1;
 			if (rand(2) == 0) changeLimit++;
@@ -5777,6 +5808,7 @@
 				outputText("\n\nYou feel strange.  Fertile... somehow.  You don't know how else to think of it, but you know your body is just aching to be pregnant and give birth.", false);
 			}
 			//-VAGs
+			if (rand(4) == 0) updateOvipositionPerk(tfSource);
 			if (player.hasVagina() && player.findPerk(PerkLib.BunnyEggs) < 0 && changes < changeLimit && rand(4) == 0 && player.bunnyScore() > 3) {
 				outputText("\n\nDeep inside yourself there is a change.  It makes you feel a little woozy, but passes quickly.  Beyond that, you aren't sure exactly what just happened, but you are sure it originated from your womb.\n\n", false);
 				outputText("(<b>Perk Gained: Bunny Eggs</b>)", false);
@@ -5957,10 +5989,12 @@
 				}
 			}
 			player.refillHunger(20);
+			flags[kFLAGS.TIMES_TRANSFORMED] += changes;
 		}
 
 		public function goldenSeed(type:Number,player:Player):void
 		{
+			var tfSource:String = "goldenSeed";
 			//'type' refers to the variety of seed.
 			//0 == standard.
 			//1 == enhanced - increase change limit and no pre-reqs for TF
@@ -6132,6 +6166,7 @@
 					}
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//****************
 			//General Appearance:
 			//****************
@@ -6318,6 +6353,7 @@
 		 -Roo face*/
 		public function kangaFruit(type:Number,player:Player):void
 		{
+			var tfSource:String = "kangaFruit";
 			clearOutput();
 			outputText("You squeeze the pod around the middle, forcing the end open.  Scooping out a handful of the yeasty-smelling seeds, you shovel them in your mouth.  Blech!  Tastes like soggy burnt bread... and yet, you find yourself going for another handful...", false);
 			//Used to track changes and the max
@@ -6438,6 +6474,7 @@
 					changes++;
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//****************
 			//Big Kanga Morphs
 			//type 1 ignores normal restrictions
@@ -6538,6 +6575,7 @@
 
 		public function sweetGossamer(type:Number,player:Player):void
 		{
+			var tfSource:String = (type == 1 ? "blackGossamer" : "sweetGossamer");
 			clearOutput();
 			changes = 0;
 			changeLimit = 1;
@@ -6653,6 +6691,7 @@
 				player.buttRating++;
 				changes++;
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//***************
 			//Appearance Changes
 			//***************
@@ -6984,6 +7023,7 @@
 //Bottle of Ectoplasm Text
 		public function ectoplasm(player:Player):void
 		{
+			var tfSource:String = "ectoplasm";
 			player.slimeFeed();
 			clearOutput();
 			outputText("You grimace and uncork the bottle, doing your best to ignore the unearthly smell drifting up to your nostrils. Steeling yourself, you raise the container to your lips and chug the contents, shivering at the feel of the stuff sliding down your throat.  Its taste, at least, is unexpectedly pleasant.  Almost tastes like oranges.", false);
@@ -7025,6 +7065,7 @@
 					changes++;
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Appearnace Change
 			//Hair
 			if (rand(4) == 0 && changes < changeLimit && player.hairType != 2) {
@@ -7086,6 +7127,7 @@
 //tooltip:
 		public function shriveledTentacle(player:Player):void
 		{
+			var tfSource:String = "shriveledTentacle";
 			clearOutput();
 			outputText("You chew on the rubbery tentacle; its texture and taste are somewhat comparable to squid, but the half-dormant nematocysts cause your mouth to tingle sensitively.", false);
 			changes = 0;
@@ -7117,6 +7159,7 @@
 			//-always increases lust by a function of sensitivity
 			//"The tingling of the tentacle
 
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//physical changes:
 			//- may randomly remove bee abdomen, if present; always checks and does so when any changes to hair might happen
 			if (rand(4) == 0 && changes < changeLimit && player.tailType == TAIL_TYPE_BEE_ABDOMEN) {
@@ -7252,6 +7295,7 @@
 
 		public function foxTF(enhanced:Boolean,player:Player):void
 		{
+			var tfSource:String = "foxTF";
 			clearOutput();
 			if (!enhanced) outputText("You examine the berry a bit, rolling the orangish-red fruit in your hand for a moment before you decide to take the plunge and chow down.  It's tart and sweet at the same time, and the flavors seem to burst across your tongue with potent strength.  Juice runs from the corners of your lips as you finish the tasty snack.");
 			else outputText("You pop the cap on the enhanced \"Vixen's Vigor\" and decide to take a swig of it.  Perhaps it will make you as cunning as the crude fox Lumi drew on the front?");
@@ -7489,6 +7533,7 @@
 						changes++;
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//[Grow Fur]
 			//FOURTH
 			if ((enhanced || player.lowerBody == LOWER_BODY_TYPE_FOX) && player.skinType != SKIN_TYPE_FUR && changes < changeLimit && rand(4) == 0) {
@@ -7732,6 +7777,7 @@
 //Consume:
 		public function foxJewel(mystic:Boolean,player:Player):void
 		{
+			var tfSource:String = "foxJewel";
 			clearOutput();
 			changes = 0;
 			changeLimit = 1;
@@ -7854,6 +7900,7 @@
 			//**********************
 			//BIG APPEARANCE CHANGES
 			//**********************
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//[Grow Fox Tail]
 			if (player.tailType != TAIL_TYPE_FOX && changes < changeLimit && ((mystic && rand(2) == 0) || (!mystic && rand(4) == 0))) {
 				//if PC has no tail
@@ -8207,6 +8254,7 @@
 //Flavour Description: A round, opaque glass vial filled with a clear, viscous fluid.  It has a symbol inscribed on it, a circle with a cross and arrow pointing out of it in opposite directions.  It looks and smells entirely innocuous.
 		public function trapOil(player:Player):void
 		{
+			var tfSource:String = "trapOil";
 			clearOutput();
 			changes = 0;
 			changeLimit = 1;
@@ -8427,6 +8475,7 @@
 					changes++;
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Nipples Turn Black:
 			if (player.findStatusEffect(StatusEffects.BlackNipples) < 0 && rand(6) == 0 && changes < changeLimit) {
 				outputText("\n\nA tickling sensation plucks at your nipples and you cringe, trying not to giggle.  Looking down you are in time to see the last spot of flesh tone disappear from your [nipples].  They have turned an onyx black!");
@@ -8518,6 +8567,7 @@
 
 		public function ringtailFig(player:Player):void
 		{
+			var tfSource:String = "ringtailFig";
 			clearOutput();
 			//eat it:
 			outputText("You split the fruit and scoop out the pulp, eating it greedily.  It's sweet and slightly gritty with seeds, and you quickly finish both halves.");
@@ -8574,6 +8624,7 @@
 				outputText(player.modThickness(80, 2), false);
 				changes++;
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//bodypart changes:
 			if (player.tailType != TAIL_TYPE_RACCOON && rand(4) == 0 && changes < changeLimit) {
 				//grow da tail
@@ -8696,6 +8747,7 @@
 //Mouse Cocoa/MousCoco (you can change the name if you're saddlesore I guess but I'll make fun of you for having no plausible source of chocolate for your bakery if you do)
 		public function mouseCocoa(player:Player):void
 		{
+			var tfSource:String = "mouseCocoa";
 			clearOutput();
 			changes = 0;
 			changeLimit = 1;
@@ -8790,6 +8842,7 @@
           changes++;
         }
       }
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//bodypart changes:
 			//gain ears
 			if (player.earType != EARS_MOUSE && changes < changeLimit && rand(4) == 0) {
@@ -9055,7 +9108,9 @@
 		}
 		
 		//Ferret Fruit
-		public function ferretTF(player:Player):void {
+		public function ferretTF(player:Player):void
+		{
+			var tfSource:String = "ferretTF";
 			//CoC Ferret TF (Ferret Fruit)
 			//Finding Ferret Fruit
 			//- Ferret Fruit may be randomly found while exploring the plains.
@@ -9227,6 +9282,7 @@
 						changes++;
 				}
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Turn ferret mask to full furface.
 			if (player.faceType == FACE_FERRET_MASK && player.skinType == SKIN_TYPE_FUR && player.earType == EARS_FERRET && player.tailType == TAIL_TYPE_FERRET && player.lowerBody == LOWER_BODY_TYPE_FERRET && rand(4) == 0 && changes < changeLimit)
 			{
@@ -9342,7 +9398,9 @@
 			flags[kFLAGS.TIMES_TRANSFORMED] += changes;
 		}
 		
-		public function pigTruffle(boar:Boolean, player:Player):void {
+		public function pigTruffle(boar:Boolean, player:Player):void
+		{
+			var tfSource:String = "pigTruffle";
 			changes = 0;
 			changeLimit = 1;
 			var temp:int = 0;
@@ -9406,6 +9464,7 @@
 				player.ballSize++;
 				changes++;
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//-----------------------
 			// TRANSFORMATIONS
 			//-----------------------
@@ -9489,7 +9548,11 @@
 			flags[kFLAGS.TIMES_TRANSFORMED] += changes;
 		}
 		
-		public function winterPudding(player:Player, returnToBakery:Boolean = false):void {
+		public function winterPudding(player:Player, returnToBakery:Boolean = false):void
+		{
+			var tfSource:String = "winterPudding";
+			changes = 0;
+			changeLimit = 2;
 			outputText("You stuff the stodgy pudding down your mouth, the taste of brandy cream sauce and bitter black treacle sugar combining in your mouth.  You can tell by its thick spongy texture that it's far from good for you, so its exclusivity is more than likely for the best.");
 			player.refillHunger(30);
 			if (player.thickness < 100 || player.tone > 0) {
@@ -9507,7 +9570,7 @@
 				//[Player horn type changed to Antlers.]
 				player.hornType = HORNS_ANTLERS;
 				player.horns = 4 + rand(12);
-				flags[kFLAGS.TIMES_TRANSFORMED]++;
+				changes++;
 			}
 			//[Show this description instead if the player already had horns when the transformation occurred.] 
 			else if (player.horns > 0 && player.hornType != HORNS_ANTLERS && rand(2) == 0) {
@@ -9515,8 +9578,10 @@
 				//[Player horn type changed to Antlers.]
 				player.hornType = HORNS_ANTLERS;
 				player.horns = 4 + rand(12);
-				flags[kFLAGS.TIMES_TRANSFORMED]++;
+				changes++;
 			}
+			if (rand(5) == 0) updateOvipositionPerk(tfSource); // I doubt, that winterPudding will ever be affected, but well ... just in case
+			flags[kFLAGS.TIMES_TRANSFORMED] += changes;
 			if (returnToBakery) {
 				doNext(kGAMECLASS.telAdre.bakeryScene.bakeryuuuuuu);
 				return;

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -267,6 +267,7 @@ package classes.Items
 
 				default:
 					if (player.findPerk(PerkLib.Oviposition) < 0) return null;
+					if (player.lizardScore() >= 8) return null; // Still high, so don't remove Oviposition yet!
 					if (tfSource != "superHummus") {
 						outputText("\n\nAnother change in your uterus ripples through your reproductive systems."
 						          +"  Somehow you know you've lost a little bit of reptilian reproductive ability.\n");

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -47,8 +47,7 @@ package classes.Items
 				if (hasClaws) outputText("now gooey claws melt back into your fingers. Well, who cares, gooey claws aren't very useful in combat to begin with.");
 				if (hasClaws || player.armType == ARM_TYPE_HARPY) outputText("  <b>You have normal human arms again.</b>");
 
-				player.clawType = CLAW_TYPE_NORMAL;
-				player.clawTone = "";
+				updateClaws();
 				player.armType = ARM_TYPE_HUMAN;
 				return true;
 			}
@@ -91,8 +90,7 @@ package classes.Items
 						outputText(" your unusual arms change more and more until they are normal human arms, leaving " + player.skinFurScales() + " behind.");
 				}
 				outputText("  <b>You have normal human arms again.</b>");
-				player.clawType = CLAW_TYPE_NORMAL;
-				player.clawTone = "";
+				updateClaws();
 				player.armType = ARM_TYPE_HUMAN;
 				changes++;
 				return true;
@@ -188,6 +186,43 @@ package classes.Items
 			}
 
 			return "invalid"; // Will never happen. Suppresses 'Error: Function does not return a value.'
+		}
+
+		public function updateClaws(clawType:int = CLAW_TYPE_NORMAL):String
+		{
+			var clawTone:String = "";
+			var oldClawTone:String = player.clawTone;
+
+			switch (clawType) {
+				case CLAW_TYPE_DRAGON:       clawTone = "steel-gray";   break;
+				case CLAW_TYPE_SALAMANDER:   clawTone = "fiery-red";    break;
+				case CLAW_TYPE_LIZARD:
+					// See http://www.bergenbattingcenter.com/lizard-skins-bat-grip/ for all those NYI! lizard skin colors
+					// I'm still not that happy with these claw tones. Any suggestion would be nice.
+					switch (player.skinTone) {
+						case "red":          clawTone = "reddish";      break;
+						case "green":        clawTone = "greenish";     break;
+						case "white":        clawTone = "light-gray";   break;
+						case "blue":         clawTone = "bluish";       break;
+						case "black":        clawTone = "dark-gray";    break;
+						case "purple":       clawTone = "purplish";     break;
+						case "silver":       clawTone = "silvery";      break;
+						case "pink":         clawTone = "pink";         break; // NYI! Maybe only with a new Skin Oil?
+						case "orange":       clawTone = "orangey";      break; // NYI!
+						case "yellow":       clawTone = "yellowish";    break; // NYI!
+						case "desert-camo":  clawTone = "pale-yellow";  break; // NYI!
+						case "gray-camo":    clawTone = "gray";         break; // NYI!
+						default:             clawTone = "gray";         break;
+					}
+					break;
+				default:
+					clawTone = "";
+			}
+
+			player.clawType = clawType;
+			player.clawTone = clawTone;
+
+			return oldClawTone;
 		}
 
 		public function updateOvipositionPerk(tfSource:String):*

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -231,7 +231,7 @@ package classes.Items
 			// First things first :)
 			if (player.findPerk(PerkLib.BasiliskWomb) >= 0) {
 				if (player.findPerk(PerkLib.Oviposition) >= 0)
-					return null; // we already have it => return null; // no change
+					return null; // we already have it => no change
 
 				// Basilisk Womb but no Oviposition? Fix, whats broken
 				outputText("\n\nDeep inside yourself there is a change.  It makes you feel a little woozy, but passes quickly."
@@ -248,6 +248,7 @@ package classes.Items
 			switch(tfSource) {
 				case "emberTFs":
 				case "snakeOil":
+				case "goldenSeed-HarpyWomb":
 				//case "catTransformation-dragonne": // Keep it? Maybe later.
 				// TFs with minor changes. Just in case, we change our mind or if we intend to upgrade them.
 				case "winterPudding":

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -190,6 +190,58 @@ package classes.Items
 			return "invalid"; // Will never happen. Suppresses 'Error: Function does not return a value.'
 		}
 
+		public function updateOvipositionPerk(tfSource:String):*
+		{
+			trace('called updateOvipositionPerk("' + tfSource + '")');
+			// First things first :)
+			if (player.findPerk(PerkLib.BasiliskWomb) >= 0) {
+				if (player.findPerk(PerkLib.Oviposition) >= 0)
+					return null; // we already have it => return null; // no change
+
+				// Basilisk Womb but no Oviposition? Fix, whats broken
+				outputText("\n\nDeep inside yourself there is a change.  It makes you feel a little woozy, but passes quickly."
+				          +"  Beyond that, you aren't sure exactly what just happened, but you are sure it originated from your basilisk womb.\n");
+				outputText("(<b>Perk Gained: Oviposition</b>)");
+
+				player.createPerk(PerkLib.Oviposition, 0, 0, 0, 0);
+				return true; // true => gained Oviposition Perk
+			}
+
+			if (changes >= changeLimit) return null;
+
+			// Note, that we don't do the score checks anymore. That was just an unly workaround and we don't want to do that again!
+			switch(tfSource) {
+				case "emberTFs":
+				case "snakeOil":
+				//case "catTransformation-dragonne": // Keep it? Maybe later.
+				// TFs with minor changes. Just in case, we change our mind or if we intend to upgrade them.
+				case "winterPudding":
+				case "rizzaRootEffect":
+					return null; // Don't change it. So we're done, yay!
+
+				case "reptilum":
+					if (player.findPerk(PerkLib.Oviposition) >= 0) return null;
+					outputText("\n\nDeep inside yourself there is a change.  It makes you feel a little woozy, but passes quickly."
+					          +"  Beyond that, you aren't sure exactly what just happened, but you are sure it originated from your womb.\n");
+					outputText("(<b>Perk Gained: Oviposition</b>)");
+
+					player.createPerk(PerkLib.Oviposition, 0, 0, 0, 0);
+					changes++;
+					return true; // Gained it
+					break;
+
+				default:
+					if (player.findPerk(PerkLib.Oviposition) < 0) return null;
+					if (tfSource != "superHummus") {
+						outputText("\n\nAnother change in your uterus ripples through your reproductive systems."
+						          +"  Somehow you know you've lost a little bit of reptilian reproductive ability.\n");
+						outputText("(<b>Perk Lost: Oviposition</b>)\n");
+					}
+					player.removePerk(PerkLib.Oviposition);
+					return false; // Lost it
+			}
+		}
+
 		public function gainSnakeTongue():Boolean
 		{
 			if (player.tongueType != TONGUE_SNAKE && changes < changeLimit) {

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -396,13 +396,13 @@ package classes {
 					}
 				}
 			}
-			if (player.findPerk(PerkLib.BunnyEggs) >= 0) { //Oviposition perk for bunny folks
-				if (player.bunnyScore() < 3) { //--Lose Oviposition perk if bunny score gets below 3.
-					outputText("\nAnother change in your uterus ripples through your reproductive systems.  Somehow you know you've lost your ability to spontaneously lay eggs.\n(<b>Perk Lost: Bunny Eggs</b>)\n");
-					player.removePerk(PerkLib.BunnyEggs);
-					needNext = true;
-				}
-				else if (player.pregnancyIncubation < 1 && player.hasVagina() && getGame().model.time.hours == 1) { //Otherwise pregger check, once every morning
+			if (player.findPerk(PerkLib.BunnyEggs) >= 0 && player.bunnyScore() < 3) { //--Lose BunnyEggs oviposition perk if bunny score gets below 3.
+				outputText("\nAnother change in your uterus ripples through your reproductive systems.  Somehow you know you've lost your ability to spontaneously lay eggs.\n(<b>Perk Lost: Bunny Eggs</b>)\n");
+				player.removePerk(PerkLib.BunnyEggs);
+				needNext = true;
+			}
+			if (player.findPerk(PerkLib.Oviposition) >= 0 || player.findPerk(PerkLib.BunnyEggs) >= 0) { //Oviposition perk for lizard and bunny folks
+				if (player.pregnancyIncubation < 1 && player.hasVagina() && getGame().model.time.hours == 1) { //Otherwise pregger check, once every morning
 					if ((player.totalFertility() > 50 && getGame().model.time.days % 15 == 0) || getGame().model.time.days % 30 == 0) { //every 15 days if high fertility get egg preg
 						outputText("\n<b>Somehow you know that eggs have begun to form inside you.  You wonder how long it will be before they start to show?</b>\n");
 						player.knockUp(PregnancyStore.PREGNANCY_OVIELIXIR_EGGS, PregnancyStore.INCUBATION_OVIELIXIR_EGGS, 1, 1);

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -396,13 +396,8 @@ package classes {
 					}
 				}
 			}
-			if (player.findPerk(PerkLib.Oviposition) >= 0 || player.findPerk(PerkLib.BunnyEggs) >= 0) { //Oviposition perk for lizard and bunny folks
-				if ((player.nagaScore() + player.lizardScore() < 3) && player.findPerk(PerkLib.Oviposition) >= 0 && player.findPerk(PerkLib.BasiliskWomb) < 0) { //--Lose Oviposition perk if lizard score gets below 3.
-					outputText("\nAnother change in your uterus ripples through your reproductive systems.  Somehow you know you've lost a little bit of reptilian reproductive ability.\n(<b>Perk Lost: Oviposition</b>)\n");
-					player.removePerk(PerkLib.Oviposition);
-					needNext = true;
-				}
-				else if (player.bunnyScore() < 3 && player.findPerk(PerkLib.BunnyEggs) >= 0) { //--Lose Oviposition perk if bunny score gets below 3.
+			if (player.findPerk(PerkLib.BunnyEggs) >= 0) { //Oviposition perk for bunny folks
+				if (player.bunnyScore() < 3) { //--Lose Oviposition perk if bunny score gets below 3.
 					outputText("\nAnother change in your uterus ripples through your reproductive systems.  Somehow you know you've lost your ability to spontaneously lay eggs.\n(<b>Perk Lost: Bunny Eggs</b>)\n");
 					player.removePerk(PerkLib.BunnyEggs);
 					needNext = true;

--- a/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
+++ b/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
@@ -2,6 +2,8 @@ package classes.Scenes.Areas.Forest
 {
 	import classes.*;
 	import classes.GlobalFlags.kFLAGS;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Items.Mutations;
 
 	public class ErlKingScene extends BaseContent
 	{
@@ -9,6 +11,13 @@ package classes.Scenes.Areas.Forest
 		{
 
 		}
+
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return mutations.changes; }
+		protected function set changes(val:int):void { mutations.changes = val; }
+		protected function get changeLimit():int { return mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
 
 		public function encounterWildHunt():void
 		{
@@ -974,17 +983,20 @@ package classes.Scenes.Areas.Forest
 			inventory.takeItem(consumables.GLDRIND, camp.returnToCampUseOneHour);
 		}
 		
-		public function deerTFs():void {
-			var changes:int = 0;
-			var changeLimit:int = 2;
+		public function deerTFs():void
+		{
+			var tfSource:String = "deerTFs";
 			var temp:int = 0;
 			var x:int = 0;
+			changes = 0;
+			changeLimit = 2;
 			if (rand(2) == 0) changeLimit++;
 			if (rand(3) == 0) changeLimit++;
 			if (player.findPerk(PerkLib.HistoryAlchemist) >= 0) changeLimit++;
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
 			// Main TFs
 			//------------
+			if (rand(5) == 0) mutations.updateOvipositionPerk(tfSource);
 			//Gain deer ears
 			if (rand(3) == 0 && changes < changeLimit && player.earType != EARS_DEER) {
 				if (player.earType == -1) outputText("\n\nTwo painful lumps sprout on the top of your head, forming into tear-drop shaped ears, covered with short fur.  ");

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -1581,8 +1581,8 @@ package classes.Scenes.NPCs
 //TF messages (Z)
 		public function emberTFs(drakesHeart:Boolean = false):void
 		{
-			var changes:int = 0;
-			var changeLimit:int = 2;
+			changes = 0;
+			changeLimit = 2;
 			if (player.findPerk(PerkLib.HistoryAlchemist) >= 0) changeLimit++;
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
 			var tfSource:String = "emberTFs";
@@ -1791,20 +1791,21 @@ package classes.Scenes.NPCs
 			// <mod name="Predator arms" author="Stadler76">
 			//Gain Dragon Arms (Derived from ARM_TYPE_SALAMANDER)
 			if (player.armType != ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_DRACONIC && player.lowerBody == LOWER_BODY_TYPE_DRAGON && changes < changeLimit && rand(3) == 0) {
-				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with shield-shaped " + player.skinTone + " scales and powerful, thick curved claws replacing your fingernails.");
+				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with shield-shaped " + player.skinTone + " scales and powerful, thick, curved steel-gray claws replacing your fingernails.");
 				outputText("\n<b>You now have dragon arms.</b>", false);
 				player.armType = ARM_TYPE_PREDATOR;
-				player.clawType = CLAW_TYPE_DRAGON;
+				mutations.updateClaws(CLAW_TYPE_DRAGON);
 				changes++
 			}
 			//Claw transition
 			if (player.armType == ARM_TYPE_PREDATOR && player.skinType == SKIN_TYPE_DRACONIC && player.clawType != CLAW_TYPE_DRAGON && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nYour " + player.claws() + " change  a little to become more dragon-like.");
-				player.clawType = CLAW_TYPE_DRAGON;
+				mutations.updateClaws(CLAW_TYPE_DRAGON);
 				outputText(" <b>You now have " + player.claws() + ".</b>");
 				changes++
 			}
 			// </mod>
+			trace("emberTFs changeLimit: ", changeLimit);
 			//Get Dragon Breath (Tainted version)
 			//Can only be obtained if you are considered a dragon-morph, once you do get it though, it won't just go away even if you aren't a dragon-morph anymore.
 
@@ -1840,13 +1841,13 @@ package classes.Scenes.NPCs
 					outputText("rut");
 					
 					player.goIntoRut(false);
-					changes++;
+					changes++; // is this really worth incrementing the changes? It even ignores the changeLimit
 				}
 				else {
 					outputText("heat");
 					
 					player.goIntoHeat(false);
-					changes++;
+					changes++; // is this really worth incrementing the changes? It even ignores the changeLimit
 				}
 				outputText("</b>.");
 			}

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -5,6 +5,7 @@ package classes.Scenes.NPCs
 {
 	import classes.*;
 	import classes.GlobalFlags.*;
+	import classes.Items.Mutations;
 
 	public class EmberScene extends NPCAwareContent implements TimeAwareInterface
 	{
@@ -57,6 +58,12 @@ package classes.Scenes.NPCs
 // TIMES_EMBER_LUSTY_FUCKED:int = 824;
 
 		public var pregnancy:PregnancyStore;
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return mutations.changes; }
+		protected function set changes(val:int):void { mutations.changes = val; }
+		protected function get changeLimit():int { return mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
 
 		public function EmberScene()
 		{
@@ -1578,6 +1585,7 @@ package classes.Scenes.NPCs
 			var changeLimit:int = 2;
 			if (player.findPerk(PerkLib.HistoryAlchemist) >= 0) changeLimit++;
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
+			var tfSource:String = "emberTFs";
 			//Gain Dragon Dick
 			if (changes < changeLimit && player.countCocksOfType(CockTypesEnum.DRAGON) < player.totalCocks() && rand(3) == 0) {
 				temp = 0;
@@ -1602,6 +1610,7 @@ package classes.Scenes.NPCs
 				player.cocks[select].cockType = CockTypesEnum.DRAGON;
 				player.cocks[select].knotMultiplier = 1.3;
 			}
+			if (rand(5) == 0) mutations.updateOvipositionPerk(tfSource);
 			//Gain Dragon Head
 			if (changes < changeLimit && rand(3) == 0 && player.faceType != FACE_DRAGON && flags[kFLAGS.EMBER_ROUNDFACE] == 0) {
 				outputText("\n\nYou scream as your face is suddenly twisted; your facial bones begin rearranging themselves under your skin, restructuring into a long, narrow muzzle.  Spikes of agony rip through your jaws as your teeth are brutally forced from your gums, giving you new rows of fangs - long, narrow and sharp.  Your jawline begins to sprout strange growths; small spikes grow along the underside of your muzzle, giving you an increasingly inhuman visage.\n\nFinally, the pain dies down, and you look for a convenient puddle to examine your changed appearance.\n\nYour head has turned into a reptilian muzzle, with small barbs on the underside of the jaw.  <b>You now have a dragon's face.</b>");

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -5,7 +5,6 @@ package classes.Scenes.NPCs
 {
 	import classes.*;
 	import classes.GlobalFlags.*;
-	import classes.Items.Mutations;
 
 	public class EmberScene extends NPCAwareContent implements TimeAwareInterface
 	{
@@ -58,12 +57,6 @@ package classes.Scenes.NPCs
 // TIMES_EMBER_LUSTY_FUCKED:int = 824;
 
 		public var pregnancy:PregnancyStore;
-		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
-		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
-		protected function get changes():int { return mutations.changes; }
-		protected function set changes(val:int):void { mutations.changes = val; }
-		protected function get changeLimit():int { return mutations.changeLimit; }
-		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
 
 		public function EmberScene()
 		{

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -1798,7 +1798,6 @@ package classes.Scenes.NPCs
 				changes++
 			}
 			// </mod>
-			trace("emberTFs changeLimit: ", changeLimit);
 			//Get Dragon Breath (Tainted version)
 			//Can only be obtained if you are considered a dragon-morph, once you do get it though, it won't just go away even if you aren't a dragon-morph anymore.
 

--- a/classes/classes/Scenes/NPCs/NPCAwareContent.as
+++ b/classes/classes/Scenes/NPCs/NPCAwareContent.as
@@ -7,6 +7,7 @@ package classes.Scenes.NPCs
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Scenes.FollowerInteractions;
 	import classes.Scenes.Places.TelAdre;
+	import classes.Items.Mutations;
 
 	/**
 	 * Contains handy references to scenes and methods
@@ -17,6 +18,14 @@ package classes.Scenes.NPCs
 		{
 
 		}
+
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return mutations.changes; }
+		protected function set changes(val:int):void { mutations.changes = val; }
+		protected function get changeLimit():int { return mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
+
 		// Common scenes
 		protected function get telAdre():TelAdre
 		{

--- a/classes/classes/Scenes/NPCs/Urta.as
+++ b/classes/classes/Scenes/NPCs/Urta.as
@@ -4678,6 +4678,7 @@ private function urtasRuinedOrgasmsFromGooPartII():void {
 	if (player.skinTone != "milky white") {
 		outputText("\n\nThen you catch sight of your body...  You hold up a hand in surprise.  Your skin has changed color!  Your time inside Urta's balls has taken its toll, it seems.  <b>You now have milky white skin!</b>");
 		player.skinTone = "milky white";
+		mutations.updateClaws(player.clawType);
 		player.cumMultiplier += 10;
 	}
 	outputText("\n\nUrta and ");

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -9,14 +9,14 @@ package classes.Scenes.Places.Bazaar
 	 */
 	public class BlackCock extends BazaarAbstractContent
 	{
-		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
-		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
-		protected function get changes():int { return mutations.changes; }
-		protected function set changes(val:int):void { mutations.changes = val; }
-		protected function get changeLimit():int { return mutations.changeLimit; }
-		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; } 
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; } 
+		protected function get changes():int { return mutations.changes; } 
+		protected function set changes(val:int):void { mutations.changes = val; } 
+		protected function get changeLimit():int { return mutations.changeLimit; } 
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; } 
 
-		public function BlackCock() {}
+		public function BlackCock() {} 
 
 		//Will eventually be used to display sprites.
 		public function displayAnitaSprite():void {
@@ -1627,6 +1627,7 @@ package classes.Scenes.Places.Bazaar
 				player.skinAdj = "tough";
 				player.skinType = SKIN_TYPE_PLAIN;
 				player.skinDesc = "skin";
+				mutations.updateClaws(player.clawType);
 				changes++;
 			}
 			//Arms change to regular
@@ -1641,6 +1642,7 @@ package classes.Scenes.Places.Bazaar
 					default:
 				}
 				player.armType = ARM_TYPE_HUMAN;
+				mutations.updateClaws();
 				changes++;
 			}
 			//Change legs to normal

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -9,14 +9,14 @@ package classes.Scenes.Places.Bazaar
 	 */
 	public class BlackCock extends BazaarAbstractContent
 	{
-		protected function get mutations():Mutations { return kGAMECLASS.mutations; } 
-		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; } 
-		protected function get changes():int { return mutations.changes; } 
-		protected function set changes(val:int):void { mutations.changes = val; } 
-		protected function get changeLimit():int { return mutations.changeLimit; } 
-		protected function set changeLimit(val:int):void { mutations.changeLimit = val; } 
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return mutations.changes; }
+		protected function set changes(val:int):void { mutations.changes = val; }
+		protected function get changeLimit():int { return mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
 
-		public function BlackCock() {} 
+		public function BlackCock() {}
 
 		//Will eventually be used to display sprites.
 		public function displayAnitaSprite():void {

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -1,6 +1,7 @@
 package classes.Scenes.Places.Bazaar 
 {
 	import classes.GlobalFlags.*;
+	import classes.Items.Mutations;
 	import classes.*;
 	/**
 	 * The Black Cock by Foxxling
@@ -8,12 +9,15 @@ package classes.Scenes.Places.Bazaar
 	 */
 	public class BlackCock extends BazaarAbstractContent
 	{
-		
-		public function BlackCock() 
-		{
-			
-		}
-		
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return mutations.changes; }
+		protected function set changes(val:int):void { mutations.changes = val; }
+		protected function get changeLimit():int { return mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
+
+		public function BlackCock() {}
+
 		//Will eventually be used to display sprites.
 		public function displayAnitaSprite():void {
 			//Anita's sprite code goes here
@@ -1399,9 +1403,11 @@ package classes.Scenes.Places.Bazaar
 		//------------
 		// TRANSFORMATIONS
 		//------------
-		public function satyrTFs():void {
-			var changes:int = 0;
-			var changeLimit:int = 3;
+		public function satyrTFs():void
+		{
+			var tfSource:String = "satyrTFs";
+			changes = 0;
+			changeLimit = 3;
 			if (player.findPerk(PerkLib.HistoryAlchemist) >= 0) changeLimit++;
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
 			//Stats and genital changes
@@ -1453,6 +1459,8 @@ package classes.Scenes.Places.Bazaar
 				changes++;
 			}
 			//Transformations
+			if (rand(5) == 0) mutations.updateOvipositionPerk(tfSource);
+
 			if (rand(3) == 0 && changes < changeLimit && player.hasScales()) {
 				outputText("\n\nYou feel an odd rolling sensation as your scales begin to shift, spreading and reforming as they grow and disappear, <b>becoming normal human skin</b>.");
 				player.skinType = SKIN_TYPE_PLAIN;
@@ -1533,9 +1541,11 @@ package classes.Scenes.Places.Bazaar
 			flags[kFLAGS.TIMES_TRANSFORMED] += changes;
 		}
 		
-		public function rhinoTFs():void {
-			var changes:int = 0;
-			var changeLimit:int = 3;
+		public function rhinoTFs():void
+		{
+			var tfSource:String = "rhinoTFs";
+			changes = 0;
+			changeLimit = 3;
 			if (player.findPerk(PerkLib.HistoryAlchemist) >= 0) changeLimit++;
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
 			// Stats Changes
@@ -1570,6 +1580,7 @@ package classes.Scenes.Places.Bazaar
 			if (rand(3) == 0 && player.rhinoScore() >= 2 && (rand(2) == 0 || !player.inRut) && player.hasCock()) {
 				player.goIntoRut(true);
 			}
+			if (rand(5) == 0) mutations.updateOvipositionPerk(tfSource);
 			// Special TFs
 			//------------
 			if (rand(4) == 0 && changes < changeLimit && player.hornType != HORNS_UNICORN && player.earType == EARS_HORSE && (player.lowerBody == LOWER_BODY_TYPE_HOOFED || player.lowerBody == LOWER_BODY_TYPE_CLOVEN_HOOFED || player.horseScore() >= 3)) {
@@ -1828,9 +1839,11 @@ package classes.Scenes.Places.Bazaar
 			flags[kFLAGS.TIMES_TRANSFORMED] += changes;
 		}
 		
-		public function echidnaTFs():void {
-			var changes:int = 0;
-			var changeLimit:int = 3;
+		public function echidnaTFs():void
+		{
+			var tfSource:String = "echidnaTFs";
+			changes = 0;
+			changeLimit = 3;
 			if (player.findPerk(PerkLib.HistoryAlchemist) >= 0) changeLimit++;
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
 			var i:int = 0;
@@ -1840,6 +1853,8 @@ package classes.Scenes.Places.Bazaar
 			
 			// Normal TFs
 			//------------
+			if (rand(5) == 0) mutations.updateOvipositionPerk(tfSource);
+
 			if (rand(4) == 0 && changes < changeLimit && player.hairType != HAIR_NORMAL && player.hairType != HAIR_QUILL) {
 				outputText("\n\nYour scalp feels really strange, but the sensation is brief. You feel your hair, and you immediately notice the change. <b>It would seem that your hair is normal again!</b>");
 				player.hairType = HAIR_NORMAL;


### PR DESCRIPTION
# Move Oviposition perk checks out of PlayerEvents.as
### Changes behind the Scenes
- I grew tired of juggling with raceScores() and then fixing the checks for Oviposition-removal in PlayerEvents.as, so I did the work to fix this.
- If your lizardScore() is still high don't remove Oviposition
- Harpy TF won't remove Oviposition anymore after gaining an Harpy Womb

### Notes
- Note, that lizans are the only race, that gain it. All others keep it or lose it
- Kitsunes with plain skin and claws don't make much sense to me. Additionally it reduces your lizardScore by 1 extra point.
- You still need to use (magical) golden seed to gain a **Harpy Womb**, then gain **Oviposition** with reptilum and then again use golden seed to reactivate the womb.
  However: It is now easier to be able to have Oviposition and the Harpy Womb active at the same time. You wanna lay large eggs? You get them ;-)
  Note, that this only affects Harpy TF (=> eating (magical) golden seed), while other TFs are unaffected.