### PR TITLE
Basilisk Eyes Phase 1

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -196,6 +196,7 @@
 			}
 			player.wingType = WING_TYPE_NONE;
 			player.wingDesc = "non-existant";
+			if (player.eyeType == EYES_BASILISK) player.eyeType = EYES_LIZARD; // Silently change them to be lizard eyes again. Simple and stupid ;)
 			//Default
 			player.skinTone = "light";
 			player.clawTone = "";

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -1305,8 +1305,8 @@ public static const UNKNOWN_FLAG_NUMBER_01296:int                               
 public static const UNKNOWN_FLAG_NUMBER_01297:int                                   = 1297;
 public static const UNKNOWN_FLAG_NUMBER_01298:int                                   = 1298;
 public static const UNKNOWN_FLAG_NUMBER_01299:int                                   = 1299;
-public static const UNKNOWN_FLAG_NUMBER_01300:int                                   = 1300;
-public static const UNKNOWN_FLAG_NUMBER_01301:int                                   = 1301;
+public static const BENOIT_EYES_TALK_UNLOCKED:int                                   = 1300;
+public static const BENOIT_BASIL_EYES_GRANTED:int                                   = 1301; // Counter to keep track, how often you gained them
 public static const UNKNOWN_FLAG_NUMBER_01302:int                                   = 1302;
 public static const UNKNOWN_FLAG_NUMBER_01303:int                                   = 1303;
 public static const UNKNOWN_FLAG_NUMBER_01304:int                                   = 1304;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -5358,7 +5358,7 @@
 			}
 			//<mod name="Reptile eyes" author="Stadler76">
 			//-Lizard eyes
-			if (player.eyeType != EYES_LIZARD && player.faceType == FACE_LIZARD && player.hasScales() && player.earType == EARS_LIZARD && changes < changeLimit && rand(4) == 0) {
+			if (!player.hasLizardEyes() && player.faceType == FACE_LIZARD && player.hasScales() && player.earType == EARS_LIZARD && changes < changeLimit && rand(4) == 0) {
 				if (player.hasReptileEyes())
 					outputText("\n\nYour eyes change slightly in their appearance.  ");
 				else

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -4984,6 +4984,11 @@
 		public function reptilum(player:Player):void
 		{
 			var tfSource:String = "reptilum";
+			if (player.hasDragonWingsAndFire())
+				tfSource += player.isBasilisk() ? "-dracolisk" : "-dragonewt";
+			else
+				tfSource += player.isBasilisk() ? "-basilisk"  : "-lizan";
+			//if (player.isTaur()) tfSource += "-taur";
 			player.slimeFeed();
 			//init variables
 			changes = 0;

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -228,6 +228,10 @@ package classes.Items
 		public function updateOvipositionPerk(tfSource:String):*
 		{
 			trace('called updateOvipositionPerk("' + tfSource + '")');
+			var tsParts:Array = tfSource.split("-");
+			if (tsParts.length > 1 && ["goldenSeed", "catTransformation"].indexOf(tsParts[0]) == -1)
+				tfSource = tsParts[0];
+
 			// First things first :)
 			if (player.findPerk(PerkLib.BasiliskWomb) >= 0) {
 				if (player.findPerk(PerkLib.Oviposition) >= 0)

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -769,7 +769,10 @@ use namespace kGAMECLASS;
 			}
 			if (lizardScore() >= 4)
 			{
-				race = "lizan";
+				if (hasDragonWingsAndFire())
+					race = isBasilisk() ? "dracolisk" : "dragonewt";
+				else
+					race = isBasilisk() ? "basilisk"  : "lizan";
 				if (isTaur())
 					race += "-taur";
 				if (lizardScore() >= 9)
@@ -1284,7 +1287,7 @@ use namespace kGAMECLASS;
 				lizardCounter++;
 			if (hasScales())
 				lizardCounter++;
-			if (hasReptileEyes() && eyeType != EYES_DRAGON) // Maybe I'll write a different function for that later. e. g. hasLizardEyes() (Stadler76)
+			if (hasLizardEyes())
 				lizardCounter++;
 			return lizardCounter;
 		}

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -277,7 +277,7 @@ package classes
 				{
 					case EYES_DRAGON: outputText(" prideful, fierce dragon eyes with vertically slitted pupils and burning orange irises. They glitter even in the darkness and they"); break;
 					case EYES_LIZARD: outputText(" those of a lizard with vertically slitted pupils and green-yellowish irises. They"); break;
-					case EYES_BASILISK: outputText(" grey basilisk eyes with vertically slitted pupils. They");
+					case EYES_BASILISK: outputText(" basilisk eyes, grey reptilian pools with vertically slitted pupils. They");
 				}
 				outputText(" come with the typical second set of eyelids, allowing you to blink twice as much as others.");
 				if (player.eyeType == EYES_BASILISK)

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -280,6 +280,8 @@ package classes
 					case EYES_BASILISK: outputText(" grey basilisk eyes with vertically slitted pupils. They");
 				}
 				outputText(" come with the typical second set of eyelids, allowing you to blink twice as much as others.");
+				if (player.eyeType == EYES_BASILISK)
+					outputText(" Others seem compelled to look into them.");
 			}
 
 			//Hair

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -272,11 +272,12 @@ package classes
 				outputText("  Your eyes are solid spheres of inky, alien darkness.");
 			else if (player.faceType != FACE_CAT && player.hasReptileEyes())
 			{
-				outputText("Your eyes are");
+				outputText("  Your eyes are");
 				switch (player.eyeType)
 				{
 					case EYES_DRAGON: outputText(" prideful, fierce dragon eyes with vertically slitted pupils and burning orange irises. They glitter even in the darkness and they"); break;
 					case EYES_LIZARD: outputText(" those of a lizard with vertically slitted pupils and green-yellowish irises. They"); break;
+					case EYES_BASILISK: outputText(" grey basilisk eyes with vertically slitted pupils. They");
 				}
 				outputText(" come with the typical second set of eyelids, allowing you to blink twice as much as others.");
 			}

--- a/classes/classes/PlayerHelper.as
+++ b/classes/classes/PlayerHelper.as
@@ -85,7 +85,7 @@ package classes
 
 		public function isBasilisk():Boolean
 		{
-			return game.bazaar.benoit.benoitManyEggsProduced() && eyeType == EYES_BASILISK;
+			return game.bazaar.benoit.benoitBigFamily() && eyeType == EYES_BASILISK;
 		}
 	}
 }

--- a/classes/classes/PlayerHelper.as
+++ b/classes/classes/PlayerHelper.as
@@ -31,6 +31,11 @@ package classes
 			return [EYES_LIZARD, EYES_DRAGON, EYES_BASILISK].indexOf(eyeType) != -1;
 		}
 
+		public function hasLizardEyes():Boolean
+		{
+			return [EYES_LIZARD, EYES_BASILISK].indexOf(eyeType) != -1;
+		}
+
 		public function hasReptileFace():Boolean
 		{
 			return [FACE_SNAKE_FANGS, FACE_LIZARD, FACE_DRAGON].indexOf(faceType) != -1;
@@ -73,14 +78,14 @@ package classes
 			return findPerk(PerkLib.Dragonfire) >= 0;
 		}
 
-		public function hasDragonWingsAndFire():Boolean
+		public function hasDragonWingsAndFire(largeWings:Boolean = true):Boolean
 		{
-			return hasDragonWings(true) && hasDragonfire();
+			return hasDragonWings(largeWings) && hasDragonfire();
 		}
 
 		public function isBasilisk():Boolean
 		{
-			return findPerk(PerkLib.BasiliskWomb) >= 0 /*&& eyeType == EYES_BASILISK*/;
+			return game.bazaar.benoit.benoitManyEggsProduced() && eyeType == EYES_BASILISK;
 		}
 	}
 }

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -176,7 +176,6 @@ public function benoitBigFamily():Boolean
 	return benoitOffspring() >= 12; // I guess, 12 eggs is a good start (Stadler76)
 }
 
-
 public function setBenoitShop(setButtonOnly:Boolean = false):void {
 	if (model.time.hours >= 9 && model.time.hours <= 17) {
 		if ((flags[kFLAGS.FEMOIT_NEXTDAY_EVENT_DONE] == 1 && this.getGame().model.time.days >= flags[kFLAGS.FEMOIT_NEXTDAY_EVENT]) || flags[kFLAGS.FEMOIT_NEXTDAY_EVENT_DONE] != 1)
@@ -309,13 +308,18 @@ public function benoitIntro():void {
 	addButton(2, "Talk", talkToBenoit);
 	addButton(14, "Leave", bazaar.enterTheBazaarAndMenu);
 	//Feminize & Herminize
-	if (flags[kFLAGS.FEMOIT_UNLOCKED] == 1 && flags[kFLAGS.BENOIT_STATUS] == 0) addButton(3, "Feminize", benoitFeminise);
-	if (flags[kFLAGS.BENOIT_STATUS] > 0 && flags[kFLAGS.BENOIT_STATUS] < 3) addButton(3, "Herminize", benoitHerminise);
+	if (flags[kFLAGS.FEMOIT_UNLOCKED] == 1 && flags[kFLAGS.BENOIT_STATUS] == 0)
+		addButton(3, "Feminize", benoitFeminise);
+	if (flags[kFLAGS.BENOIT_STATUS] > 0 && flags[kFLAGS.BENOIT_STATUS] < 3)
+		addButton(3, "Herminize", benoitHerminise);
 	//Basilisk Womb
-	if (flags[kFLAGS.BENOIT_WOMB_TALK_UNLOCKED] == 1 && player.findPerk(PerkLib.BasiliskWomb) < 0 && flags[kFLAGS.BENOIT_TESTED_BASILISK_WOMB] == 0 && [0, 3].indexOf(flags[kFLAGS.BENOIT_STATUS]) >= 0) addButton(4, "Basil. Womb", tryToConvertToBassyWomb);
+	if (flags[kFLAGS.BENOIT_WOMB_TALK_UNLOCKED] == 1 && player.findPerk(PerkLib.BasiliskWomb) < 0 && flags[kFLAGS.BENOIT_TESTED_BASILISK_WOMB] == 0 && [0, 3].indexOf(flags[kFLAGS.BENOIT_STATUS]) >= 0)
+		addButton(4, "Basil. Womb", tryToConvertToBassyWomb);
 	//Suggest & sex
-	if (flags[kFLAGS.BENOIT_SUGGEST_UNLOCKED] > 0 && player.hasVagina() && (flags[kFLAGS.BENOIT_STATUS] == 0 || flags[kFLAGS.BENOIT_STATUS] == 3)) addButton(5, "Suggest", eggySuggest);
-	if (player.hasCock() && flags[kFLAGS.BENOIT_STATUS] > 0 && player.lust >= 33) addButton(6, "Sex", femoitSexIntro);
+	if (flags[kFLAGS.BENOIT_SUGGEST_UNLOCKED] > 0 && player.hasVagina() && (flags[kFLAGS.BENOIT_STATUS] == 0 || flags[kFLAGS.BENOIT_STATUS] == 3))
+		addButton(5, "Suggest", eggySuggest);
+	if (player.hasCock() && flags[kFLAGS.BENOIT_STATUS] > 0 && player.lust >= 33)
+		addButton(6, "Sex", femoitSexIntro);
 	if (flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] == 1 && player.eyeType != EYES_BASILISK)
 		addButton(7, "Basil. Eyes", convertToBassyEyes);
 }
@@ -652,6 +656,19 @@ private function talkToBenoit():void {
 		benoitAffection(5);
 	}
 	if (benoitBigFamily() && player.inte >= 60 && flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] == 0) {
+		outputText("You ask " + benoitMF("Benoit","Benoite") + " if " + benoitMF("he","she") + " has ever thought about granting you the eyes of a basilisk.");
+
+		outputText("\n\nThe basilisk is silent for a time, running his claws along the counter pensively.  \"<i>Yes,</i>\" " + benoitMF("he","she") + " says eventually, in a quiet tone."
+		          +"  \"<i>I 'ave.  Away from ze mountains, I 'ave 'ad time to sink.  I am not ze demons' slave anymore, and I am a funny joke of a basilisk anyway,"
+		          +" so I 'ave often thought about... making certain zacrifices.  If we 'ad just one more of our kind, away from zeir corruption, zen...</i>\" "
+		          + benoitMF("he","she") + " trails off, sighing heavily before smiling ruefully at you.  \"<i>Zose were ze kind of soughts I 'ad before I met you.  Crazy, yes?"
+		          +"  Even more crazy to be still sinking zem when a good " + player.mf("man", "woman") + " is giving me " + player.mf("'is", "'er")
+		          +" love for no reason except through ze kindness of " + player.mf("'is", "'er") + " 'art.  Still... it is so frustrating, being able to sink clearly about zese sings"
+		          +" and not being able to do anysing about it.</i>\"");
+		
+		outputText("\n\nYour mind wanders.  You doubt that even if you wanted to, you could turn into a basilisk proper.");
+		outputText("\n\nBenoit answers warily.  \"<i>You did so much for my folk, that I may figure out somesing to grant zem to you."
+		          +"  But, [name], tell me you're not going to do somesing so reckless as experiment on your body?</i>\"");
 		//toggle on "Basil. Eyes" from benoit's main menu.
 		flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] = 1;
 		outputText("\n\n(<b>Basilisk Eyes option enabled in Benoit's menu!</b>)");
@@ -662,7 +679,7 @@ private function talkToBenoit():void {
 	//Requires: Had sex with Benoit at least twice, have vagina, select talk
 	if (((flags[kFLAGS.BENOIT_TIMES_SEXED_FEMPCS] > 2 && player.inte >= 60 && flags[kFLAGS.BENOIT_WOMB_TALK_UNLOCKED] == 0) || flags[kFLAGS.BENOIT_TIMES_SEXED_FEMPCS] == 2) && player.hasVagina()) {
 		outputText("You ask " + benoitMF("Benoit","Benoite") + " if " + benoitMF("he","she") + " has ever thought about trying to do something to help his people's plight.");
-		
+
 		outputText("\n\nThe basilisk is silent for a time, running his claws along the counter pensively.  \"<i>Yes,</i>\" " + benoitMF("he","she") + " says eventually, in a quiet tone.  \"<i>I 'ave.  Away from ze mountains, I 'ave 'ad time to sink.  I am not ze demons' slave anymore, and I am a funny joke of a basilisk anyway, so I 'ave often thought about... making certain zacrifices.  If we 'ad just one female, away from zeir corruption, zen...</i>\" " + benoitMF("he","she") + " trails off, sighing heavily before smiling ruefully at you.  \"<i>Zose were ze kind of soughts I 'ad before I met you.  Crazy, yes?  Even more crazy to be still sinking zem when a good woman is giving me 'er love for no reason except through ze kindness of 'er 'art.  Still... it is so frustrating, being able to sink clearly about zese sings and not being able to do anysing about it.</i>\"");
 		
 		if (player.inte >= 60) {

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -165,15 +165,15 @@ public function clearBenoitPreggers():void
 	}
 }
 
-public function benoitTotalEggs():int
+public function benoitOffspring():int
 {
 	return flags[kFLAGS.BENOIT_EGGS] + flags[kFLAGS.FEMOIT_EGGS_LAID];
 }
 
-public function benoitManyEggsProduced():Boolean
+public function benoitBigFamily():Boolean
 {
 	if (flags[kFLAGS.BENOIT_STATUS] == 0) return false;
-	return benoitTotalEggs() >= 12; // I guess, 12 eggs is a good start (Stadler76)
+	return benoitOffspring() >= 12; // I guess, 12 eggs is a good start (Stadler76)
 }
 
 
@@ -651,7 +651,7 @@ private function talkToBenoit():void {
 		flags[kFLAGS.BENOIT_TALKED_TODAY] = 1;
 		benoitAffection(5);
 	}
-	if (benoitManyEggsProduced() && player.inte >= 60 && flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] == 0) {
+	if (benoitBigFamily() && player.inte >= 60 && flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] == 0) {
 		//toggle on "Basil. Eyes" from benoit's main menu.
 		flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] = 1;
 		outputText("\n\n(<b>Basilisk Eyes option enabled in Benoit's menu!</b>)");

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -656,22 +656,26 @@ private function talkToBenoit():void {
 		benoitAffection(5);
 	}
 	if (benoitBigFamily() && player.inte >= 60 && flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] == 0) {
-		outputText("You ask " + benoitMF("Benoit","Benoite") + " if " + benoitMF("he","she") + " has ever thought about granting you the eyes of a basilisk.");
+		// Talk scene written by MissBlackthorne
+		outputText("You ask " + benoitMF("Benoit", "Benoite") + " how the petrifying effect of " + benoitMF("his", "her") + " brethrens gaze works,"
+		          +" is it something their eyes naturally do or type of sight? " + benoitMF("He","She") + " stiffens for a moment before letting out a frustrated sigh.");
 
-		outputText("\n\nThe basilisk is silent for a time, running " + benoitMF("his","her") + " claws along the counter pensively.  \"<i>Yes,</i>\" " + benoitMF("he","she") + " says eventually, in a quiet tone."
-		          +"  \"<i>I 'ave.  Away from ze mountains, I 'ave 'ad time to sink.  I am not ze demons' slave anymore, and I am a funny joke of a basilisk anyway,"
-		          +" so I 'ave often thought about... making certain zacrifices.  If we 'ad just one more of our kind, away from zeir corruption, zen...</i>\" "
-		          + benoitMF("he","she") + " trails off, sighing heavily before smiling ruefully at you.  \"<i>Zose were ze kind of soughts I 'ad before I met you.  Crazy, yes?"
-		          +"  Even more crazy to be still sinking zem when a good " + player.mf("man", "woman") + " is giving me " + player.mf("'is", "'er")
-		          +" love for no reason except through ze kindness of " + player.mf("'is", "'er") + " 'art.  Still... it is so frustrating, being able to sink clearly about zese sings"
-		          +" and not being able to do anysing about it.</i>\"");
-		
-		outputText("\n\nYour mind wanders.  You doubt that even if you wanted to, you could turn your eyes into those of a basilisk.");
-		outputText("\n\nBenoit answers warily.  \"<i>You did so much for my folk, that I may figure out somesing to grant zem to you."
-		          +"  But, [name], tell me you're not going to do somesing so reckless as experiment on your body?</i>\"");
+		outputText("\n\n\"<i>[name], you do know i am blind yes? Zis is not somesing to joke about.</i>\"");
+
+		outputText("\n\nYou hurriedly tell your scaled lover that you didn't mean it in a cruel way, you were merely curious."
+		          +" After all, you've transformed yourself to become more basilisk like for " + benoitMF("him", "her")
+		          +" already, so you're curious if you could get even closer to being a true basilisk.");
+
+		outputText("\n\nAfter a few moments " + benoitMF("Benoit", "Benoite") + " nods slightly.");
+		outputText("\n\"<i>I see...are you sure about zis [name]? It is so reckless to experiment on your body like zis....But I suppose you have done so much for my folk,"
+		          +" zat if you wish to be one of us, i could look into it. Beware though, zey are dangerous, so while i shall do zis to thank you,"
+		          +" I do not wish to risk you becoming like ze others...Ze demons no doubt affected our gaze too, ze perverts...</i>\"");
+
+		outputText("\n\nYou smile at the lizard's concern for you before leaving " + benoitMF("Benoit", "Benoite") + " to find a recipe in peace.");
+
 		//toggle on "Basil. Eyes" from benoit's main menu.
 		flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] = 1;
-		outputText("\n\n(<b>Basilisk Eyes option enabled in Benoit's menu!</b>)");
+		outputText("\n\n(<b>Basilisk Eyes option enabled in " + benoitMF("Benoit", "Benoite") + "'s menu!</b>)");
 		doNext(camp.returnToCampUseOneHour);
 		return;
 	}

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -172,7 +172,6 @@ public function benoitOffspring():int
 
 public function benoitBigFamily():Boolean
 {
-	if (flags[kFLAGS.BENOIT_STATUS] == 0) return false;
 	return benoitOffspring() >= 12; // I guess, 12 eggs is a good start (Stadler76)
 }
 

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -165,6 +165,18 @@ public function clearBenoitPreggers():void
 	}
 }
 
+public function benoitTotalEggs():int
+{
+	return flags[kFLAGS.BENOIT_EGGS] + flags[kFLAGS.FEMOIT_EGGS_LAID];
+}
+
+public function benoitManyEggsProduced():Boolean
+{
+	if (flags[kFLAGS.BENOIT_STATUS] == 0) return false;
+	return benoitTotalEggs() >= 12; // I guess, 12 eggs is a good start (Stadler76)
+}
+
+
 public function setBenoitShop(setButtonOnly:Boolean = false):void {
 	if (model.time.hours >= 9 && model.time.hours <= 17) {
 		if ((flags[kFLAGS.FEMOIT_NEXTDAY_EVENT_DONE] == 1 && this.getGame().model.time.days >= flags[kFLAGS.FEMOIT_NEXTDAY_EVENT]) || flags[kFLAGS.FEMOIT_NEXTDAY_EVENT_DONE] != 1)
@@ -304,6 +316,8 @@ public function benoitIntro():void {
 	//Suggest & sex
 	if (flags[kFLAGS.BENOIT_SUGGEST_UNLOCKED] > 0 && player.hasVagina() && (flags[kFLAGS.BENOIT_STATUS] == 0 || flags[kFLAGS.BENOIT_STATUS] == 3)) addButton(5, "Suggest", eggySuggest);
 	if (player.hasCock() && flags[kFLAGS.BENOIT_STATUS] > 0 && player.lust >= 33) addButton(6, "Sex", femoitSexIntro);
+	if (flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] == 1 && player.eyeType != EYES_BASILISK)
+		addButton(7, "Basil. Eyes", convertToBassyEyes);
 }
 //Buy or Sell First Time, only if prelover/prefem: You ask him what the deal is with his shop.
 private function buyOrSellExplanationFirstTime():void {
@@ -636,6 +650,13 @@ private function talkToBenoit():void {
 	if (flags[kFLAGS.BENOIT_TALKED_TODAY] == 0) {
 		flags[kFLAGS.BENOIT_TALKED_TODAY] = 1;
 		benoitAffection(5);
+	}
+	if (benoitManyEggsProduced() && player.inte >= 60 && flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] == 0) {
+		//toggle on "Basil. Eyes" from benoit's main menu.
+		flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] = 1;
+		outputText("\n\n(<b>Basilisk Eyes option enabled in Benoit's menu!</b>)");
+		doNext(camp.returnToCampUseOneHour);
+		return;
 	}
 	//Basilisk Womb
 	//Requires: Had sex with Benoit at least twice, have vagina, select talk
@@ -1170,6 +1191,15 @@ private function repeatBenoitFuckTakeCharge():void {
 	benoitAffection(2);
 	flags[kFLAGS.BENOIT_TIMES_SEXED_FEMPCS]++;
 	player.orgasm();
+	doNext(camp.returnToCampUseOneHour);
+}
+
+//Basilisk Eyes
+private function convertToBassyEyes():void {
+	clearOutput();
+	outputText("\n\n(<b>You now have basilisk eyes</b>)");
+	player.eyeType = EYES_BASILISK;
+	flags[kFLAGS.BENOIT_BASIL_EYES_GRANTED]++
 	doNext(camp.returnToCampUseOneHour);
 }
 

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -1215,24 +1215,39 @@ private function repeatBenoitFuckTakeCharge():void {
 }
 
 //Basilisk Eyes
-private function convertToBassyEyes():void {
+private function convertToBassyEyes():void
+{
 	var eyesGranted:int = flags[kFLAGS.BENOIT_BASIL_EYES_GRANTED] + 1;
 	var benoitE:String = benoitMF("Benoit", "Benoite");
-	var benoitHeShe:String = benoitMF("he", "she");
-	var benoitHisHer:String = benoitMF("his", "her");
-	var benoitHimHer:String = benoitMF("him", "her");
+	var benoit_heshe:String = benoitMF("he", "she");
+	var benoit_HeShe:String = benoitMF("He", "She");
+	var benoit_hisher:String = benoitMF("his", "her");
+	var benoit_himher:String = benoitMF("him", "her");
 	clearOutput();
 	if (eyesGranted <= 1) { // First time
-		outputText("Stubby text summary for starters:\n");
-		outputText("You tell " + benoitE + ", that you've decided, that you want the basilisk eyes and ask "
-		           + benoitMF("him", "her") + ", if " + benoitHeShe + " could grant them to you.");
-		outputText("\n\n" + benoitE + " begins to fetch some ingredients, mixes a solution, adds " + benoitHisHer + " blood"
-		          +" and a freshly shedded tear to it (can reptiles actually shed tears? Naah, whatever, I don't really care about biology, when it adds more fluff to a fantasy game."
-		          +" Whoever writes this: just decide for yourself :) (Stadler76)) and gives the potion/tinture/whatever to you.");
-		outputText("\n\nYou drink it/pour it on your eyes and they become basilisk eyes.");
+		outputText("You tell " + benoitE + " that you've weighed up the pros and cons and that you want to become more of a basilisk. "
+		          + benoit_HeShe + " nods as " + benoit_heshe + " feels " + benoit_hisher + " way across the counter before rummaging about underneath.");
+		outputText("\n\n\"<i>I 'ave found a way to transform your eyes, but I 'ave no idea if it will even work."
+		          +" Ze one oo told me about zis was insistent zat ze recipe relies on you being a basilisk enough already.</i>\"");
+		outputText("\n\nAs the blind basilisk begins to pull out bottle after bottle from under the counter, you wonder what " + benoit_heshe + " means.");
+		outputText("\n\n\"<i> 'Opefully, you 'aving birthed so many will be enough.</i>\" " + benoit_HeShe + " mutters as " + benoit_heshe + " pulls out a large bowl. "
+		          + benoit_HeShe + " begins to sloppily pour several measures from the bottles into the bowl, stirring it now and then with a wooden spoon."
+		          +" The mixture seems to be a flat matte grey when " + benoit_heshe + " stops. Placing " + benoit_hisher + " palm over the bowl "
+		          + benoit_heshe + " cuts it open with a claw, hissing at the pain as droplets of blood fall in with a small splash. "
+		          + benoit_HeShe + " brings a finger to one of " + benoit_hisher + " milky eyes, wiping a tear drop from it before letting that slide down into the mixture too.");
+		outputText("\n\nAs " + benoitE + " goes to fetch a cloth to cover the cut, you watch in awe as the once matte mixture takes on a wet sheen, like an endless grey seeing pool."
+		          +" It reminds you of the eyes of the basilisks in the mountains and flinch away before realising how silly that is.");
+		outputText("\n\n\"<i>Are you going to drink it zen? Or am I to close my shop all day for nuzzing?</i>\" " + benoitE + " says, startling you,"
+		          +" having not noticed the blind basilisk return, being that you were so fixated on the mixture.");
+		outputText("\n\nWith a swift nod you grab the bowl, draining it before realising your non-verbal response. You groan,"
+		          +" the mixture thick on your tongue though not tasting overly foul. Your eyelids feel heavy, like they were made of stone."
+		          +" You tell " + benoitE + " you think you need to rest for a moment, the basilisk now hurrying you to a corner of store room where a pile of fabrics are. "
+		          + benoit_HeShe + " helps you onto them as you lay back and your eyes close.");
+		doNext(convertToBassyEyesPageTwo);
+		return;
 	} else {
-		outputText("You tell " + benoitE + ", that you've lost the basilisk eyes and ask " + benoitHimHer + ", if "
-		           + benoitHeShe + " could grant them to you again.");
+		outputText("You tell " + benoitE + ", that you've lost the basilisk eyes and ask " + benoit_himher + ", if "
+		          + benoit_heshe + " could grant them to you again.");
 		if (eyesGranted == 2) { // Second time
 			outputText("\n\n" + benoitE + " says: \"<i>Oh, you’ve lost zem?"
 			          +" Not what I expected to hear today, but very well [name]. I shall make ze potion...</i>\" ");
@@ -1244,16 +1259,46 @@ private function convertToBassyEyes():void {
 			          +" You should be more careful not to lose zem so often [name]!</i>\" ");
 		}
 		outputText(benoitE + " pads over to the section of the counter, pulling out bottles again");
-		if (eyesGranted >= 6) outputText(", grumbling as " + benoitHeShe + " does");
-		outputText(".\n\"<i>Here we go... For ze " + num2Text2(eyesGranted) + " time</i>\", " + benoitHeShe + " mumbles, though you can tell, " + benoitHeShe + "'s not mad");
+		if (eyesGranted >= 6) outputText(", grumbling as " + benoit_heshe + " does");
+		outputText(".\n\"<i>Here we go... For ze " + num2Text2(eyesGranted) + " time</i>\", " + benoit_heshe + " mumbles, though you can tell, " + benoit_heshe + "'s not mad");
 		outputText(eyesGranted < 6 ? "." : ", simply tired of making the potion so often. Maybe you should be a bit more careful in the future?");
 		outputText("\n\nWithin minutes a bowl is slid to you, a familiar grey mixture sloshing within. You drain the bowl and move to lay down.");
-		outputText("\n\nWhen you wake you open your eyes slowly, waiting to adjust. You thank " + benoitE + " for " + benoitHisHer + " help with a small kiss on the snout"
+		outputText("\n\nWhen you wake you open your eyes slowly, waiting to adjust. You thank " + benoitE + " for " + benoit_hisher + " help with a small kiss on the snout"
 		          +" before leaving, once again feeling the compulsion to look deep into the grey orbs of basilisks fade as you catch your reflection in the mirror.");
 	}
-	outputText("\n\n(<b>Your eyes are now basilisk eyes!</b>)");
+	convertToBassyEyesFinal();
+}
+
+private function convertToBassyEyesPageTwo():void
+{
+	var benoitE:String = benoitMF("Benoit", "Benoite");
+	var benoit_heshe:String = benoitMF("he", "she");
+	var benoit_HeShe:String = benoitMF("He", "She");
+	var benoit_hisher:String = benoitMF("his", "her");
+	var benoit_HisHer:String = benoitMF("His", "Her");
+	var benoit_hishers:String = benoitMF("his", "hers");
+	clearOutput();
+	outputText("When you wake, you open your eyes and cry out, quickly closing them again. Gods it's bright! " + benoitE + " rushes over to you and places a hand on your shoulder.");
+	outputText("\n\n\"<i>What iz it? Did somesing 'appen? You're not 'urt are you?</i>\" " + benoit_HeShe + " says in an increasing worry. You put your hand to "
+	          + benoit_hishers + " and say that you're fine, everything was just a little bright. You open your eyes again, this time slowly, letting your eyes adjust."
+	          +" You ask the basilisk if " + benoit_heshe + " could get you a mirror, curious if the potion has worked. "
+	          + benoit_HeShe + " rushes off with a nod and comes back with a small hand mirror.");
+	outputText("\n\n\"<i>Well?</i>\"");
+	outputText("\n\nYour eyes widen as you look in the mirror, the grey reptilian orbs staring back at you catching you off guard. They're absolutely mesmerising,"
+	          +" the swirling greys and wet sheen parted by a thin black slit of a pupil. While you feel you could look into their depths forever,"
+	          +" you don't feel any kind of compulsion like when you look into other basilisk's eyes. Somehow you think you'll be immune to their gaze from now on,"
+	          +" though it does make sense. After all, why would a basilisk ever try to use their gaze on one another?");
+	outputText("\n\nYou smile and put down the mirror, sharing that it worked and thanking " + benoitE + " with a kiss on the tip of " + benoit_hisher + " scaled snout. "
+	          + benoit_HisHer + " scales colour a deeper grey-green, waving a hand in a nonchalant gesture.");
+	outputText("\n\n\"<i>It was nussing, a gift from me to you, for all you've done.</i>\" " + benoit_HeShe + " says shyly before returning to a more normal business like demeanor."
+	          +" You are subsequently shoo’ed from the store, though not without a sticky but loving lick to the cheek from the basilisk.");
+	convertToBassyEyesFinal();
+}
+
+private function convertToBassyEyesFinal():void
+{
 	player.eyeType = EYES_BASILISK;
-	trace("eyesGranted:", eyesGranted);
+	outputText("\n\n(<b>Your eyes are now basilisk eyes!</b>)");
 	flags[kFLAGS.BENOIT_BASIL_EYES_GRANTED]++
 	doNext(camp.returnToCampUseOneHour);
 }

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -1217,7 +1217,33 @@ private function repeatBenoitFuckTakeCharge():void {
 
 //Basilisk Eyes
 private function convertToBassyEyes():void {
+	var eyesGranted:int = flags[kFLAGS.BENOIT_BASIL_EYES_GRANTED];
 	clearOutput();
+	trace("eyesGranted:", eyesGranted);
+	outputText("Stubby text summaries for starters:\n");
+	if (eyesGranted == 0) { // First time
+		outputText("You tell " + benoitMF("Benoit", "Benoite") + ", that you've decided, that you want the basilisk eyes and ask "
+		           + benoitMF("him", "her") + ", if " + benoitMF("he", "she") + " could grant them to you.");
+		outputText("\n\n" + benoitMF("Benoit", "Benoite") + " begins to fetch some ingredients, mixes a solution, adds " + benoitMF("his", "her") + " blood"
+		          +" and a freshly shedded tear to it (can reptiles actually shed tears? Naah, whatever, I don't really care about biology, when it adds more fluff to a fantasy game."
+		          +" Whoever writes this: just decide for yourself :) (Stadler76)) and gives the potion/tinture/whatever to you.");
+		outputText("\n\nYou drink it/pour it on your eyes and they become basilisk eyes.");
+	} else {
+		outputText("You tell " + benoitMF("Benoit", "Benoite") + ", that you've lost the basilisk eyes and ask " + benoitMF("him", "her") + ", if "
+		           + benoitMF("he", "she") + " could grant them to you again.");
+		if (eyesGranted == 1) { // Second time
+			outputText("\n\n" + benoitMF("Benoit", "Benoite") + " says: \"<i>Oh, you've lost zem? No problem,");
+		} else if (eyesGranted >= 2 && eyesGranted < 5) { // Third time and later
+			outputText("\n\n" + benoitMF("Benoit", "Benoite") + " says: \"<i>Oh, you've lost zem again? 'mm ok...");
+		} else /*if (eyesGranted >= 5)*/ { // Sixth time and later
+			outputText("\n\n" + benoitMF("Benoit", "Benoite") + " sighs: \"<i>You should be more careful not to lose zem so often!</i>\" "
+			          + benoitMF("he", "she") + " grumbles... \"<I>'mm well...");
+		}
+		outputText(" just give me a moment, zo I can fetch ze ingredienns for you again...</i>\"");
+		outputText("\n\"<i>For ze " + num2Text2(eyesGranted + 1) + " time</i>\", " + benoitMF("he", "she") + " mumbles...");
+		outputText("\n\n" + benoitMF("Benoit", "Benoite") + " fetches the ingedients again and gives the potion/tinture/whatever again to you. You drink it/pour it on your eyes"
+		          +" and they again become basilisk eyes.");
+	}
 	outputText("\n\n(<b>You now have basilisk eyes</b>)");
 	player.eyeType = EYES_BASILISK;
 	flags[kFLAGS.BENOIT_BASIL_EYES_GRANTED]++

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -658,7 +658,7 @@ private function talkToBenoit():void {
 	if (benoitBigFamily() && player.inte >= 60 && flags[kFLAGS.BENOIT_EYES_TALK_UNLOCKED] == 0) {
 		outputText("You ask " + benoitMF("Benoit","Benoite") + " if " + benoitMF("he","she") + " has ever thought about granting you the eyes of a basilisk.");
 
-		outputText("\n\nThe basilisk is silent for a time, running his claws along the counter pensively.  \"<i>Yes,</i>\" " + benoitMF("he","she") + " says eventually, in a quiet tone."
+		outputText("\n\nThe basilisk is silent for a time, running " + benoitMF("his","her") + " claws along the counter pensively.  \"<i>Yes,</i>\" " + benoitMF("he","she") + " says eventually, in a quiet tone."
 		          +"  \"<i>I 'ave.  Away from ze mountains, I 'ave 'ad time to sink.  I am not ze demons' slave anymore, and I am a funny joke of a basilisk anyway,"
 		          +" so I 'ave often thought about... making certain zacrifices.  If we 'ad just one more of our kind, away from zeir corruption, zen...</i>\" "
 		          + benoitMF("he","she") + " trails off, sighing heavily before smiling ruefully at you.  \"<i>Zose were ze kind of soughts I 'ad before I met you.  Crazy, yes?"
@@ -666,7 +666,7 @@ private function talkToBenoit():void {
 		          +" love for no reason except through ze kindness of " + player.mf("'is", "'er") + " 'art.  Still... it is so frustrating, being able to sink clearly about zese sings"
 		          +" and not being able to do anysing about it.</i>\"");
 		
-		outputText("\n\nYour mind wanders.  You doubt that even if you wanted to, you could turn into a basilisk proper.");
+		outputText("\n\nYour mind wanders.  You doubt that even if you wanted to, you could turn your eyes into those of a basilisk.");
 		outputText("\n\nBenoit answers warily.  \"<i>You did so much for my folk, that I may figure out somesing to grant zem to you."
 		          +"  But, [name], tell me you're not going to do somesing so reckless as experiment on your body?</i>\"");
 		//toggle on "Basil. Eyes" from benoit's main menu.

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -1216,35 +1216,44 @@ private function repeatBenoitFuckTakeCharge():void {
 
 //Basilisk Eyes
 private function convertToBassyEyes():void {
-	var eyesGranted:int = flags[kFLAGS.BENOIT_BASIL_EYES_GRANTED];
+	var eyesGranted:int = flags[kFLAGS.BENOIT_BASIL_EYES_GRANTED] + 1;
+	var benoitE:String = benoitMF("Benoit", "Benoite");
+	var benoitHeShe:String = benoitMF("he", "she");
+	var benoitHisHer:String = benoitMF("his", "her");
+	var benoitHimHer:String = benoitMF("him", "her");
 	clearOutput();
-	trace("eyesGranted:", eyesGranted);
-	outputText("Stubby text summaries for starters:\n");
-	if (eyesGranted == 0) { // First time
-		outputText("You tell " + benoitMF("Benoit", "Benoite") + ", that you've decided, that you want the basilisk eyes and ask "
-		           + benoitMF("him", "her") + ", if " + benoitMF("he", "she") + " could grant them to you.");
-		outputText("\n\n" + benoitMF("Benoit", "Benoite") + " begins to fetch some ingredients, mixes a solution, adds " + benoitMF("his", "her") + " blood"
+	if (eyesGranted <= 1) { // First time
+		outputText("Stubby text summary for starters:\n");
+		outputText("You tell " + benoitE + ", that you've decided, that you want the basilisk eyes and ask "
+		           + benoitMF("him", "her") + ", if " + benoitHeShe + " could grant them to you.");
+		outputText("\n\n" + benoitE + " begins to fetch some ingredients, mixes a solution, adds " + benoitHisHer + " blood"
 		          +" and a freshly shedded tear to it (can reptiles actually shed tears? Naah, whatever, I don't really care about biology, when it adds more fluff to a fantasy game."
 		          +" Whoever writes this: just decide for yourself :) (Stadler76)) and gives the potion/tinture/whatever to you.");
 		outputText("\n\nYou drink it/pour it on your eyes and they become basilisk eyes.");
 	} else {
-		outputText("You tell " + benoitMF("Benoit", "Benoite") + ", that you've lost the basilisk eyes and ask " + benoitMF("him", "her") + ", if "
-		           + benoitMF("he", "she") + " could grant them to you again.");
-		if (eyesGranted == 1) { // Second time
-			outputText("\n\n" + benoitMF("Benoit", "Benoite") + " says: \"<i>Oh, you've lost zem? No problem,");
-		} else if (eyesGranted >= 2 && eyesGranted < 5) { // Third time and later
-			outputText("\n\n" + benoitMF("Benoit", "Benoite") + " says: \"<i>Oh, you've lost zem again? 'mm ok...");
-		} else /*if (eyesGranted >= 5)*/ { // Sixth time and later
-			outputText("\n\n" + benoitMF("Benoit", "Benoite") + " sighs: \"<i>You should be more careful not to lose zem so often!</i>\" "
-			          + benoitMF("he", "she") + " grumbles... \"<I>'mm well...");
+		outputText("You tell " + benoitE + ", that you've lost the basilisk eyes and ask " + benoitHimHer + ", if "
+		           + benoitHeShe + " could grant them to you again.");
+		if (eyesGranted == 2) { // Second time
+			outputText("\n\n" + benoitE + " says: \"<i>Oh, you’ve lost zem?"
+			          +" Not what I expected to hear today, but very well [name]. I shall make ze potion...</i>\" ");
+		} else if (eyesGranted >= 3 && eyesGranted < 6) { // Third time and later
+			outputText("\n\n" + benoitE + " says: \"<i>You’ve lost zem again?"
+			          +" Not what I expected to hear today, but very well [name]. I shall make ze potion...</i>\" ");
+		} else /*if (eyesGranted >= 6)*/ { // Sixth time and later
+			outputText("\n\n" + benoitE + " says: \"<i>You’ve lost zem again?"
+			          +" You should be more careful not to lose zem so often [name]!</i>\" ");
 		}
-		outputText(" just give me a moment, zo I can fetch ze ingredienns for you again...</i>\"");
-		outputText("\n\"<i>For ze " + num2Text2(eyesGranted + 1) + " time</i>\", " + benoitMF("he", "she") + " mumbles...");
-		outputText("\n\n" + benoitMF("Benoit", "Benoite") + " fetches the ingedients again and gives the potion/tinture/whatever again to you. You drink it/pour it on your eyes"
-		          +" and they again become basilisk eyes.");
+		outputText(benoitE + " pads over to the section of the counter, pulling out bottles again");
+		if (eyesGranted >= 6) outputText(", grumbling as " + benoitHeShe + " does");
+		outputText(".\n\"<i>Here we go... For ze " + num2Text2(eyesGranted) + " time</i>\", " + benoitHeShe + " mumbles, though you can tell, " + benoitHeShe + "'s not mad");
+		outputText(eyesGranted < 6 ? "." : ", simply tired of making the potion so often. Maybe you should be a bit more careful in the future?");
+		outputText("\n\nWithin minutes a bowl is slid to you, a familiar grey mixture sloshing within. You drain the bowl and move to lay down.");
+		outputText("\n\nWhen you wake you open your eyes slowly, waiting to adjust. You thank " + benoitE + " for " + benoitHisHer + " help with a small kiss on the snout"
+		          +" before leaving, once again feeling the compulsion to look deep into the grey orbs of basilisks fade as you catch your reflection in the mirror.");
 	}
-	outputText("\n\n(<b>You now have basilisk eyes</b>)");
+	outputText("\n\n(<b>Your eyes are now basilisk eyes!</b>)");
 	player.eyeType = EYES_BASILISK;
+	trace("eyesGranted:", eyesGranted);
 	flags[kFLAGS.BENOIT_BASIL_EYES_GRANTED]++
 	doNext(camp.returnToCampUseOneHour);
 }

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -44,12 +44,13 @@ package classes.internals
 		public static function num2Text2(number:int):String {
 			if (number < 0) return number.toString(); //Can't really have the -10th of something
 			if (number <= 10) return NUMBER_WORDS_POSITIONAL[number];
-			switch (number % 10) {
+			// For (number > 10) the method would return 11st, 12nd, 13rd and so on with the switch-case below (Stadler76)
+			/*switch (number % 10) {
 				case 1: return number.toString() + "st";
 				case 2: return number.toString() + "nd";
 				case 3: return number.toString() + "rd";
 				default:
-			}
+			}*/
 			return number.toString() + "th";
 		}
 		

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -71,7 +71,7 @@ public static const EYES_FOUR_SPIDER_EYES:int                                   
 public static const EYES_BLACK_EYES_SAND_TRAP:int                                   =   2;
 public static const EYES_LIZARD:int                                                 =   3;
 public static const EYES_DRAGON:int                                                 =   4; // Slightly different description/TF and *maybe* in the future(!) grant different perks/combat abilities
-public static const EYES_BASILISK:int                                               =   5; // NYI! Example for now!!! Maybe later and granted from Benoit.
+public static const EYES_BASILISK:int                                               =   5;
 
 // earType
 public static const EARS_HUMAN:int                                                  =   0;


### PR DESCRIPTION
## Benoit(e) talk scene and scenes to gain and regain basilisk eyes
### Credits
- **MissBlackthorne** (Basilisk eyes description, Benoit(e) scene texts)

### Gameplay changes
- If you have a total of at least 12 eggs (subject to change) produced for Benoit(e) the talk scene activates to enable the 'Basil. Eyes'-button.
- You can gain and regain them without any limit cuz you did so much for him ;)
- Gaining them the first time results in a two-page story scene.
- **Re**gaining them results in a short scene.
- Basilisk eyes revert to lizard eyes upon ascension.
- Your race now shows up as basilisk/dracolisk/dragonewt(-taur) in the player appearance tab

### Internal changes
- Added `PlayerHelper:hasLizardEyes()` to check, if the player has basilisk or lizard eyes, thus excluding dragon eyes.
- `PlayerHelper:isBasilisk()` now returns true, when you have enough total eggs produced for and with Benoit(e) and when you have basilisk eyes.
- Added 5 new methods to Benoit.as:
 - `public function benoitOffspring():int`
 - `public function benoitBigFamily():Boolean`
 - `private function convertToBassyEyes():void`
 - `private function convertToBassyEyesPageTwo():void`
 - `private function convertToBassyEyesFinal():void`
- Applied some pretty printing to `Benoit:setBenoitShop()` in addition to the new button 'Basil. Eyes'
- Removed the comment from `EYES_BASILISK` in `appearanceDefs.as` since its not NYI anymore ^^
- Added two new flags:
```as3
public static const BENOIT_EYES_TALK_UNLOCKED:int = 1300;
public static const BENOIT_BASIL_EYES_GRANTED:int = 1301; // Counter to keep track, how often you gained them
```

### Notes
If you intend to see what happens, when you gain or regain them I suggest, that you TF to be all dragon including the dragon eyes and then gain them. After that there's a relatively high chance, that they become dragon eyes, when you drink Ember's blood or eat the flower again.
Upon ascension basilisk eyes revert to be lizard ones since you don't meet the requirements for them anymore.
To explain, how the lizan-subraces work, I think its the easiest to show you the code snippet:
```as3
			if (lizardScore() >= 4)
			{
				if (hasDragonWingsAndFire())
					race = isBasilisk() ? "dracolisk" : "dragonewt";
				else
					race = isBasilisk() ? "basilisk"  : "lizan";
				// [...]
			}
```
Meaning, that if you don't meet the requirements to be considered a basilisk (basilisk eyes and enough eggs laid and/or fertilized), you'll show up as a lizan; or as a dragonewt if you have **fully grown** dragon wings **and** the Dragonfire-perk. If you meet the requirements you'll show up as a basilisk; or as a dracolisk if you have **fully grown** dragon wings **and** the Dragonfire-perk.
