### PR TITLE
Removed calls to totalCocks() and cockTotal() in Player.as

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1015,7 +1015,7 @@ use namespace kGAMECLASS;
 				humanCounter++;
 			if (lowerBody == 0)
 				humanCounter++;
-			if (countCocksOfType(CockTypesEnum.HUMAN) == 1 && totalCocks() == 1)
+			if (countCocksOfType(CockTypesEnum.HUMAN) == 1 && cocks.length == 1)
 				humanCounter++;
 			if (breastRows.length == 1 && skinType == 0)
 				humanCounter++;
@@ -1561,7 +1561,7 @@ use namespace kGAMECLASS;
 				mutantCounter++;
 			if (tailType > 0)
 				mutantCounter++;
-			if (cockTotal() > 1)
+			if (cocks.length > 1)
 				mutantCounter++;
 			if (hasCock() && hasVagina())
 				mutantCounter++;


### PR DESCRIPTION
### Notes
2 calls removed, 2005 calls remaining, sigh.
Let's get rid of them **(very)** slowly, but sure.
**Please note**, that I don't intend to remove them all at once. Actually I don't even intend to do this alone. Actually all devs should always use `cocks.length` so no more calls to these two totally useless and stupid methods are added to the codebase.
If you have GNU grep and GNU coreutils installed, this is the command I used to count them:
`grep -P -rno "(cockTotal|totalCocks)\(\)[^:]" . | wc -l`