### PR TITLE
Minor tweaks and fixes

### DIFF
--- a/classes/classes/Items/Consumables/BodyLotion.as
+++ b/classes/classes/Items/Consumables/BodyLotion.as
@@ -89,12 +89,12 @@ package classes.Items.Consumables
 				game.HPChange(10, true);
 			}
 			else {
-				if (game.player.skinType != 3) { //If skin is goo, don't change.
+				if ([SKIN_TYPE_GOO, SKIN_TYPE_DRACONIC].indexOf(game.player.skinType) == -1) { //If skin is goo or dragon scales, don't change.
 					if (_adj != "clear") game.player.skinAdj = _adj;
 					else game.player.skinAdj = "";
 				}
 				switch(game.player.skinType) {
-					case 0: //Plain
+					case SKIN_TYPE_PLAIN: //Plain
 						outputText("You " + game.player.clothedOrNaked("take a second to disrobe before uncorking the flask of lotion and rubbing", "uncork the flask of lotion and rub") + " the " + liquidDesc() + " across your body. As you rub the mixture into your arms and [chest], your whole body begins to tingle pleasantly. ");
 						switch(_adj) {
 							case "smooth":
@@ -113,7 +113,7 @@ package classes.Items.Consumables
 								outputText("<b>This text should not happen. Please let Kitteh6660 know.</b>");
 						}
 						break;
-					case 1: //Fur
+					case SKIN_TYPE_FUR: //Fur
 						outputText("" + game.player.clothedOrNaked("Once you’ve disrobed you take the lotion and", "You take the lotion and") + " begin massaging it into your skin despite yourself being covered with fur. It takes little effort but once you’ve finished... nothing happens. A few moments pass and then your skin begins to tingle. ");
 						switch(_adj) {
 							case "smooth":
@@ -132,7 +132,7 @@ package classes.Items.Consumables
 								outputText("<b>This text should not happen. Please let Kitteh6660 know.</b>");
 						}
 						break;
-					case 2: //Scales
+					case SKIN_TYPE_SCALES: //Scales
 						outputText("You " + game.player.clothedOrNaked("take a second to disrobe before uncorking the flask of lotion and rubbing", "uncork the flask of lotion and rub") + " the " + liquidDesc() + " across your body. As you rub the mixture into your arms and [chest], your whole body begins to tingle pleasantly.");
 						switch(_adj) {
 							case "smooth":
@@ -151,9 +151,13 @@ package classes.Items.Consumables
 								outputText("<b>This text should not happen. Please let Kitteh6660 know.</b>");
 						}
 						break;
-					case 3: //Goo
+					case SKIN_TYPE_GOO: //Goo
 						outputText("You take the lotion and pour the " + liquidDesc() + " into yourself. The concoction dissolves, leaving your gooey epidermis unchanged. As a matter of fact nothing happens at all.");
 						//No changes due to gooey skin.
+						break;
+					case SKIN_TYPE_DRACONIC: //Dragon scales
+						outputText("You take the lotion and pour the " + liquidDesc() + " on your scales. The concoction dissolves, leaving your dragon scales unchanged. As a matter of fact nothing happens at all.");
+						//No changes due to dragon scales.
 						break;
 					default:
 						outputText("You " + game.player.clothedOrNaked("take a second to disrobe before uncorking the bottle of oil and rubbing", "uncork the bottle of oil and rub") + " the smooth liquid across your body. Even before you’ve covered your arms and [chest] your skin begins to tingle pleasantly all over. After your skin darkens a little, it begins to change until you have " + _adj + " skin.");

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -5574,7 +5574,7 @@
 			}
 			//Arms
 			if (player.armType != ARM_TYPE_SALAMANDER && player.lowerBody == LOWER_BODY_TYPE_SALAMANDER && changes < changeLimit && rand(3) == 0) {
-				outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  After longer moment of ignoring it you finaly glancing down in irritation, only to discover that your arms former appearance changed into this of salamander one with leathery, red scales and short claws replacing your fingernails.  <b>You now have a salamander arms.</b>", false);
+				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of a salamander with leathery, red scales and short, fiery-red claws replacing your fingernails.  <b>You now have salamander arms.</b>");
 				player.armType = ARM_TYPE_SALAMANDER;
 				updateClaws(CLAW_TYPE_SALAMANDER);
 				changes++;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -770,6 +770,8 @@ use namespace kGAMECLASS;
 			if (lizardScore() >= 4)
 			{
 				race = "lizan";
+				if (isTaur())
+					race += "-taur";
 				if (lizardScore() >= 9)
 					return race; // High lizardScore? always return lizan-race
 			}
@@ -838,11 +840,8 @@ use namespace kGAMECLASS;
 			}
 			if (mutantScore() >= 5 && race == "human")
 				race = "corrupted mutant";
-			if (minoScore() >= 4) {
+			if (minoScore() >= 4)
 				race = "minotaur-morph";
-				if (isTaur())
-					race = "minotaur-taur";
-			}
 			if (cowScore() > 5)
 			{
 				race = "cow-";
@@ -956,6 +955,8 @@ use namespace kGAMECLASS;
 					else {
 						if (horseScore() >= 5)
 							race = "equitaur";
+						else if (minoScore() >= 4)
+							race = "mino-centaur";
 						else
 							race = "centaur";
 					}

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -458,7 +458,7 @@ package classes
 			else if (player.armType == ARM_TYPE_SPIDER) 
 				outputText("  Shining black exoskeleton  covers your arms from the biceps down, resembling a pair of long black gloves from a distance.", false);	
 			else if (player.armType == ARM_TYPE_SALAMANDER)
-				outputText("  Shining thick, leathery red scales covers your arms from the biceps down and your fingernails are now a short curved claws.", false);
+				outputText("  Shining thick, leathery red scales cover your arms from the biceps down and your fingernails are now short, fiery-red curved claws.", false);
 			else if (player.armType == ARM_TYPE_PREDATOR)
 				outputText("  Your arms are covered by " + player.skinFurScales() + " and your fingernails are now " + player.claws() + ".", false);
 			//Done with head bits. Move on to body stuff

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -9,14 +9,14 @@ package classes.Scenes.Places.Bazaar
 	 */
 	public class BlackCock extends BazaarAbstractContent
 	{
-		protected function get mutations():Mutations { return kGAMECLASS.mutations; } 
-		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; } 
-		protected function get changes():int { return mutations.changes; } 
-		protected function set changes(val:int):void { mutations.changes = val; } 
-		protected function get changeLimit():int { return mutations.changeLimit; } 
-		protected function set changeLimit(val:int):void { mutations.changeLimit = val; } 
+		protected function get mutations():Mutations { return kGAMECLASS.mutations; }
+		protected function set mutations(val:Mutations):void { kGAMECLASS.mutations = val; }
+		protected function get changes():int { return mutations.changes; }
+		protected function set changes(val:int):void { mutations.changes = val; }
+		protected function get changeLimit():int { return mutations.changeLimit; }
+		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
 
-		public function BlackCock() {} 
+		public function BlackCock() {}
 
 		//Will eventually be used to display sprites.
 		public function displayAnitaSprite():void {


### PR DESCRIPTION
## Minor tweaks and fixes
### Gameplay changes
- Dragon scales are too tough to be smoothed and thus immune to body lotions
- I've corrected the grammar of the salamander arms in the TF and in the player appearance tab
- lizans with a tauric lower body now show up as a lizan-taur :)
- If you're a minotaur with hooves and a tauric lower body, you showed up as a centaur and never as a minotaur-taur.
 - Fixed that by moving the taur-part to the centaur-section and renamed them to be mino-centaurs, since minotaur-taur sounds a bit ... weird.
 
### Changes behind the Scenes
- whitespace-only fix in BlackCock.as. Yes, I am a bit pedantic :X

### Notes
- I hope, I can start with my basilisk eyes real soon