### PR TITLE
Reworking salamanderScore()

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1590,20 +1590,22 @@ use namespace kGAMECLASS;
 		public function salamanderScore():Number
 		{
 			var salamanderCounter:Number = 0;
-			if (faceType == 0)
+			if (armType == ARM_TYPE_SALAMANDER)
 				salamanderCounter++;
-			if (earType == 0)
-				salamanderCounter++;
-			if (armType == 5)
-				salamanderCounter++;
-			if (lowerBody == 25)
+			if (lowerBody == LOWER_BODY_TYPE_SALAMANDER)
 				salamanderCounter++;
 			if (tailType == TAIL_TYPE_SALAMANDER)
 				salamanderCounter++;
-			if (countCocksOfType(CockTypesEnum.LIZARD) > 0)
-				salamanderCounter++;
 			if (findPerk(PerkLib.Lustzerker) >= 0)
 				salamanderCounter++;
+			if (salamanderCounter >= 2) {
+				if (countCocksOfType(CockTypesEnum.LIZARD) > 0)
+					salamanderCounter++;
+				if (faceType == 0)
+					salamanderCounter++;
+				if (earType == 0)
+					salamanderCounter++;
+			}
 			return salamanderCounter;
 		}
 		

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -193,7 +193,7 @@ public static const LOWER_BODY_TYPE_CLOVEN_HOOFED:int                           
 //public static const LOWER_BODY_TYPE_RHINO:int                                       =  22;
 public static const LOWER_BODY_TYPE_ECHIDNA:int                                     =  23;
 public static const LOWER_BODY_TYPE_DEERTAUR:int                                    =  24; // DEPRECATED, use LOWER_BODY_TYPE_CLOVEN_HOOFED and legCount=4
-public static const LOWER_BODY_TYPE_SALAMANDER:int						       			=  25;
+public static const LOWER_BODY_TYPE_SALAMANDER:int                                  =  25;
 
 // piercingtypesNOPEDISABLED
 public static const PIERCING_TYPE_NONE:int                                          =   0;


### PR DESCRIPTION
## Reworking salamanderScore()
### Changes behind the Scenes
- Lizard cocks and especially human face and ears should only count towards your salamanderScore() if you have some other salamander-features.

### Notes
- I replaced the numeric body part checks with the constants there, too.
 - Except the checks for human body parts, since they always stand for human, normal or none and it is clear enough, that these are for human body parts.
- Please note, that the maximum salamanderScore has not changed at all. I just don't want humans to have a salamanderScore() > 0.