### PR TITLE
Removed plot variables from `CoC.as`

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -243,7 +243,6 @@
 			}
 			//PLOTZ
 			kGAMECLASS.monk = 0;
-			kGAMECLASS.sand = 0;
 		//Replaced by flag	kGAMECLASS.beeProgress = 0;
 			kGAMECLASS.giacomo = 0;
 			kGAMECLASS.isabellaScene.isabellaOffspringData = []; //CLEAR!

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -243,7 +243,6 @@
 			}
 
 			// Init none-flag plot variables (The few there still are...)
-			kGAMECLASS.monk = 0;
 			kGAMECLASS.isabellaScene.isabellaOffspringData = []; //CLEAR!
 
 			//Lets get this bitch started

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -244,7 +244,6 @@
 			//PLOTZ
 			kGAMECLASS.monk = 0;
 		//Replaced by flag	kGAMECLASS.beeProgress = 0;
-			kGAMECLASS.giacomo = 0;
 			kGAMECLASS.isabellaScene.isabellaOffspringData = []; //CLEAR!
 			//Lets get this bitch started
 			kGAMECLASS.inCombat = false;

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -241,10 +241,11 @@
 				player.nosePShort = "";
 				player.nosePLong = "";
 			}
-			//PLOTZ
+
+			// Init none-flag plot variables (The few there still are...)
 			kGAMECLASS.monk = 0;
-		//Replaced by flag	kGAMECLASS.beeProgress = 0;
 			kGAMECLASS.isabellaScene.isabellaOffspringData = []; //CLEAR!
+
 			//Lets get this bitch started
 			kGAMECLASS.inCombat = false;
 			kGAMECLASS.inDungeon = false;

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -243,7 +243,6 @@
 			}
 			//PLOTZ
 			kGAMECLASS.monk = 0;
-			kGAMECLASS.whitney = 0;
 			kGAMECLASS.sand = 0;
 		//Replaced by flag	kGAMECLASS.beeProgress = 0;
 			kGAMECLASS.giacomo = 0;

--- a/classes/classes/CharSpecial.as
+++ b/classes/classes/CharSpecial.as
@@ -1393,7 +1393,7 @@ package classes
 			//flags[kFLAGS.AMILY_FOLLOWER] = 2;
 			
 			// Jojo
-			//kGAMECLASS.monk = 5;
+			//flags[kFLAGS.JOJO_STATUS] = 5;
 			
 			// Bimbo Sophie
 			flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00282] = 1;

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -315,7 +315,6 @@ the text from being too boring.
 
 		//These plot variables are to be replaced.
 		public var monk:Number;
-		public var sand:Number;
 		public var giacomo:int;
 
 		public var temp:int;
@@ -475,7 +474,6 @@ the text from being too boring.
 
 			//Plot variables
 			monk = 0;
-			sand = 0;
 			giacomo = 0;
 //Replaced by flag			beeProgress = 0;
 

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -313,7 +313,6 @@ the text from being too boring.
 		public var time :TimeModel;
 		public var currentText:String;
 
-		public var explored:Boolean;
 		//These plot variables are to be replaced.
 		public var whitney:Number;
 		public var monk:Number;
@@ -476,7 +475,6 @@ the text from being too boring.
 			//{ region PlotVariables
 
 			//Plot variables
-			explored = false;
 			whitney = 0;
 			monk = 0;
 			sand = 0;

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -314,7 +314,6 @@ the text from being too boring.
 		public var currentText:String;
 
 		public var explored:Boolean;
-		public var foundDesert:Boolean;
 		public var foundMountain:Boolean;
 		public var foundLake:Boolean;
 		//These plot variables are to be replaced.
@@ -480,7 +479,6 @@ the text from being too boring.
 
 			//Plot variables
 			explored = false;
-			foundDesert = false;
 			foundMountain = false;
 			foundLake = false;
 			whitney = 0;

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -314,7 +314,6 @@ the text from being too boring.
 		public var currentText:String;
 
 		//These plot variables are to be replaced.
-		public var whitney:Number;
 		public var monk:Number;
 		public var sand:Number;
 		public var giacomo:int;
@@ -475,7 +474,6 @@ the text from being too boring.
 			//{ region PlotVariables
 
 			//Plot variables
-			whitney = 0;
 			monk = 0;
 			sand = 0;
 			giacomo = 0;

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -314,7 +314,6 @@ the text from being too boring.
 		public var currentText:String;
 
 		public var explored:Boolean;
-		public var foundForest:Boolean;
 		public var foundDesert:Boolean;
 		public var foundMountain:Boolean;
 		public var foundLake:Boolean;
@@ -481,7 +480,6 @@ the text from being too boring.
 
 			//Plot variables
 			explored = false;
-			foundForest = false;
 			foundDesert = false;
 			foundMountain = false;
 			foundLake = false;

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -473,7 +473,6 @@ the text from being too boring.
 
 			//Plot variables
 			monk = 0;
-//Replaced by flag			beeProgress = 0;
 
 //			itemStorage = [];
 //			gearStorage = [];

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -314,7 +314,6 @@ the text from being too boring.
 		public var currentText:String;
 
 		public var explored:Boolean;
-		public var foundLake:Boolean;
 		//These plot variables are to be replaced.
 		public var whitney:Number;
 		public var monk:Number;
@@ -478,7 +477,6 @@ the text from being too boring.
 
 			//Plot variables
 			explored = false;
-			foundLake = false;
 			whitney = 0;
 			monk = 0;
 			sand = 0;

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -313,9 +313,6 @@ the text from being too boring.
 		public var time :TimeModel;
 		public var currentText:String;
 
-		//These plot variables are to be replaced.
-		public var monk:Number;
-
 		public var temp:int;
 		public var args:Array;
 		public var funcs:Array;
@@ -472,7 +469,6 @@ the text from being too boring.
 			//{ region PlotVariables
 
 			//Plot variables
-			monk = 0;
 
 //			itemStorage = [];
 //			gearStorage = [];

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -315,7 +315,6 @@ the text from being too boring.
 
 		//These plot variables are to be replaced.
 		public var monk:Number;
-		public var giacomo:int;
 
 		public var temp:int;
 		public var args:Array;
@@ -474,7 +473,6 @@ the text from being too boring.
 
 			//Plot variables
 			monk = 0;
-			giacomo = 0;
 //Replaced by flag			beeProgress = 0;
 
 //			itemStorage = [];

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -314,7 +314,6 @@ the text from being too boring.
 		public var currentText:String;
 
 		public var explored:Boolean;
-		public var foundMountain:Boolean;
 		public var foundLake:Boolean;
 		//These plot variables are to be replaced.
 		public var whitney:Number;
@@ -479,7 +478,6 @@ the text from being too boring.
 
 			//Plot variables
 			explored = false;
-			foundMountain = false;
 			foundLake = false;
 			whitney = 0;
 			monk = 0;

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -2301,7 +2301,7 @@ public static const UNKNOWN_FLAG_NUMBER_02292:int                               
 public static const UNKNOWN_FLAG_NUMBER_02293:int                                   = 2293;
 public static const UNKNOWN_FLAG_NUMBER_02294:int                                   = 2294;
 public static const SANDWITCH_SERVICED:int                                          = 2295;	// Number of times, the player has serviced a sand witch.
-public static const UNKNOWN_FLAG_NUMBER_02296:int                                   = 2296;
+public static const JOJO_STATUS:int                                                 = 2296; // Replacement for `CoC.monk` variable.
 public static const UNKNOWN_FLAG_NUMBER_02297:int                                   = 2297;
 public static const UNKNOWN_FLAG_NUMBER_02298:int                                   = 2298;
 public static const UNKNOWN_FLAG_NUMBER_02299:int                                   = 2299;

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -2300,7 +2300,7 @@ public static const UNKNOWN_FLAG_NUMBER_02291:int                               
 public static const UNKNOWN_FLAG_NUMBER_02292:int                                   = 2292;
 public static const UNKNOWN_FLAG_NUMBER_02293:int                                   = 2293;
 public static const UNKNOWN_FLAG_NUMBER_02294:int                                   = 2294;
-public static const UNKNOWN_FLAG_NUMBER_02295:int                                   = 2295;
+public static const SANDWITCH_SERVICED:int                                          = 2295;	// Number of times, the player has serviced a sand witch.
 public static const UNKNOWN_FLAG_NUMBER_02296:int                                   = 2296;
 public static const UNKNOWN_FLAG_NUMBER_02297:int                                   = 2297;
 public static const UNKNOWN_FLAG_NUMBER_02298:int                                   = 2298;

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -834,7 +834,7 @@ package classes
 					}
 					else 
 					{ //Surely Benoit and Cotton deserve their place in this list
-						if (player.pregnancyType == PregnancyStore.PREGNANCY_IZMA || player.pregnancyType == PregnancyStore.PREGNANCY_MOUSE || player.pregnancyType == PregnancyStore.PREGNANCY_AMILY || (player.pregnancyType == PregnancyStore.PREGNANCY_JOJO && (getGame().monk <= 0 || flags[kFLAGS.JOJO_BIMBO_STATE] >= 3)) || player.pregnancyType == PregnancyStore.PREGNANCY_EMBER || player.pregnancyType == PregnancyStore.PREGNANCY_BENOIT || player.pregnancyType == PregnancyStore.PREGNANCY_COTTON || player.pregnancyType == PregnancyStore.PREGNANCY_URTA || player.pregnancyType == PregnancyStore.PREGNANCY_BEHEMOTH) 
+						if (player.pregnancyType == PregnancyStore.PREGNANCY_IZMA || player.pregnancyType == PregnancyStore.PREGNANCY_MOUSE || player.pregnancyType == PregnancyStore.PREGNANCY_AMILY || player.pregnancyType == PregnancyStore.PREGNANCY_JOJO && (flags[kFLAGS.JOJO_STATUS] <= 0 || flags[kFLAGS.JOJO_BIMBO_STATE] >= 3) || player.pregnancyType == PregnancyStore.PREGNANCY_EMBER || player.pregnancyType == PregnancyStore.PREGNANCY_BENOIT || player.pregnancyType == PregnancyStore.PREGNANCY_COTTON || player.pregnancyType == PregnancyStore.PREGNANCY_URTA || player.pregnancyType == PregnancyStore.PREGNANCY_BEHEMOTH) 
 							outputText("\n<b>Your belly protrudes unnaturally far forward, bulging with the spawn of one of this land's natives.</b>", false);
 						else if (player.pregnancyType != PregnancyStore.PREGNANCY_MARBLE) 
 							outputText("\n<b>Your belly protrudes unnaturally far forward, bulging with the unclean spawn of some monster or beast.</b>", false);
@@ -915,7 +915,7 @@ package classes
 					}
 					if (player.pregnancyIncubation <= 48) 
 					{ //Surely Benoit and Cotton deserve their place in this list
-						if (player.pregnancyType == PregnancyStore.PREGNANCY_IZMA || player.pregnancyType == PregnancyStore.PREGNANCY_MOUSE || player.pregnancyType == PregnancyStore.PREGNANCY_AMILY || (player.pregnancyType == PregnancyStore.PREGNANCY_JOJO && getGame().monk <= 0) || player.pregnancyType == PregnancyStore.PREGNANCY_EMBER || player.pregnancyType == PregnancyStore.PREGNANCY_BENOIT || player.pregnancyType == PregnancyStore.PREGNANCY_COTTON || player.pregnancyType == PregnancyStore.PREGNANCY_URTA || player.pregnancyType == PregnancyStore.PREGNANCY_MINERVA || player.pregnancyType == PregnancyStore.PREGNANCY_BEHEMOTH) 
+						if (player.pregnancyType == PregnancyStore.PREGNANCY_IZMA || player.pregnancyType == PregnancyStore.PREGNANCY_MOUSE || player.pregnancyType == PregnancyStore.PREGNANCY_AMILY || (player.pregnancyType == PregnancyStore.PREGNANCY_JOJO && flags[kFLAGS.JOJO_STATUS] <= 0) || player.pregnancyType == PregnancyStore.PREGNANCY_EMBER || player.pregnancyType == PregnancyStore.PREGNANCY_BENOIT || player.pregnancyType == PregnancyStore.PREGNANCY_COTTON || player.pregnancyType == PregnancyStore.PREGNANCY_URTA || player.pregnancyType == PregnancyStore.PREGNANCY_MINERVA || player.pregnancyType == PregnancyStore.PREGNANCY_BEHEMOTH) 
 							outputText("\n<b>Your belly protrudes unnaturally far forward, bulging with the spawn of one of this land's natives.</b>", false);
 						else if (player.pregnancyType != PregnancyStore.PREGNANCY_MARBLE) 
 							outputText("\n<b>Your belly protrudes unnaturally far forward, bulging with the unclean spawn of some monster or beast.</b>", false);

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1044,7 +1044,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		
 		//PLOTZ
 		saveFile.data.monk = getGame().monk;
-		saveFile.data.beeProgress = 0; //Now saved in a flag. getGame().beeProgress;
 		
 		saveFile.data.isabellaOffspringData = [];
 		for (i = 0; i < kGAMECLASS.isabellaScene.isabellaOffspringData.length; i++) {
@@ -2142,8 +2141,9 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		game.monk = saveFile.data.monk;
 		flags[kFLAGS.SANDWITCH_SERVICED] = (flags[kFLAGS.SANDWITCH_SERVICED] || saveFile.data.sand);
 		flags[kFLAGS.GIACOMO_MET]        = (flags[kFLAGS.GIACOMO_MET] || saveFile.data.giacomo);
-		if (saveFile.data.beeProgress != undefined && saveFile.data.beeProgress == 1) game.forest.beeGirlScene.setTalked(); //Bee Progress update is now in a flag
-			//The flag will be zero for any older save that still uses beeProgress and newer saves always store a zero in beeProgress, so we only need to update the flag on a value of one.
+		
+		if (saveFile.data.beeProgress == 1)
+			game.forest.beeGirlScene.setTalked();
 			
 		kGAMECLASS.isabellaScene.isabellaOffspringData = [];
 		if (saveFile.data.isabellaOffspringData == undefined) {

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1042,9 +1042,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.days = model.time.days;
 		saveFile.data.autoSave = player.autoSave;
 		
-		//PLOTZ
-		saveFile.data.monk = getGame().monk;
-		
+		// Save non-flag plot variables.
 		saveFile.data.isabellaOffspringData = [];
 		for (i = 0; i < kGAMECLASS.isabellaScene.isabellaOffspringData.length; i++) {
 			saveFile.data.isabellaOffspringData.push(kGAMECLASS.isabellaScene.isabellaOffspringData[i]);
@@ -2138,7 +2136,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			player.autoSave = saveFile.data.autoSave;
 		
 		//PLOTZ
-		game.monk = saveFile.data.monk;
+		flags[kFLAGS.JOJO_STATUS]        = (flags[kFLAGS.JOJO_STATUS] || saveFile.data.monk);
 		flags[kFLAGS.SANDWITCH_SERVICED] = (flags[kFLAGS.SANDWITCH_SERVICED] || saveFile.data.sand);
 		flags[kFLAGS.GIACOMO_MET]        = (flags[kFLAGS.GIACOMO_MET] || saveFile.data.giacomo);
 		

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1034,7 +1034,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.exploredForest = player.exploredForest;
 		saveFile.data.exploredDesert = player.exploredDesert;
 		saveFile.data.explored = player.explored;
-		saveFile.data.foundForest = getGame().foundForest;
 		saveFile.data.foundDesert = getGame().foundDesert;
 		saveFile.data.foundMountain = getGame().foundMountain;
 		saveFile.data.foundLake = getGame().foundLake;
@@ -2134,7 +2133,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		player.exploredForest = saveFile.data.exploredForest;
 		player.exploredDesert = saveFile.data.exploredDesert;
 		player.explored = saveFile.data.explored;
-		game.foundForest = saveFile.data.foundForest;
 		game.foundDesert = saveFile.data.foundDesert;
 		game.foundMountain = saveFile.data.foundMountain;
 		game.foundLake = saveFile.data.foundLake;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1034,7 +1034,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.exploredForest = player.exploredForest;
 		saveFile.data.exploredDesert = player.exploredDesert;
 		saveFile.data.explored = player.explored;
-		saveFile.data.foundLake = getGame().foundLake;
 		saveFile.data.gameState = gameStateGet();
 		
 		//Time and Items
@@ -2131,7 +2130,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		player.exploredForest = saveFile.data.exploredForest;
 		player.exploredDesert = saveFile.data.exploredDesert;
 		player.explored = saveFile.data.explored;
-		game.foundLake = saveFile.data.foundLake;
 		
 		//Days
 		//Time and Items

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1043,7 +1043,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.autoSave = player.autoSave;
 		
 		//PLOTZ
-		saveFile.data.whitney = getGame().whitney;
 		saveFile.data.monk = getGame().monk;
 		saveFile.data.sand = getGame().sand;
 		saveFile.data.giacomo = getGame().giacomo;
@@ -2142,7 +2141,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			player.autoSave = saveFile.data.autoSave;
 		
 		//PLOTZ
-		game.whitney = saveFile.data.whitney;
 		game.monk = saveFile.data.monk;
 		game.sand = saveFile.data.sand;
 		if (saveFile.data.giacomo == undefined)

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1044,7 +1044,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		
 		//PLOTZ
 		saveFile.data.monk = getGame().monk;
-		saveFile.data.giacomo = getGame().giacomo;
 		saveFile.data.beeProgress = 0; //Now saved in a flag. getGame().beeProgress;
 		
 		saveFile.data.isabellaOffspringData = [];
@@ -2142,10 +2141,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		//PLOTZ
 		game.monk = saveFile.data.monk;
 		flags[kFLAGS.SANDWITCH_SERVICED] = (flags[kFLAGS.SANDWITCH_SERVICED] || saveFile.data.sand);
-		if (saveFile.data.giacomo == undefined)
-			game.giacomo = 0;
-		else
-			game.giacomo = saveFile.data.giacomo;
+		flags[kFLAGS.GIACOMO_MET]        = (flags[kFLAGS.GIACOMO_MET] || saveFile.data.giacomo);
 		if (saveFile.data.beeProgress != undefined && saveFile.data.beeProgress == 1) game.forest.beeGirlScene.setTalked(); //Bee Progress update is now in a flag
 			//The flag will be zero for any older save that still uses beeProgress and newer saves always store a zero in beeProgress, so we only need to update the flag on a value of one.
 			

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1044,7 +1044,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		
 		//PLOTZ
 		saveFile.data.monk = getGame().monk;
-		saveFile.data.sand = getGame().sand;
 		saveFile.data.giacomo = getGame().giacomo;
 		saveFile.data.beeProgress = 0; //Now saved in a flag. getGame().beeProgress;
 		
@@ -2142,7 +2141,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		
 		//PLOTZ
 		game.monk = saveFile.data.monk;
-		game.sand = saveFile.data.sand;
+		flags[kFLAGS.SANDWITCH_SERVICED] = (flags[kFLAGS.SANDWITCH_SERVICED] || saveFile.data.sand);
 		if (saveFile.data.giacomo == undefined)
 			game.giacomo = 0;
 		else

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1034,7 +1034,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.exploredForest = player.exploredForest;
 		saveFile.data.exploredDesert = player.exploredDesert;
 		saveFile.data.explored = player.explored;
-		saveFile.data.foundMountain = getGame().foundMountain;
 		saveFile.data.foundLake = getGame().foundLake;
 		saveFile.data.gameState = gameStateGet();
 		
@@ -2132,7 +2131,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		player.exploredForest = saveFile.data.exploredForest;
 		player.exploredDesert = saveFile.data.exploredDesert;
 		player.explored = saveFile.data.explored;
-		game.foundMountain = saveFile.data.foundMountain;
 		game.foundLake = saveFile.data.foundLake;
 		
 		//Days

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1034,7 +1034,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.exploredForest = player.exploredForest;
 		saveFile.data.exploredDesert = player.exploredDesert;
 		saveFile.data.explored = player.explored;
-		saveFile.data.foundDesert = getGame().foundDesert;
 		saveFile.data.foundMountain = getGame().foundMountain;
 		saveFile.data.foundLake = getGame().foundLake;
 		saveFile.data.gameState = gameStateGet();
@@ -2133,7 +2132,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		player.exploredForest = saveFile.data.exploredForest;
 		player.exploredDesert = saveFile.data.exploredDesert;
 		player.explored = saveFile.data.explored;
-		game.foundDesert = saveFile.data.foundDesert;
 		game.foundMountain = saveFile.data.foundMountain;
 		game.foundLake = saveFile.data.foundLake;
 		

--- a/classes/classes/Scenes/Areas/Desert/SandWitchScene.as
+++ b/classes/classes/Scenes/Areas/Desert/SandWitchScene.as
@@ -99,9 +99,9 @@
 					dynStats("lib", .5, "sen", 1, "lus", 10);
 				}
 				outputText("The sand-witch smiles and thanks you for your offering.  You notice her dress is damp in four spots on the front.  ", false);
-				if (getGame().sand == 0)
+				if (flags[kFLAGS.SANDWITCH_SERVICED] == 0) {
 					outputText("You wonder at what her robes conceal as she vanishes into the dunes.", false);
-				if (getGame().sand == 1) {
+				} else {
 					if (player.cor <= 33)
 						outputText("You are glad to avoid servicing her again as she vanishes into the dunes.", false);
 					else if (player.cor <= 66)
@@ -193,7 +193,8 @@ internal function sandwitchRape():void {
 		outputText("  You hear the soft impact of her robe upon the sands and cannot resist a peek at your captor.  You turn to behold a curvy, dark-skinned beauty, whose form is dominated by a quartet of lactating breasts.  Somewhere in your lust fogged mind you register the top two as something close to double-D's, and her lower pair to be about C's.  She smiles and leans over you, pushing you to the ground violently.\n\nShe turns over you and drops down, planting her slick honey-pot firmly against your mouth.  Her scent is strong, overpowering in its intensity.  Your tongue darts out for a taste and finds a treasure trove of sticky sweetness.  Instinctively you tongue-fuck her, greedily devouring her cunny-juice, shoving your tongue in as far as possible before suckling at her clit.  Dimly you feel the milk spattering over you, splashing off you and into the warm desert sands.  Everywhere the milk touches feels silky smooth and sensitive, and your hands begin stroking your body, rubbing it in as the witch sprays more and more of it.  You lose track of time, orgasming many times, slick and sticky with sexual fluids.", false);
 		player.slimeFeed();
 		dynStats("lib", 1, "sen", 5);
-		if (kGAMECLASS.sand == 0) kGAMECLASS.sand = 1;
+
+		flags[kFLAGS.SANDWITCH_SERVICED]++;
 		combat.cleanupAfterCombat();
 	}
 	//HP DEFEAT

--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -154,8 +154,10 @@ package classes.Scenes.Areas
 			
 			//Build choice list!
 			choice[choice.length] = 0; //General Goblin and Imp Encounters
-			if ((player.findStatusEffect(StatusEffects.PureCampJojo) < 0 && !camp.campCorruptJojo()) && flags[kFLAGS.JOJO_DEAD_OR_GONE] <= 0 && (kGAMECLASS.monk < 2 || rand(2) == 0)) choice[choice.length] = 1; //Jojo
-			if ((player.findStatusEffect(StatusEffects.PureCampJojo) < 0 && !camp.campCorruptJojo()) && flags[kFLAGS.JOJO_DEAD_OR_GONE] <= 0 && player.findPerk(PerkLib.PiercedFurrite) >= 0 && rand(5) == 0 && (player.cor > 25 || kGAMECLASS.monk > 0)) choice[choice.length] = 1; //Extra chance of Jojo encounter.
+			if (player.findStatusEffect(StatusEffects.PureCampJojo) < 0 && !camp.campCorruptJojo() && flags[kFLAGS.JOJO_DEAD_OR_GONE] <= 0 && (flags[kFLAGS.JOJO_STATUS] < 2 || rand(2) == 0))
+				choice[choice.length] = 1; //Jojo
+			if (player.findStatusEffect(StatusEffects.PureCampJojo) < 0 && !camp.campCorruptJojo() && flags[kFLAGS.JOJO_DEAD_OR_GONE] <= 0 && player.findPerk(PerkLib.PiercedFurrite) >= 0 && rand(5) == 0 && (player.cor > 25 || flags[kFLAGS.JOJO_STATUS] > 0))
+				choice[choice.length] = 1; //Extra chance of Jojo encounter.
 			if (player.level >= 2) choice[choice.length] = 2; //Tentacle Beast
 			if (flags[kFLAGS.CORRUPTED_GLADES_DESTROYED] < 100 && rand(100) >= Math.round(flags[kFLAGS.CORRUPTED_GLADES_DESTROYED] * 0.75)) choice[choice.length] = 3; //Corrupted Glade
 			choice[choice.length] = 4; //Trip on a root
@@ -219,13 +221,12 @@ package classes.Scenes.Areas
 					break;
 				case 1: //Jojo
 					clearOutput();
-					if (kGAMECLASS.monk == 0 && player.findStatusEffect(StatusEffects.PureCampJojo) < 0) 
-					{	
+					if (flags[kFLAGS.JOJO_STATUS] == 0 && player.findStatusEffect(StatusEffects.PureCampJojo) < 0) {
 						if (player.cor < 25)
 						{
 							if (player.level >= 4)
 							{
-								kGAMECLASS.monk = 1;
+								flags[kFLAGS.JOJO_STATUS] = 1;
 								kGAMECLASS.jojoScene.lowCorruptionJojoEncounter();
 								return;
 							}
@@ -242,12 +243,10 @@ package classes.Scenes.Areas
 							kGAMECLASS.jojoScene.highCorruptionJojoEncounter();
 						}
 						return;
-					}
-					else if (kGAMECLASS.monk == 1 || kGAMECLASS.monk < 0) { //Negative monk value indicates rape is disabled.
-						kGAMECLASS.jojoScene.repeatJojoEncounter();
-					}
-					else if (kGAMECLASS.monk >= 2) { //Angry/Horny Jojo
+					} else if (flags[kFLAGS.JOJO_STATUS] >= 2) { //Angry/Horny Jojo
 						kGAMECLASS.jojoScene.corruptJojoEncounter();
+					} else { // JOJO_STATUS is 1 or Negative (indicates rape is disabled.)
+						kGAMECLASS.jojoScene.repeatJojoEncounter();
 					}
 					break;
 				case 2: //Tentacle Beast

--- a/classes/classes/Scenes/Areas/Forest/BeeGirlScene.as
+++ b/classes/classes/Scenes/Areas/Forest/BeeGirlScene.as
@@ -758,14 +758,14 @@ package classes.Scenes.Areas.Forest
 			clearOutput();
 			spriteSelect(6);
 			//The first time you only get the option to have eggs laid in your bum ;) BEE_GIRL_TALKED
-			if (attitude < BEE_GIRL_TALKED) { //Replaced beeProgress
+			if (attitude < BEE_GIRL_TALKED) {
+				attitude = BEE_GIRL_TALKED;
 				outputText("She stops buzzing, taken aback by your resistance to her wiles.  <i>“Y-you zzzure you don't want to cuddle with me?”</i> she stammers, thrusting her exotic black and yellow breasts forwards enticingly.  With some difficulty you manage to pry your eyes back up to her face and ask her why she is trying to tempt you to embrace her.\n\n");
 				outputText("She buzzes out a giggle, <i>“Well where elzzz would I lay eggzzz?  The coloniezzz alwayzzz need more workerzzz, and as one of the Queen'zzz handmaidenzzz I get zzzooooo full of eggzzz...  I promizzze to make it feel gooood if you come to me.”</i>\n\n");
 				if (player.cor < 33) outputText("You are sure no good can come of this, but your body is ready to say yes.");
 				if (player.cor >= 33 && player.cor <= 66) outputText("Her offer intrigues you, and the arousing sweetness of her scent makes it difficult to resist.");
 				if (player.cor > 66) outputText("Looking at her through lust-tinted eyes, you're sure she can deliver on her offer.  Getting closer to her scent alone would be worth bearing a few eggs...");
 				outputText("\n\nDo you accept her offer?");
-				attitude = BEE_GIRL_TALKED; //Replaced beeProgress
 				doYesNo(beeEncounterClassic, camp.returnToCampUseOneHour);
 			}
 			else {

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2570,7 +2570,6 @@ private function promptSaveUpdate():void {
 		flags[kFLAGS.GIACOMO_NOTICES_WORMS] = 0;
 		flags[kFLAGS.PHOENIX_ENCOUNTERED] = 0;
 		flags[kFLAGS.PHOENIX_WANKED_COUNTER] = 0;
-		if (kGAMECLASS.giacomo > 0) flags[kFLAGS.GIACOMO_MET] = 1;
 		flags[kFLAGS.MOD_SAVE_VERSION] = 4;
 		doCamp();
 		return;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1205,7 +1205,7 @@ package classes.Scenes.Combat
 					flags[kFLAGS.FORCE_BEE_TO_PRODUCE_HONEY] = 0;
 				}
 			}
-			if (monster is Jojo && getGame().monk > 4) {
+			if (monster is Jojo && flags[kFLAGS.JOJO_STATUS] > 4) {
 				if (rand(2) == 0) itype = consumables.INCUBID;
 				else {
 					if (rand(2) == 0) itype = consumables.B__BOOK;

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -519,7 +519,7 @@ package classes.Scenes.Combat
 			if (monster.short == "Jojo")
 			{
 				// Not a completely corrupted monkmouse
-				if (kGAMECLASS.monk < 2)
+				if (flags[kFLAGS.JOJO_STATUS] < 2)
 				{
 					outputText("You thrust your palm forward, sending a blast of pure energy towards Jojo. At the last second he sends a blast of his own against yours canceling it out\n\n");
 					flags[kFLAGS.SPELLS_CAST]++;

--- a/classes/classes/Scenes/DebugMenu.as
+++ b/classes/classes/Scenes/DebugMenu.as
@@ -608,7 +608,7 @@ package classes.Scenes
 			outputText("Which NPC would you like to reset?");
 			menu();
 			if (flags[kFLAGS.URTA_COMFORTABLE_WITH_OWN_BODY] < 0 || flags[kFLAGS.URTA_QUEST_STATUS] == -1) addButton(0, "Urta", resetUrta);
-			if (kGAMECLASS.monk >= 5 || flags[kFLAGS.JOJO_DEAD_OR_GONE] > 0) addButton(1, "Jojo", resetJojo);
+			if (flags[kFLAGS.JOJO_STATUS] >= 5 || flags[kFLAGS.JOJO_DEAD_OR_GONE] > 0) addButton(1, "Jojo", resetJojo);
 			if (flags[kFLAGS.EGG_BROKEN] > 0) addButton(2, "Ember", resetEmber);
 			if (flags[kFLAGS.SHEILA_DISABLED] > 0 || flags[kFLAGS.SHEILA_DEMON] > 0 || flags[kFLAGS.SHEILA_CITE] < 0 || flags[kFLAGS.SHEILA_CITE] >= 6) addButton(6, "Sheila", resetSheila);
 			
@@ -659,13 +659,13 @@ package classes.Scenes
 		private function resetJojo():void {
 			clearOutput();
 			outputText("Did you do something wrong with Jojo? Corrupted him? Accidentally removed him from the game? No problem!");
-			doYesNo(reallyResetSheila, resetNPCMenu);
+			doYesNo(reallyResetJojo, resetNPCMenu);
 		}
 		private function reallyResetJojo():void {
 			clearOutput();
-			if (kGAMECLASS.monk > 1) {
+			if (flags[kFLAGS.JOJO_STATUS] > 1) {
 				outputText("Jojo is no longer corrupted!  ");
-				kGAMECLASS.monk = 0;
+				flags[kFLAGS.JOJO_STATUS] = 0;
 			}
 			if (flags[kFLAGS.JOJO_DEAD_OR_GONE] > 0) {
 				outputText("Jojo has respawned.  ");

--- a/classes/classes/Scenes/Dungeons/DesertCave.as
+++ b/classes/classes/Scenes/Dungeons/DesertCave.as
@@ -2310,7 +2310,7 @@ package classes.Scenes.Dungeons
 			
 			outputText("\n\nSuddenly, the Queen jerks up, looking you in the eye with her strange, white-irised gaze.");
 			//(No new PG.  Corrupt version)
-			if (player.cor > player.inte || kGAMECLASS.monk >= 5 || player.findStatusEffect(StatusEffects.Exgartuan) >= 0 || kGAMECLASS.amilyScene.amilyCorrupt() || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00283] > 0 || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00282] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0) {
+			if (player.cor > player.inte || flags[kFLAGS.JOJO_STATUS] >= 5 || player.findStatusEffect(StatusEffects.Exgartuan) >= 0 || kGAMECLASS.amilyScene.amilyCorrupt() || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00283] > 0 || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00282] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0) {
 				outputText("  \"<i>There is some truth to your tale, [name], but I am a Sand Mother.  We are schooled in the art of sussing out the corrupt or unclean.  If we could not detect disguised demons and demonic agents, we would not flourish as we do now, and this great desert would not be on the cusp of resurrection.</i>\"");
 				outputText("\n\nThe Sand Mother steps out of her throne, brandishing a shining scepter as she rises.  Her lips curve into a cruel smile and she challenges, \"<i>Fight me, [name], and fall like every demonic agent before you.  Do not fear, for when you lose, you shall be reborn to serve a just cause.  Your taint may yet be exorcised.</i>\"");
 				outputText("\n\nThere's no way out, it's a fight!");

--- a/classes/classes/Scenes/Explore/Giacomo.as
+++ b/classes/classes/Scenes/Explore/Giacomo.as
@@ -70,7 +70,7 @@ package classes.Scenes.Explore {
 		public function giacomoEncounter():void {
 			spriteSelect(23);
 			clearOutput();
-			if (kGAMECLASS.giacomo == 0) {
+			if (flags[kFLAGS.GIACOMO_MET] == 0) {
 				firstEncounter();
 			}
 			else if (player.findStatusEffect(StatusEffects.WormOffer) < 0 && player.findStatusEffect(StatusEffects.Infested) >= 0) { //If infested && no worm offer yet
@@ -108,7 +108,7 @@ package classes.Scenes.Explore {
 			outputText("Giacomo pauses and turns his head in both directions in a mocking gesture of paranoid observation.  His little bit of theatrics does make you wonder what he is about to offer.\n");
 			outputText("\"<i>...maybe you would be interested in some items that enhance the pleasures of the flesh?  Hmmm?</i>\"\n\n");
 			outputText("Giacomo's grin is nothing short of creepy as he offers his wares to you.  What are you interested in?");
-			kGAMECLASS.giacomo = 1;
+			flags[kFLAGS.GIACOMO_MET] = 1;
 		}
 		
 		private function potionMenu():void {

--- a/classes/classes/Scenes/Masturbation.as
+++ b/classes/classes/Scenes/Masturbation.as
@@ -1949,7 +1949,7 @@ package classes.Scenes {
 					//(+sensitivity by 3 & intellect -2 & libido +1	)
 				}
 				//Option Jojo veyeurism?
-				if (getGame().monk >= 5 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) {
+				if (flags[kFLAGS.JOJO_STATUS] >= 5 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) {
 					outputText("\n\nAs you stand and try to clean up you manage to spot Jojo off in the woods, ");
 					if (player.findStatusEffect(StatusEffects.TentacleJojo) >= 0)
 						outputText("his tentacles splattering mouse-jizz everywhere as he gets off from your show.");

--- a/classes/classes/Scenes/Monsters/GoblinAssassinScene.as
+++ b/classes/classes/Scenes/Monsters/GoblinAssassinScene.as
@@ -216,7 +216,7 @@ package classes.Scenes.Monsters
 			//Dick stuff:
 			if (player.hasCock()) {
 				//Corrupt too big scene
-				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && kGAMECLASS.monk > 2)
+				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && flags[kFLAGS.JOJO_STATUS] > 2)
 					corruptTooBig = rapeAGoblinCorruptTooBig;
 				//Regular too big scene
 				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity())

--- a/classes/classes/Scenes/Monsters/GoblinElderScene.as
+++ b/classes/classes/Scenes/Monsters/GoblinElderScene.as
@@ -231,7 +231,7 @@ package classes.Scenes.Monsters
 			//Dick stuff:
 			if (player.hasCock()) {
 				//Corrupt too big scene
-				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && kGAMECLASS.monk > 2)
+				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && flags[kFLAGS.JOJO_STATUS] > 2)
 					corruptTooBig = rapeAGoblinCorruptTooBig;
 				//Regular too big scene
 				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity())

--- a/classes/classes/Scenes/Monsters/GoblinScene.as
+++ b/classes/classes/Scenes/Monsters/GoblinScene.as
@@ -230,7 +230,7 @@ package classes.Scenes.Monsters
 			//Dick stuff:
 			if (player.hasCock()) {
 				//Corrupt too big scene
-				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && kGAMECLASS.monk > 2)
+				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && flags[kFLAGS.JOJO_STATUS] > 2)
 					corruptTooBig = rapeAGoblinCorruptTooBig;
 				//Regular too big scene
 				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity())

--- a/classes/classes/Scenes/Monsters/GoblinShamanScene.as
+++ b/classes/classes/Scenes/Monsters/GoblinShamanScene.as
@@ -205,7 +205,7 @@ package classes.Scenes.Monsters
 			//Dick stuff:
 			if (player.hasCock()) {
 				//Corrupt too big scene
-				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && kGAMECLASS.monk > 2)
+				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && flags[kFLAGS.JOJO_STATUS] > 2)
 					corruptTooBig = rapeAGoblinCorruptTooBig;
 				//Regular too big scene
 				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity())

--- a/classes/classes/Scenes/Monsters/GoblinWarriorScene.as
+++ b/classes/classes/Scenes/Monsters/GoblinWarriorScene.as
@@ -206,7 +206,7 @@ package classes.Scenes.Monsters
 			//Dick stuff:
 			if (player.hasCock()) {
 				//Corrupt too big scene
-				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && kGAMECLASS.monk > 2)
+				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity() && player.cor > 80 && flags[kFLAGS.JOJO_STATUS] > 2)
 					corruptTooBig = rapeAGoblinCorruptTooBig;
 				//Regular too big scene
 				if (player.cockArea(player.biggestCockIndex()) > monster.vaginalCapacity())

--- a/classes/classes/Scenes/NPCs/AmilyScene.as
+++ b/classes/classes/Scenes/NPCs/AmilyScene.as
@@ -377,7 +377,7 @@ package classes.Scenes.NPCs
 						outputText("\"<i>Don't make any sudden moves!</i>\" A voice calls out, high pitched and a little squeaky, but firm and commanding. You freeze to avoid giving your assailant a reason to shoot at you again. \"<i>Stand up and turn around, slowly,</i>\" it commands again. You do as you are told.\n\n", false);
 
 						//[Jojo previously encountered]
-						if (monk != 0) {
+						if (flags[kFLAGS.JOJO_STATUS] != 0) {
 							outputText("The creature that has cornered you is clearly of the same race as Jojo, though notably a female member of his species. Her fur is thick with dust, but you can still easily make out its auburn color. Her limbs and midriff are wiry, hardened as much by meals that are less than frequent as by constant exercise and physical exertion. Her buttocks are non-existent, and her breasts can't be any larger than an A-cup. She wears a tattered pair of pants and an equally ragged-looking shirt. A very large and wicked-looking dagger – more of a short sword really – is strapped to her hip, and she is menacing you with a blowpipe.\n\n", false);
 						}
 						//[Jojo not previously encountered]
@@ -439,7 +439,7 @@ package classes.Scenes.NPCs
 						outputText("\"<i>Don't make any sudden moves!</i>\" A voice calls out, high pitched and a little squeaky, but firm and commanding. You freeze to avoid giving your assailant a reason to shoot at you again. \"<i>Stand up and turn around, slowly,</i>\" it commands again. You do as you are told.\n\n", false);
 
 						//[Jojo previously encountered]
-						if (monk > 0) {
+						if (flags[kFLAGS.JOJO_STATUS] > 0) {
 							outputText("The creature that has cornered you is clearly of the same race as Jojo, though notably a female member of his species. Her fur is thick with dust, but you can still easily make out its auburn color. Her limbs and midriff are wiry, hardened as much by meals that are less than frequent as by constant exercise and physical exertion. Her buttocks are non-existent, and her breasts can't be any larger than an A-cup. She wears a tattered pair of pants and an equally ragged-looking shirt. A very large and wicked-looking dagger – more of a short sword really – is strapped to her hip, and she is menacing you with a blowpipe.\n\n", false);
 						}
 						//[Jojo not previously encountered]
@@ -495,7 +495,7 @@ package classes.Scenes.NPCs
 						outputText("\"<i>Don't make any sudden moves!</i>\" A voice calls out, high pitched and a little squeaky, but firm and commanding. You freeze to avoid giving your assailant a reason to shoot at you again. \"<i>Stand up and turn around, slowly,</i>\" it commands again. You do as you are told.\n\n", false);
 
 						//[Jojo previously encountered]
-						if (monk > 0) {
+						if (flags[kFLAGS.JOJO_STATUS] > 0) {
 							outputText("The creature that has cornered you is clearly of the same race as Jojo, though notably a female member of his species. Her fur is thick with dust, but you can still easily make out its auburn color. Her limbs and midriff are wiry, hardened as much by meals that are less than frequent as by constant exercise and physical exertion. Her buttocks are non-existent, and her breasts can't be any larger than an A-cup. She wears a tattered pair of pants and an equally ragged-looking shirt. A very large and wicked-looking dagger – more of a short sword really – is strapped to her hip, and she is menacing you with a blowpipe.\n\n", false);
 						}
 						//[Jojo not previously encountered]
@@ -547,7 +547,7 @@ package classes.Scenes.NPCs
 						outputText("\"<i>Don't make any sudden moves!</i>\" A voice calls out, high pitched and a little squeaky, but firm and commanding. You freeze to avoid giving your assailant a reason to shoot at you again. \"<i>Stand up and turn around, slowly,</i>\" it commands again. You do as you are told.\n\n", false);
 
 						//[Jojo previously encountered]
-						if (monk > 0) {
+						if (flags[kFLAGS.JOJO_STATUS] > 0) {
 							outputText("The creature that has cornered you is clearly of the same race as Jojo, though notably a female member of his species. Her fur is thick with dust, but you can still easily make out its auburn color. Her limbs and midriff are wiry, hardened as much by meals that are less than frequent as by constant exercise and physical exertion. Her buttocks are non-existent, and her breasts can't be any larger than an A-cup. She wears a tattered pair of pants and an equally ragged-looking shirt. A very large and wicked-looking dagger – more of a short sword really – is strapped to her hip, and she is menacing you with a blowpipe.\n\n", false);
 						}
 						//[Jojo not previously encountered]
@@ -4676,7 +4676,7 @@ package classes.Scenes.NPCs
 
 			outputText("\"<i>Torturing myself you say? I think you're right. Maybe I should see if ", false);
 			//[(if Jojo's corrupt)
-			if (monk >= 5 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) outputText("Jojo wants to play,", false);
+			if (flags[kFLAGS.JOJO_STATUS] >= 5 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) outputText("Jojo wants to play,", false);
 			//(else)
 			else outputText("I can't find someone else to play with,", false);
 			outputText("</i>\" you say, nonchalantly attempting to pull away from her. \"<i>No!</i>\" Amily screams; her legs tighten about your waist with such force that she actually lifts herself off of the ground in her eagerness to plant herself firmly against your crotch, rubbing her slavering pussy against you. \"<i>Mine! My fuck! Mine!</i>\" she squeaks indignantly. You laugh at how far you've pushed your little mouse slave.  Sliding your " + player.cockDescript(0) + " against her pussy, you bend down and grope her breasts roughly, drawing a desperate moan from her; slowly you get closer to her ears, then whisper, \"<i>Go ahead,</i>\" while humping against her to further excite her.\n\n", false);

--- a/classes/classes/Scenes/NPCs/CeraphScene.as
+++ b/classes/classes/Scenes/NPCs/CeraphScene.as
@@ -90,7 +90,7 @@ package classes.Scenes.NPCs
 			spriteSelect(7);
 			clearOutput();
 			//UBER-Fullbodypenetration
-			if (!player.isTaur() && player.biggestCockArea() > 500 && (player.statusEffectv1(StatusEffects.Exgartuan) == 1 || monk >= 5)) {
+			if (!player.isTaur() && player.biggestCockArea() > 500 && (player.statusEffectv1(StatusEffects.Exgartuan) == 1 || flags[kFLAGS.JOJO_STATUS] >= 5)) {
 				hugeCorruptionForceFuckCeraph();
 				return;
 			}

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -1170,7 +1170,7 @@ package classes.Scenes.NPCs
 				//(If player has not yet impregnated Tamani)
 				else if (subChoice == 3 && !kGAMECLASS.forest.tamaniScene.pregnancy.isPregnant) outputText("one goblin being teased by a bunch of pregnant goblins for not being pregnant yet.  She just spat back that she wanted a 'better catch' to be her baby-maker than a mere imp and wandered off.");
 				//(If Jojo isn't in the camp & not corrupt)
-				else if (rand(2) == 0 && monk <= 1 && player.findStatusEffect(StatusEffects.PureCampJojo) < 0) outputText("this mouse-morph monk, sitting in a glade and meditating. A goblin tried to proposition him; he just gave her a lecture and sent her running away in tears.  When an imp tried to attack him, he crushed its skull with a staff he had.  Not bad moves for such a weedy little thing...");
+				else if (rand(2) == 0 && flags[kFLAGS.JOJO_STATUS] <= 1 && player.findStatusEffect(StatusEffects.PureCampJojo) < 0) outputText("this mouse-morph monk, sitting in a glade and meditating. A goblin tried to proposition him; he just gave her a lecture and sent her running away in tears.  When an imp tried to attack him, he crushed its skull with a staff he had.  Not bad moves for such a weedy little thing...");
 				else outputText("one glade I touched down in to catch myself a nice brace of plump coneys, when all of a sudden this... this thing made out of flailing vines and fruit attacks me.  It went up in a puff of smoke once I torched it, of course.");
 			}
 			else if (choice == 2) { //Lake

--- a/classes/classes/Scenes/NPCs/Exgartuan.as
+++ b/classes/classes/Scenes/NPCs/Exgartuan.as
@@ -924,7 +924,7 @@ private function exgartuanSleepSurprise():void {
 		outputText("  Liquid-hot pressure slides over the underside of your " + player.cockDescript(0) + ", licking wetly at the pulsating, need-filled demon-prick.  Your rogue tongue's attentions have the desired effect, and the cries of your pleasure are muffled by your own thick flesh and its rapidly distending urethra.\n\n", false);
 		
 		outputText("If someone were watching", false);
-		if (monk >= 5 && player.findStatusEffect(StatusEffects.NoJojo) < 0 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) outputText(", and judging by Jojo's high pitched whines, he certainly is,", false);
+		if (flags[kFLAGS.JOJO_STATUS] >= 5 && player.findStatusEffect(StatusEffects.NoJojo) < 0 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) outputText(", and judging by Jojo's high pitched whines, he certainly is,", false);
 		outputText(" they'd see dick-flesh bulging with a heavy load as it's pumped into your lips.  The fully-inflated cum-tube distends your mouth, stretching your jaw painfully, and dumps its creamy cargo into its willing receptacle.  Your belly burbles as it adjusts to the ", false);
 		temp = player.cumQ();
 		if (temp < 50) outputText("surprisingly light", false);
@@ -947,7 +947,7 @@ private function exgartuanSleepSurprise():void {
 		}
 		outputText("\n\n", false);
 		
-		if (monk >= 5 && player.findStatusEffect(StatusEffects.NoJojo) < 0 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) {
+		if (flags[kFLAGS.JOJO_STATUS] >= 5 && player.findStatusEffect(StatusEffects.NoJojo) < 0 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) {
 			outputText("The splatter of mouse-cum erupting in the wood reaches your ears, bringing a wistful smile to your face.  That slutty mouse is such a peeping tom!  ", false);
 		}
 		outputText("Your eyes slowly roll back down while Exgartuan deflates, leaving a trail of pleased, white submission ", false);

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -1,6 +1,7 @@
 ﻿package classes.Scenes.NPCs
 {
 	import classes.*;
+	import classes.GlobalFlags.*;
 
 	public class Jojo extends Monster
 	{
@@ -16,13 +17,13 @@
 		}
 		
 		override protected function performCombatAction():void {
-			if (game.monk > 1 && rand(2) == 0)
-				selfCorruption(); //Shouldn't do any self corruption at monk one. Otherwise a 50/50 chance
+			if (flags[kFLAGS.JOJO_STATUS] > 1 && rand(2) == 0)
+				selfCorruption(); // 50/50 chance of "selfCorruption", if already started at corruption path.
 			else eAttack();
 		}
 		
 		private function selfCorruption():void {
-			switch (game.monk) {
+			switch (flags[kFLAGS.JOJO_STATUS]) {
 				case 2:
 					outputText("Jojo looks lost in thought for a moment, and fails to attack.  ");
 					lust += 4;
@@ -80,7 +81,7 @@
 			this.hairColor = "white";
 			this.hairLength = 2;
 			initStrTouSpeInte(35, 40, 65, 55);
-			initLibSensCor(15, 40, game.monk * 15);
+			initLibSensCor(15, 40, flags[kFLAGS.JOJO_STATUS] * 15);
 			this.weaponName = "paw";
 			this.weaponVerb="punch";
 			this.armorName = "robes";
@@ -92,19 +93,19 @@
 			this.special1 = selfCorruption;
 			//Create jojo sex attributes
 			//Variations based on jojo's corruption.
-			if (game.monk == 3) {
+			if (flags[kFLAGS.JOJO_STATUS] == 3) {
 				this.lust += 30;
 				this.cocks[0].cockThickness += .2;
 				this.cocks[0].cockLength += 1.5;
 				if (player.gender == 1 || player.gender == 3) this.ass.analLooseness = 2;
 			}
-			if (game.monk == 4) {
+			if (flags[kFLAGS.JOJO_STATUS] == 4) {
 				this.lust += 40;
 				this.cocks[0].cockThickness += .5;
 				this.cocks[0].cockLength += 3.5;
 				if (player.gender == 1 || player.gender == 3) this.ass.analLooseness = 3;
 			}
-			if (game.monk == 5) {
+			if (flags[kFLAGS.JOJO_STATUS] == 5) {
 				this.lust += 50;
 				this.cocks[0].cockThickness += 1;
 				this.cocks[0].cockLength += 5.5;

--- a/classes/classes/Scenes/NPCs/JojoScene.as
+++ b/classes/classes/Scenes/NPCs/JojoScene.as
@@ -45,10 +45,6 @@
 		}
 		//End of Interface Implementation
 
-	protected function set monk(value:Number):void{
-		kGAMECLASS.monk = value;
-	}
-
 //const TIMES_AMILY_AND_JOJO_PLAYED_TIMES:int = 434;
 //const AMILY_X_JOJO_COOLDOWN:int = 435;
 //const JOJO_MOVE_IN_DISABLED:int = 550;
@@ -87,7 +83,7 @@ public function tentacleJojo():Boolean {
 
 }
 override public function campCorruptJojo():Boolean {
-	return monk >= 5 && player.findStatusEffect(StatusEffects.NoJojo) < 0 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0;
+	return flags[kFLAGS.JOJO_STATUS] >= 5 && player.findStatusEffect(StatusEffects.NoJojo) < 0 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0;
 }
 
 private function jojoMutationOffer():void {
@@ -1094,7 +1090,7 @@ public function jojoFollowerMeditate():void {
 		private function postCombatRape():void {
 			jojoSprite();
 			outputText("  You disrobe and prepare to ");
-			if (monk == 5)
+			if (flags[kFLAGS.JOJO_STATUS] == 5)
 				outputText("fuck your violent little slut senseless.  ");
 			else outputText("teach the uppity monk a lesson...\n\n");
 			menu();
@@ -1110,7 +1106,7 @@ public function jojoFollowerMeditate():void {
 			if (player.findStatusEffect(StatusEffects.EverRapedJojo) < 0)
 				player.createStatusEffect(StatusEffects.EverRapedJojo, 1, 0, 0, 0);
 			else player.addStatusValue(StatusEffects.EverRapedJojo, 1, 1);
-			switch (monk) {
+			switch (flags[kFLAGS.JOJO_STATUS]) {
 				case 1:
 					jojosFirstRape();
 					break;
@@ -1143,7 +1139,7 @@ public function jojoFollowerMeditate():void {
 					outputText("With a satisfied sigh, you pull your " + player.cockDescript(0) + " out with an audible 'pop'.  Your cum begins leaking out, pooling under him and mixing with his own.  The little guy must have cum hard; he seems fairly comatose.  As you leave your senseless victim, you realize  you feel more satisfied than you have in a while, almost like you've cum so hard it took some of your libido with it.");
 					player.orgasm();
 					dynStats("lib", -10, "cor", 4);
-					monk+=1;
+					flags[kFLAGS.JOJO_STATUS] += 1;
 				}
 				else 
 				{
@@ -1151,7 +1147,7 @@ public function jojoFollowerMeditate():void {
 					outputText("With a satisfied sigh, you pull your " + player.cockDescript(0) + " out with an audible 'pop'.  Your cum begins leaking out, pooling under him and mixing with his own.  The little guy must have cum hard, he seems fairly comatose.  As you leave your senseless victim, you realize  you feel more satisfied than you have in a while, almost like you've cum so hard it took some of your libido with it.");
 					player.orgasm();
 					dynStats("lib", -10, "cor", 4);
-					monk+=1;
+					flags[kFLAGS.JOJO_STATUS] += 1;
 				}
 			}
 			else if (player.gender == 2) 
@@ -1194,7 +1190,7 @@ public function jojoFollowerMeditate():void {
 				
 				player.orgasm();
 				dynStats("lib", -10, "cor", 4);
-				monk+=1;
+				flags[kFLAGS.JOJO_STATUS] += 1;
 				
 				//Preggers chance!
 				player.knockUp(PregnancyStore.PREGNANCY_JOJO, PregnancyStore.INCUBATION_MOUSE + 82); //Jojo's kids take longer for some reason
@@ -1225,7 +1221,7 @@ public function jojoFollowerMeditate():void {
 					outputText("\n\nWith a satisfied sigh, you pull your " + player.cockDescript(0) + " out with an audible 'pop'.  Your cum begins leaking out, pooling under him and mixing with his own.  The little guy must have cum hard, he seems fairly comatose.  As you leave your senseless victim, you realize  you feel more satisfied than you have in a while, almost like you've cum so hard it took some of your libido with it.");
 					player.orgasm();
 					dynStats("lib", -10, "cor", 4);
-					monk+=1;
+					flags[kFLAGS.JOJO_STATUS] += 1;
 				}
 				else 
 				{
@@ -1248,7 +1244,7 @@ public function jojoFollowerMeditate():void {
 					outputText("\n\nWith a satisfied sigh, you pull your " + player.cockDescript(0) + " out with an audible 'pop'.  Your cum begins leaking out, pooling under him and mixing with his own.  The little guy must have cum hard, he seems fairly comatose.  As you leave your senseless victim, you realize  you feel more satisfied than you have in a while, almost like you've cum so hard it took some of your libido with it.");
 					player.orgasm();
 					dynStats("lib", -10, "cor", 4);
-					monk+=1;
+					flags[kFLAGS.JOJO_STATUS] += 1;
 				}
 			}
 		}
@@ -1256,7 +1252,7 @@ public function jojoFollowerMeditate():void {
 		private function jojosSecondRape():void {
 			clearOutput();
 			outputText("The poor mouse is already hard... his cock is throbbing eagerly as it protrudes through the opening in his robe, looking nearly eight inches long.  You're pretty sure it wasn't that big last time.\n\n");
-			monk+=1;
+			flags[kFLAGS.JOJO_STATUS] += 1;
 			player.orgasm();
 			dynStats("lib", -10, "cor", 4);
 			if (player.gender == 1) {
@@ -1309,7 +1305,7 @@ public function jojoFollowerMeditate():void {
 				player.orgasm();
 				if (player.lib > 60 && player.cor > 40) {
 					outputText("You smile as you hear him begin masturbating in the background.  There can be no doubt, you are tainting him more and more...");
-					monk+=1;
+					flags[kFLAGS.JOJO_STATUS] += 1;
 					dynStats("lib", -10, "cor", 4);
 				}
 				else
@@ -1348,7 +1344,7 @@ public function jojoFollowerMeditate():void {
 				player.orgasm();
 				if (player.lib > 60 && player.cor > 50) {
 					outputText("You lean down and whisper strange un-words as you stroke his cock.  It spasms and grows, cum pumping from it slowly but constantly.  You walk away, leaving him in a growing puddle of what was once his morals.  You don't know where the words came from, but you do know you're getting better at tempting and corrupting.");
-					monk+=1;
+					flags[kFLAGS.JOJO_STATUS] += 1;
 					dynStats("lib", -10, "cor", 4);
 				}
 				else
@@ -1390,7 +1386,7 @@ public function jojoFollowerMeditate():void {
 				player.orgasm();
 				if (player.lib > 60 && player.cor > 50) {
 					outputText("You lean down and whisper strange un-words as you stroke his cock.  It spasms and grows, cum pumping from it slowly but constantly.  You walk away, leaving him in a growing puddle of what was once his morals.  You don't know where the words came from, but you do know you're getting better at tempting and corrupting.");
-					monk+=1;
+					flags[kFLAGS.JOJO_STATUS] += 1;
 					dynStats("lib", -10, "cor", 4);
 				}
 				else {
@@ -1425,7 +1421,7 @@ public function jojoFollowerMeditate():void {
 					outputText("<b>You feel a familiar power growing within you and decide to unleash it.</b>  You grab the prayer beads from his outfit and spit on them, making them slick and wet.  Holding them below your flagging cock, you focus on the demonic visions in your mind, slowly but constantly milking larger and larger dollops of cum onto the once holy beads.  Jojo moans as he comes to understand your intent, and turns around, shaking his lithe mouse-bum at you.  You lean over him, whispering into his ear, \"<i>Each defiled bead I push into you is going to make you more of a willing slut.  More of a willing receptacle for demon cum.  More of a fountain of desire waiting to be tapped by Succubi.  More my toy.</i>\"\n\n");
 					outputText("He whimpers as you slide the first bead in, his eyes growing foggy and his bum wiggling more eagerly.  You push the second bead inside him, and feel his asshole stretch and loosen, welcoming the corruption.  The third bead slips right in, and he moans, \"<i>sluuuut</i>,\" His cock grows longer and thicker throughout the moan, stopping at over a foot long and 3 inches thick, dribbling cum.  You whisper, \"<i>Cum, my Toy,</i>\" and push the remaining beads inside him.  His eyes roll back as his paws frantically milk his " + monster.cockDescriptShort(0) + ", cum spraying from him like a fountain.  Jojo trembles, losing complete control and falling away from you.  You still hold the end of his beads, and smile as they pop out, stained almost as dark as the poor mouse's soul.\n\n");
 					outputText("You walk away, leaving your new pet to explore his outlook on life, and to test your awakened powers.  ");
-					monk+=1;
+					flags[kFLAGS.JOJO_STATUS] += 1;
 					player.orgasm();
 					dynStats("lib", -10, "cor", 10);
 				}
@@ -1509,7 +1505,7 @@ public function jojoFollowerMeditate():void {
 					outputText("\n\n<b>You feel a familiar power growing within you and decide to unleash it.</b>  You grab the prayer beads from his outfit and spit on them, making them slick and wet.  Holding them below his flagging cock, you focus on the demonic visions in your mind, slowly but constantly milking larger and larger dollops of cum onto the once holy beads.  Jojo moans as he comes to understand your intent, and turns around, shaking his lithe mouse-bum at you.  You lean over him, whispering into his ear, \"<i>Each defiled bead I push into you is going to make you more of a willing slut.  More of a willing receptacle for demon cum.  More of a fountain of desire waiting to be tapped by Succubi.  More my toy.</i>\"\n\n");
 					outputText("He whimpers as you slide the first bead in, his eyes growing foggy and his bum wiggling more eagerly.  You push the second bead inside him, and feel his asshole stretch and loosen, welcoming the corruption.  The third bead slips right in, and he moans, \"<i>sluuuut</i>,\" His cock grows longer and thicker throughout the moan, stopping at over a foot long and 3 inches thick, dribbling cum.  You whisper, \"<i>Cum, my Toy,</i>\" and push the remaining beads inside him.  His eyes roll back as his paws frantically milk his " + monster.cockDescriptShort(0) + ", cum spraying from him like a fountain.  Jojo trembles, losing complete control and falling away from you.  You still hold the end of his beads, and smile as they pop out, stained almost as dark as the poor mouse's soul.\n\n");
 					outputText("You walk away, leaving your new pet to explore his outlook on life, and to test your awakened powers.  ");
-					monk+=1;
+					flags[kFLAGS.JOJO_STATUS] += 1;
 					player.orgasm();
 					dynStats("lib", -10, "cor", 10);
 				}
@@ -1536,7 +1532,7 @@ public function jojoFollowerMeditate():void {
 		
 		public function loseToJojo():void {
 			clearOutput();
-			if (monk == 2 || monk == 3) {
+			if (flags[kFLAGS.JOJO_STATUS] == 2 || flags[kFLAGS.JOJO_STATUS] == 3) {
 				outputText("Jojo glares down at you, and begins praying, slowly laying prayer papers all over your battered form.  You feel rage that quickly dissipates, replaced with a calm sense of peace.  You quickly lose consciousness, but are happy he defeated you.\n\nWhen you wake, you discover a note:\n\"<i>The fighting allowed me to exorcise most of your inner demons.  A part of me wanted to seek revenge for what you had done to me, but I know it was the taint on your soul that was responsible.  If we meet again I would be happy to meditate with you.\n\n          -Jojo.</i>\"");
 				player.orgasm();
 				dynStats("lib", -10., "cor", -15);
@@ -1550,7 +1546,7 @@ public function jojoFollowerMeditate():void {
 				if (player.countCocksOfType(CockTypesEnum.HORSE) > 0) player.lib += 3;
 				if (player.dogCocks() > 0) player.lib += 2;
 				if (player.biggestLactation() >= 1) player.lib += 2;
-				monk = 0;
+				flags[kFLAGS.JOJO_STATUS] = 0;
 			}
 			else {
 				outputText("Jojo grins wickedly as he senses your defeat, " + monster.cockDescriptShort(0) + " throbbing hard.  ");
@@ -2302,11 +2298,11 @@ public function lowCorruptionIntro():void
 	menu();
 	addButton(0, "Meditate", meditateInForest); // OH GOD NO SEND HELP
 	addButton(1, "Leave", camp.returnToCampUseOneHour);
-	if (player.cor > 10 && player.lust >= 33 && player.gender > 0 && flags[kFLAGS.DISABLED_JOJO_RAPE] <= 0 && monk >= 0) addButton(4, "Rape", jojoRape, null, null, null, "Rape the poor monk mouse-morph." + (player.cor < 50 ? "  Why would you do that?": ""));
+	if (player.cor > 10 && player.lust >= 33 && player.gender > 0 && flags[kFLAGS.DISABLED_JOJO_RAPE] <= 0 && flags[kFLAGS.JOJO_STATUS] >= 0) addButton(4, "Rape", jojoRape, null, null, null, "Rape the poor monk mouse-morph." + (player.cor < 50 ? "  Why would you do that?": ""));
 }
 
 public function highCorruptionJojoEncounter():void {
-	kGAMECLASS.monk = 1;
+	flags[kFLAGS.JOJO_STATUS] = 1;
 	kGAMECLASS.jojoScene.jojoSprite();
 	outputText("While marvelling at the strange trees and vegetation of the forest, the bushes ruffle ominously.  A bush seems to explode into a flurry of swirling leaves and movement.  Before you can react you feel your " + player.feet() + " being swept out from under you, and land hard on your back.\n\n", false);
 	outputText("The angry visage of a lithe white mouse gazes down on your prone form with a look of confusion.", false);
@@ -2316,7 +2312,7 @@ public function highCorruptionJojoEncounter():void {
 	menu();
 	addButton(0, "Accept", getGame().jojoScene.meditateInForest);
 	addButton(1, "Decline", camp.returnToCampUseOneHour);
-	if (player.cor > 10 && player.lust >= 33 && player.gender > 0 && flags[kFLAGS.DISABLED_JOJO_RAPE] <= 0 && monk >= 0) addButton(2, "Rape", getGame().jojoScene.jojoRape, null, null, null, "Rape the poor monk mouse-morph." + (player.cor < 50 ? "  Why would you do that?": ""));
+	if (player.cor > 10 && player.lust >= 33 && player.gender > 0 && flags[kFLAGS.DISABLED_JOJO_RAPE] <= 0 && flags[kFLAGS.JOJO_STATUS] >= 0) addButton(2, "Rape", getGame().jojoScene.jojoRape, null, null, null, "Rape the poor monk mouse-morph." + (player.cor < 50 ? "  Why would you do that?": ""));
 }
 
 //Repeat encounter
@@ -2344,10 +2340,10 @@ public function repeatJojoEncounter():void {
 public function corruptJojoEncounter():void {
 	kGAMECLASS.jojoScene.jojoSprite();
 	outputText("You are enjoying a peaceful walk through the woods when Jojo drops out of the trees ahead, ", true);
-	if (kGAMECLASS.monk == 2) outputText("his mousey visage twisted into a ferocious snarl.  \"YOU!\" he screams, launching himself towards you, claws extended.", false);
-	if (kGAMECLASS.monk == 3) outputText("unsteady on his feet, but looking for a fight!", false);
-	if (kGAMECLASS.monk == 4) outputText("visibly tenting his robes, but intent on fighting you.", false);
-	if (kGAMECLASS.monk == 5) outputText("panting and nude, his fur rustling in the breeze, a twitching behemoth of a cock pulsing between his legs.", false);
+	if (flags[kFLAGS.JOJO_STATUS] == 2) outputText("his mousey visage twisted into a ferocious snarl.  \"YOU!\" he screams, launching himself towards you, claws extended.", false);
+	if (flags[kFLAGS.JOJO_STATUS] == 3) outputText("unsteady on his feet, but looking for a fight!", false);
+	if (flags[kFLAGS.JOJO_STATUS] == 4) outputText("visibly tenting his robes, but intent on fighting you.", false);
+	if (flags[kFLAGS.JOJO_STATUS] == 5) outputText("panting and nude, his fur rustling in the breeze, a twitching behemoth of a cock pulsing between his legs.", false);
 	startCombat(new Jojo());
 }
 
@@ -2461,7 +2457,7 @@ public function jojoCamp():void {
 			outputText("You walk up to the boulder where Jojo usually sits, and see him sitting cross legged with his eyes closed.  He seems to be deep in meditation, but when you approach his eyes open suddenly and he gets up appearing slightly distressed, “<i>Uh... [name], I can feel a bit of corruption within you.  It is not much, but I think you should be concerned about it before it gets out of hand and you do something you might regret.  If you want to I'd be happy to meditate with you as you rid yourself of it.</i>” he offers with a concerned look on his face.\n\n");
 		}
 		outputText("Do you accept Jojo's help?\n\n");
-		simpleChoices("Yes", acceptOfferOfHelp, "No", refuseOfferOfHelp, "", null, "", null, "Rape", (player.lust >= 33 && player.gender > 0 && monk >= 0 ? jojoAtCampRape : null));
+		simpleChoices("Yes", acceptOfferOfHelp, "No", refuseOfferOfHelp, "", null, "", null, "Rape", (player.lust >= 33 && player.gender > 0 && flags[kFLAGS.JOJO_STATUS] >= 0 ? jojoAtCampRape : null));
 	}
 	else { //Normal shit
 		if (player.cor > 10)
@@ -2496,7 +2492,7 @@ private function jojoCampMenu():void {
 	addButton(4, jojoDefense, jojoDefenseToggle, null, null, null, (player.findStatusEffect(StatusEffects.JojoNightWatch) >= 0 ? "Request him to stop guarding the camp.": "Request him to guard the camp at night."));
 	if (player.findStatusEffect(StatusEffects.Infested) >= 0) addButton(5, "Purge", wormRemoval, null, null, null, "Request him to purge the worms from your body.");
 	if (player.cor > 10 && player.lust >= 33 && player.gender > 0 && flags[kFLAGS.DISABLED_JOJO_RAPE] <= 0) addButton(8, "Rape", jojoAtCampRape, null, null, null, "Rape the poor monk mouse-morph." + (player.cor < 25 ? "  Why would you do that?": ""));
-	if (player.lust >= 33 && monk <= -3) addButton(8, "Sex", pureJojoSexMenu, null, null, null, "Initiate sexy time with the mouse-morph.");
+	if (player.lust >= 33 && flags[kFLAGS.JOJO_STATUS] <= -3) addButton(8, "Sex", pureJojoSexMenu, null, null, null, "Initiate sexy time with the mouse-morph.");
 	addButton(14, "Leave", camp.campFollowers);
 }
 
@@ -2537,9 +2533,9 @@ public function talkMenu():void
 		if (flags[kFLAGS.TIMES_TALKED_WITH_JOJO] < 4) addButtonDisabled(9, "Sex?", "You should socialize with Jojo a bit more.");
 		//if (player.findStatusEffect(StatusEffects.EverRapedJojo) >= 0) addButtonDisabled(9, "Sex?". "You've raped Jojo in the past, now you can't ask him out.");
 	}
-	if (player.cor <= 10 && player.lust >= 33 && monk == -1) addButtonDisabled(9, "Sex?", "You need to spend more time with Jojo. \n\nTalk sessions: " + flags[kFLAGS.TIMES_TALKED_WITH_JOJO] + "/6 \nTraining sessions: " + flags[kFLAGS.TIMES_TRAINED_WITH_JOJO] + "/10 \nMeditation sessions: " + player.statusEffectv1(StatusEffects.JojoMeditationCount) + "/10 \nYou must be pure enough and have sufficient lust as well.");
-	if (player.cor <= 10 && player.lust >= 33 && flags[kFLAGS.TIMES_TALKED_WITH_JOJO] >= 6 && flags[kFLAGS.TIMES_TRAINED_WITH_JOJO] >= 10 && player.statusEffectv1(StatusEffects.JojoMeditationCount) >= 10 && monk > -3) addButton(9, "Sex?", offerSexFirstTimeHighAffection, null, null, null, "You've spent quite the time with Jojo, maybe you can offer him if he's willing to have sex with you?"); //Will unlock consensual sex scenes.
-	if (monk <= -3) removeButton(9);
+	if (player.cor <= 10 && player.lust >= 33 && flags[kFLAGS.JOJO_STATUS] == -1) addButtonDisabled(9, "Sex?", "You need to spend more time with Jojo. \n\nTalk sessions: " + flags[kFLAGS.TIMES_TALKED_WITH_JOJO] + "/6 \nTraining sessions: " + flags[kFLAGS.TIMES_TRAINED_WITH_JOJO] + "/10 \nMeditation sessions: " + player.statusEffectv1(StatusEffects.JojoMeditationCount) + "/10 \nYou must be pure enough and have sufficient lust as well.");
+	if (player.cor <= 10 && player.lust >= 33 && flags[kFLAGS.TIMES_TALKED_WITH_JOJO] >= 6 && flags[kFLAGS.TIMES_TRAINED_WITH_JOJO] >= 10 && player.statusEffectv1(StatusEffects.JojoMeditationCount) >= 10 && flags[kFLAGS.JOJO_STATUS] > -3) addButton(9, "Sex?", offerSexFirstTimeHighAffection, null, null, null, "You've spent quite the time with Jojo, maybe you can offer him if he's willing to have sex with you?"); //Will unlock consensual sex scenes.
+	if (flags[kFLAGS.JOJO_STATUS] <= -3) removeButton(9);
 	addButton(14, "Back", jojoCamp);
 }
 
@@ -3048,7 +3044,7 @@ public function offerSexFirstTime():void {
 	outputText("\n\nBut...? You press. After all, isn't it better for the both of you to turn to each other to slake your lusts then to bottle things up or go to the monsters who roam this land?");
 	outputText("\n\n\"<i>I-I can't... I made a vow of chastity... I can't simply break my vows... please understand, [name]...</i>\" he says gazing at you apologetically, though you detect just the slightest hint of desire in his eyes before he averts his gaze and shakes his head of whatever thoughts could be plaguing it.");
 	outputText("\n\nYou acknowledge his position and excuse yourself, but before you can leave he calls out to you. \"<i>Wait, [name]!</i>\" he says getting up and moving towards you. \"<i>While I can't really have sex with you, that doesn't mean I can't help you. If you want we could meditate to help you... umm... restrain your needs?</i>\" he suggests.");
-	monk = -1;
+	flags[kFLAGS.JOJO_STATUS] = -1;
 	doYesNo(agreeToMeditate, noThanksToMeditate);
 }
 private function agreeToMeditate():void {
@@ -3071,7 +3067,7 @@ public function offerSexFirstTimeHighAffection():void {
 	outputText("You've been spending great time with Jojo. You've meditated with him, you've discussed with him and you've even trained with him! Now's the time to ask him out.");
 	outputText("\n\nYou approach Jojo. \"Yes, [name]? What is it you need?\" Jojo asks. You ask him if he would like to have sex.");
 	outputText("\n\n\"<i>I'm sorry. I still can't break my vows of chastity,</i>\" he says apologetically.");
-	monk = -2;
+	flags[kFLAGS.JOJO_STATUS] = -2;
 	menu();
 	addButton(0, "Meditate", jojoFollowerMeditate);
 	addButton(1, "Drop It", noThanksToMeditate);
@@ -3088,7 +3084,7 @@ public function confrontChastity():void {
 	outputText("\n\n<b>You have unlocked Jojo sex menu!</b>");
 	if (silly()) outputText("<b> Jojo can only learn four moves. Delete a move to learn a new one? Yes. 1... 2... 3... Poof! Jojo has forgot Chastity and learned Sex!</b>");
 	flags[kFLAGS.DISABLED_JOJO_RAPE] = 1;
-	monk = -3;
+	flags[kFLAGS.JOJO_STATUS] = -3;
 	doNext(pureJojoSexMenu);
 }
 

--- a/classes/classes/Scenes/NPCs/NPCAwareContent.as
+++ b/classes/classes/Scenes/NPCs/NPCAwareContent.as
@@ -163,9 +163,6 @@ package classes.Scenes.NPCs
 		{
 			return kGAMECLASS.joyScene;
 		}
-		protected function get monk():Number {
-			return kGAMECLASS.monk;
-		}
 		public function campCorruptJojo():Boolean
 		{
 			return kGAMECLASS.jojoScene.campCorruptJojo();

--- a/classes/classes/Scenes/NPCs/SophieBimbo.as
+++ b/classes/classes/Scenes/NPCs/SophieBimbo.as
@@ -161,7 +161,7 @@ private function acceptBimboSophie():void {
 		if (flags[kFLAGS.AMILY_FOLLOWER] == 1) outputText("flushes hotly and denies the bimbo's request with a terse 'no'.", false);
 		else outputText("flushes hotly and wiggles her hips Sophie's way.  The slutty, corrupted mouse and Sophie will clearly be helping to sate each other's needs in your absence.", false);
 	}
-	else if (monk >= 5 && player.findStatusEffect(StatusEffects.NoJojo) < 0 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0)
+	else if (flags[kFLAGS.JOJO_STATUS] >= 5 && player.findStatusEffect(StatusEffects.NoJojo) < 0 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0)
 	{
 		outputText("  Afterwards, she offers to suck Jojo's cock.  The corrupted slut-mouse nods and stiffens in delight, though he keeps glancing back your way.  Those two will probably spend a lot of time together...", false);
 	}

--- a/classes/classes/Scenes/Places/TelAdre.as
+++ b/classes/classes/Scenes/Places/TelAdre.as
@@ -126,7 +126,7 @@ private function telAdreCrystal():void {
 		return;
 	}
 	//-50+ corruption or corrupted Jojo
-	else if (player.cor >= 50 || kGAMECLASS.monk >= 5) {
+	else if (player.cor >= 50 || flags[kFLAGS.JOJO_STATUS] >= 5) {
 		outputText("The crystal pendant shimmers, vibrating in place and glowing a purple hue.  Edryn steps back, watching you warily, \"<i>You've been deeply touched by corruption.  You balance on a razor's edge between falling completely and returning to sanity.  You may enter, but we will watch you closely.</i>\"\n\n", false);
 	}
 	//-25+ corruption or corrupted Marae

--- a/classes/classes/Scenes/Places/TelAdre/Cotton.as
+++ b/classes/classes/Scenes/Places/TelAdre/Cotton.as
@@ -354,7 +354,7 @@ private function cottonChat():void {
 	if (flags[kFLAGS.FREED_VALA] != 0)
 		chats[chats.length] = 3;
 	//(Jojo chat)
-	if (kGAMECLASS.monk > 0)
+	if (flags[kFLAGS.JOJO_STATUS] > 0)
 		chats[chats.length] = 4;
 	var choice:Number = chats[rand(chats.length)];
 
@@ -391,12 +391,12 @@ private function cottonChat():void {
 	//(Jojo chat)
 	else if (choice == 5) {
 		//(If Jojo hasn't been corrupted)
-		if (kGAMECLASS.monk == 1) {
+		if (flags[kFLAGS.JOJO_STATUS] == 1) {
 			outputText("While you're doing your stretches, you find yourself chatting about the folks of Tel'Adre and beyond. \"<i>Jojo?</i>\" Cotton says, \"<i>You know Jojo too? I met him a while back. He taught me the finer points of meditation, which I incorporate into my yoga. Here, let's try.</i>\" You spend the rest of the workout in meditative poses, and by the time you're done, you feel... lighter somehow.\n\n", false);
 			dynStats("cor", -1);
 		}
 		//(If Jojo has been corrupted)
-		else if (kGAMECLASS.monk > 1) outputText("While you're doing your stretches, you find yourself chatting about the folks of Tel'Adre. \"<i>Jojo?</i>\" Cotton says, \"<i>You know Jojo too? I met him a while back. He taught me the finer points of meditation. I haven't seen him much lately, though. I wonder where he's gone to.</i>\" You smile inwardly, knowing exactly where he's gone to.\n\n", false);
+		else if (flags[kFLAGS.JOJO_STATUS] > 1) outputText("While you're doing your stretches, you find yourself chatting about the folks of Tel'Adre. \"<i>Jojo?</i>\" Cotton says, \"<i>You know Jojo too? I met him a while back. He taught me the finer points of meditation. I haven't seen him much lately, though. I wonder where he's gone to.</i>\" You smile inwardly, knowing exactly where he's gone to.\n\n", false);
 	}
 }
 //(If Leave)

--- a/classes/classes/Scenes/Places/TelAdre/Rubi.as
+++ b/classes/classes/Scenes/Places/TelAdre/Rubi.as
@@ -3629,7 +3629,7 @@ public function hypnoBimboficationForRubiSloots():void
 	outputText("\n\nRubi is watching you in open mouthed fascination. His lips move, stammering, trying to talk, but he just can't get the words out. It's no wonder, really - you've got your big, hard tool");
 	if (player.cockTotal() > 1) outputText("s");
 	outputText(" whipped out and swaying with your sinuous movements, and all he has is his comparatively undersized little pecker. You rock your whole body with the snake-like grace given to you by your naga body, swaying rhythmically as you meet his eyes. Knowing full well just what kinds of depravity you'd like to force him into, you feel a ");
-	if (kGAMECLASS.monk >= 5) outputText("familiar ");
+	if (flags[kFLAGS.JOJO_STATUS] >= 5) outputText("familiar ");
 	else outputText("strange ");
 	outputText("dark power welling up within you.");
 	outputText("\n\nRubi is powerless to resist your hypnotic gaze. Your very eyes seem alight with wisps of dark, almost-demonic power, beginning to entrance the vulnerable ");

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -482,7 +482,7 @@ package classes.Scenes
 						}
 						else {
 							outputText("\n<b>The unmistakable bulge of pregnancy is visible in your tummy.  It's feeling heavier by the moment.  ", false);
-							if (getGame().monk > 0) {
+							if (flags[kFLAGS.JOJO_STATUS] > 0) {
 								if (player.cor < 40) outputText("You are distressed by your unwanted pregnancy, and your inability to force this thing out of you.</b>", false);
 								if (player.cor >= 40 && player.cor < 75) outputText("Considering the size of the creatures you've fucked, you hope it doesn't hurt when it comes out.</b>", false);
 								if (player.cor >= 75) outputText("You think dreamily about the monstrous cocks that have recently been fucking you, and hope that your offspring inherit such a pleasure tool.</b>", false);
@@ -1870,7 +1870,7 @@ package classes.Scenes
 				}		
 
 				//Main Text here
-				if (player.pregnancyType == PregnancyStore.PREGNANCY_JOJO && (getGame().monk < 0 || flags[kFLAGS.JOJO_BIMBO_STATE] >= 3) && !prison.inPrison) {
+				if (player.pregnancyType == PregnancyStore.PREGNANCY_JOJO && (flags[kFLAGS.JOJO_STATUS] < 0 || flags[kFLAGS.JOJO_BIMBO_STATE] >= 3) && !prison.inPrison) {
 					if (flags[kFLAGS.JOJO_BIMBO_STATE] >= 3) {
 						kGAMECLASS.joyScene.playerGivesBirthToJoyBabies();
 						return true;

--- a/classes/classes/Scenes/Seasonal/XmasElf.as
+++ b/classes/classes/Scenes/Seasonal/XmasElf.as
@@ -41,7 +41,7 @@
 			}
 			awardAchievement("Naughty or Nice", kACHIEVEMENTS.HOLIDAY_CHRISTMAS_I);
 			outputText("You wonder out loud, \"<i>So this... present is mine?</i>\"\n\n", false);
-			if (player.cor >= 90 || getGame().monk >= 5 || player.findStatusEffect(StatusEffects.Exgartuan) >= 0 || getGame().amilyScene.amilyCorrupt() || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00283] > 0 || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00282] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0)
+			if (player.cor >= 90 || flags[kFLAGS.JOJO_STATUS] >= 5 || player.findStatusEffect(StatusEffects.Exgartuan) >= 0 || getGame().amilyScene.amilyCorrupt() || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00283] > 0 || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00282] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0)
 			{
 				outputText("She nods, bouncing up and down in excitement and flushing slightly, \"<i>Yup, just tear the lid off and get your gift!</i>\"\n\n", false);
 				if (flags[kFLAGS.PC_ENCOUNTERED_CHRISTMAS_ELF_BEFORE] > 0) outputText("Here we go again...\n\n");
@@ -75,7 +75,7 @@
 			spriteSelect(9);
 			clearOutput();
 			outputText("You easily rip through the ribbons holding the box together and pull off the top.   You gasp in ", false);
-			if (player.cor >= 90 || getGame().monk >= 5 || player.findStatusEffect(StatusEffects.Exgartuan) >= 0 || getGame().amilyScene.amilyCorrupt() || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00283] > 0 || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00282] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0) {
+			if (player.cor >= 90 || flags[kFLAGS.JOJO_STATUS] >= 5 || player.findStatusEffect(StatusEffects.Exgartuan) >= 0 || getGame().amilyScene.amilyCorrupt() || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00283] > 0 || flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00282] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0) {
 				//[Bad Present]
 				outputText("shock at the box's contents – a nine inch cock with damn near a dozen buzzing, elliptical devices taped to it.  A pair of coal lumps rattles around underneath it, positioned as if they were the dick's testicles.\n\n", false);
 				


### PR DESCRIPTION
Removed a bunch of plot related variables which were still residing in `CoC.as`. Some had already been replaced and were simply hanging out, while others needed migration to a flag based solution. Where applicable, new save/load logic were implemented.
The total list of variables are:
- `foundForest`: removed without trouble
- `foundDesert`: removed without trouble
- `foundMountain`: removed without trouble
- `foundLake`: removed without trouble
- `explored`: removed without trouble
- `whitney`: removed without trouble
- `sand`: migrated to the new `SANDWITCH_SERVICED` flag.
- `giacomo`: merged with the already existing `GIACOMO_MET` flag.
- `beeProgress`: a small bit of cleanup, related to the save/load code.
- `monk`: This one was more difficult, due to it's ubiquitous, non-standardized usage. Still pretty much a search&replace operation, to use the new `JOJO_STATUS` flag, instead.