### PR TITLE
Add confirm dialog to quickload and quicksave

### DIFF
--- a/classes/classes/Bindings.as
+++ b/classes/classes/Bindings.as
@@ -1,0 +1,61 @@
+package classes 
+{
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.GlobalFlags.kFLAGS;
+	import coc.view.MainView;
+	import flash.net.SharedObject;
+
+	/**
+	 * class to relocate ControlBindings-code into single method-calls
+	 * @author Stadler76
+	 */
+	public class Bindings 
+	{
+		public function get game():CoC { return kGAMECLASS; }
+
+		public function Bindings() {}
+
+		public function execQuickSave(slot:int):void
+		{
+			if (game.mainView.menuButtonIsVisible(MainView.MENU_DATA) && game.player.str > 0) {
+				var doQuickSave:Function = function():void {
+					game.mainView.nameBox.text = "";
+					game.saves.saveGame("CoC_" + slot);
+					game.outputText("Game saved to slot " + slot + "!", true);
+					game.doNext(game.playerMenu);
+				};
+				game.clearOutput();
+				game.outputText("You are about to quicksave the current game to slot <b>" + slot + "</b>\n\nAre you sure?");
+				game.menu();
+				game.addButton(0, "No", game.playerMenu);
+				game.addButton(1, "Yes", doQuickSave);
+			}
+		}
+
+		public function execQuickLoad(slot:uint):void
+		{
+			if (game.mainView.menuButtonIsVisible(MainView.MENU_DATA)) {
+				var saveFile:* = SharedObject.getLocal("CoC_" + slot, "/");
+				var doQuickLoad:Function = function():void {
+					if (game.saves.loadGame("CoC_" + slot)) {
+						game.showStats();
+						game.statScreenRefresh();
+						game.outputText("Slot " + slot + " Loaded!", true);
+						game.doNext(game.playerMenu);
+					}
+				};
+				if (saveFile.data.exists) {
+					if (game.player.str == 0) {
+						doQuickLoad();
+						return;
+					}
+					game.clearOutput();
+					game.outputText("You are about to quickload the current game from slot <b>" + slot + "</b>\n\nAre you sure?");
+					game.menu();
+					game.addButton(0, "No", game.playerMenu);
+					game.addButton(1, "Yes", doQuickLoad);
+				}
+			}
+		}
+	}
+}

--- a/classes/classes/Bindings.as
+++ b/classes/classes/Bindings.as
@@ -12,6 +12,7 @@ package classes
 	public class Bindings 
 	{
 		public function get game():CoC { return kGAMECLASS; }
+		public function get flags():DefaultDict { return game.flags; }
 
 		public function Bindings() {}
 
@@ -24,6 +25,10 @@ package classes
 					game.outputText("Game saved to slot " + slot + "!", true);
 					game.doNext(game.playerMenu);
 				};
+				if (flags[kFLAGS.DISABLE_QUICKSAVE_CONFIRM] != 0) {
+					doQuickSave();
+					return;
+				}
 				game.clearOutput();
 				game.outputText("You are about to quicksave the current game to slot <b>" + slot + "</b>\n\nAre you sure?");
 				game.menu();
@@ -45,7 +50,7 @@ package classes
 					}
 				};
 				if (saveFile.data.exists) {
-					if (game.player.str == 0) {
+					if (game.player.str == 0 || flags[kFLAGS.DISABLE_QUICKLOAD_CONFIRM] != 0) {
 						doQuickLoad();
 						return;
 					}

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -281,7 +281,8 @@ the text from being too boring.
 		
 		public var mainViewManager:MainViewManager = new MainViewManager();
 		//Scenes in includes folder GONE! Huzzah!
-		
+
+		public var bindings:Bindings = new Bindings();
 		/****
 			This is used purely for bodges while we get things cleaned up.
 			Hopefully, anything you stick to this object can be removed eventually.

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -1303,8 +1303,8 @@ public static const UNKNOWN_FLAG_NUMBER_01294:int                               
 public static const UNKNOWN_FLAG_NUMBER_01295:int                                   = 1295;
 public static const UNKNOWN_FLAG_NUMBER_01296:int                                   = 1296;
 public static const UNKNOWN_FLAG_NUMBER_01297:int                                   = 1297;
-public static const UNKNOWN_FLAG_NUMBER_01298:int                                   = 1298;
-public static const UNKNOWN_FLAG_NUMBER_01299:int                                   = 1299;
+public static const DISABLE_QUICKLOAD_CONFIRM:int                                   = 1298; // Disable the confirmation-dialog on quickload
+public static const DISABLE_QUICKSAVE_CONFIRM:int                                   = 1299; // Disable the confirmation-dialog on quicksave
 public static const BENOIT_EYES_TALK_UNLOCKED:int                                   = 1300;
 public static const BENOIT_BASIL_EYES_GRANTED:int                                   = 1301; // Counter to keep track, how often you gained them
 public static const UNKNOWN_FLAG_NUMBER_01302:int                                   = 1302;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -622,6 +622,8 @@ public function savePermObject(isFile:Boolean):void {
 		saveFile.data.flags[kFLAGS.USE_12_HOURS] = flags[kFLAGS.USE_12_HOURS];
 		saveFile.data.flags[kFLAGS.AUTO_LEVEL] = flags[kFLAGS.AUTO_LEVEL];
 		saveFile.data.flags[kFLAGS.USE_METRICS] = flags[kFLAGS.USE_METRICS];
+		saveFile.data.flags[kFLAGS.DISABLE_QUICKLOAD_CONFIRM] = flags[kFLAGS.DISABLE_QUICKLOAD_CONFIRM];
+		saveFile.data.flags[kFLAGS.DISABLE_QUICKSAVE_CONFIRM] = flags[kFLAGS.DISABLE_QUICKSAVE_CONFIRM];
 		//achievements
 		saveFile.data.achievements = [];
 		for (i = 0; i < achievements.length; i++)
@@ -666,6 +668,8 @@ public function loadPermObject():void {
 			if (saveFile.data.flags[kFLAGS.USE_12_HOURS] != undefined) flags[kFLAGS.USE_12_HOURS] = saveFile.data.flags[kFLAGS.USE_12_HOURS];
 			if (saveFile.data.flags[kFLAGS.AUTO_LEVEL] != undefined) flags[kFLAGS.AUTO_LEVEL] = saveFile.data.flags[kFLAGS.AUTO_LEVEL];
 			if (saveFile.data.flags[kFLAGS.USE_METRICS] != undefined) flags[kFLAGS.USE_METRICS] = saveFile.data.flags[kFLAGS.USE_METRICS];
+			if (saveFile.data.flags[kFLAGS.DISABLE_QUICKLOAD_CONFIRM] != undefined) flags[kFLAGS.DISABLE_QUICKLOAD_CONFIRM] = saveFile.data.flags[kFLAGS.DISABLE_QUICKLOAD_CONFIRM];
+			if (saveFile.data.flags[kFLAGS.DISABLE_QUICKSAVE_CONFIRM] != undefined) flags[kFLAGS.DISABLE_QUICKSAVE_CONFIRM] = saveFile.data.flags[kFLAGS.DISABLE_QUICKSAVE_CONFIRM];
 		}
 		//achievements, will check if achievement exists.
 		if (saveFile.data.achievements) {

--- a/includes/ControlBindings.as
+++ b/includes/ControlBindings.as
@@ -1,8 +1,12 @@
 import classes.GlobalFlags.kGAMECLASS;
 import flash.ui.Keyboard;
 import coc.view.MainView;
+import classes.Bindings;
 
 use namespace kGAMECLASS;
+
+// I'm planning to move this whole thing out of includes later (Stadler76)
+var bindings:Bindings = kGAMECLASS.bindings;
 
 inputManager.AddBindableControl(
 	"Show Stats",
@@ -24,171 +28,18 @@ inputManager.AddBindableControl(
 		}
 	});
 
-inputManager.AddBindableControl(
-	"Quicksave 1",
-	"Quicksave the current game to slot 1",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA) && player.str > 0)
-		{
-			mainView.nameBox.text = "";
-			saves.saveGame("CoC_1");
-			outputText("Game saved to slot 1!", true);
-			doNext(playerMenu);
-		}
-	});
-	
-inputManager.AddBindableControl(
-	"Quicksave 2",
-	"Quicksave the current game to slot 2",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA) && player.str > 0)
-		{
-			mainView.nameBox.text = "";
-			saves.saveGame("CoC_2");
-			outputText("Game saved to slot 2!", true);
-			doNext(playerMenu);
-		}
-	});
-	
-inputManager.AddBindableControl(
-	"Quicksave 3",
-	"Quicksave the current game to slot 2",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA) && player.str > 0)
-		{
-			mainView.nameBox.text = "";
-			saves.saveGame("CoC_3");
-			outputText("Game saved to slot 3!", true);
-			doNext(playerMenu);
-		}
-	});
-	
-inputManager.AddBindableControl(
-	"Quicksave 4",
-	"Quicksave the current game to slot 4",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA) && player.str > 0)
-		{
-			mainView.nameBox.text = "";
-			saves.saveGame("CoC_4");
-			outputText("Game saved to slot 4!", true);
-			doNext(playerMenu);
-		}
-	});
-	
-inputManager.AddBindableControl(
-	"Quicksave 5",
-	"Quicksave the current game to slot 5",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA) && player.str > 0)
-		{
-			mainView.nameBox.text = "";
-			saves.saveGame("CoC_5");
-			outputText("Game saved to slot 5!", true);
-			doNext(playerMenu);
-		}
-	});
-	
-inputManager.AddBindableControl(
-	"Quickload 1",
-	"Quickload the current game from slot 1",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA))
-		{
-			var saveFile:* = SharedObject.getLocal("CoC_1", "/");
-			if (saveFile.data.exists)
-			{
-				if (saves.loadGame("CoC_1"))
-				{
-					showStats();
-					statScreenRefresh();
-					outputText("Slot 1 Loaded!", true);
-					doNext(playerMenu);
-				}
-			}
-		}
-	});
+inputManager.AddBindableControl("Quicksave 1", "Quicksave the current game to slot 1", function():void { bindings.execQuickSave(1); });
+inputManager.AddBindableControl("Quicksave 2", "Quicksave the current game to slot 2", function():void { bindings.execQuickSave(2); });
+inputManager.AddBindableControl("Quicksave 3", "Quicksave the current game to slot 3", function():void { bindings.execQuickSave(3); });
+inputManager.AddBindableControl("Quicksave 4", "Quicksave the current game to slot 4", function():void { bindings.execQuickSave(4); });
+inputManager.AddBindableControl("Quicksave 5", "Quicksave the current game to slot 5", function():void { bindings.execQuickSave(5); });
 
-inputManager.AddBindableControl(
-	"Quickload 2",
-	"Quickload the current game from slot 2",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA))
-		{
-			var saveFile:* = SharedObject.getLocal("CoC_2", "/");
-			if (saveFile.data.exists)
-			{
-				if (saves.loadGame("CoC_2"))
-				{
-					showStats();
-					statScreenRefresh();
-					outputText("Slot 2 Loaded!", true);
-					doNext(playerMenu);
-				}
-			}
-		}
-	});
-	
-inputManager.AddBindableControl(
-	"Quickload 3",
-	"Quickload the current game from slot 3",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA))
-		{
-			var saveFile:* = SharedObject.getLocal("CoC_3", "/");
-			if (saveFile.data.exists)
-			{
-				if (saves.loadGame("CoC_3"))
-				{
-					showStats();
-					statScreenRefresh();
-					outputText("Slot 3 Loaded!", true);
-					doNext(playerMenu);
-				}
-			}
-		}
-	});
-	
-inputManager.AddBindableControl(
-	"Quickload 4",
-	"Quickload the current game from slot 4",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA))
-		{
-			var saveFile:* = SharedObject.getLocal("CoC_4", "/");
-			if (saveFile.data.exists)
-			{
-				if (saves.loadGame("CoC_4"))
-				{
-					showStats();
-					statScreenRefresh();
-					outputText("Slot 4 Loaded!", true);
-					doNext(playerMenu);
-				}
-			}
-		}
-	});
-	
-inputManager.AddBindableControl(
-	"Quickload 5",
-	"Quickload the current game from slot 5",
-	function():void {
-		if (mainView.menuButtonIsVisible(MainView.MENU_DATA))
-		{
-			var saveFile:* = SharedObject.getLocal("CoC_5", "/");
-			if (saveFile.data.exists)
-			{
-				if (saves.loadGame("CoC_5"))
-				{
-					showStats();
-					statScreenRefresh();
-					outputText("Slot 5 Loaded!", true);
-					doNext(playerMenu);
-				}
-			}
-		}
-	});
-	
+inputManager.AddBindableControl("Quickload 1", "Quickload the current game from slot 1", function():void { bindings.execQuickLoad(1); });
+inputManager.AddBindableControl("Quickload 2", "Quickload the current game from slot 2", function():void { bindings.execQuickLoad(2); });
+inputManager.AddBindableControl("Quickload 3", "Quickload the current game from slot 3", function():void { bindings.execQuickLoad(3); });
+inputManager.AddBindableControl("Quickload 4", "Quickload the current game from slot 4", function():void { bindings.execQuickLoad(4); });
+inputManager.AddBindableControl("Quickload 5", "Quickload the current game from slot 5", function():void { bindings.execQuickLoad(5); });
+
 inputManager.AddBindableControl(
 	"Show Menu",
 	"Show the main menu",

--- a/includes/startUp.as
+++ b/includes/startUp.as
@@ -537,7 +537,25 @@ public function settingsScreenInterfaceSettings():void {
 		outputText("Measurement: <b>Metric</b>\n Height and cock size will be measured in metres and centimetres.");
 	else
 		outputText("Measurement: <b>Imperial</b>\n Height and cock size will be measured in feet and inches.");
-		
+
+	outputText("\n\n");
+
+	if (flags[kFLAGS.DISABLE_QUICKLOAD_CONFIRM] == 0)
+	{
+		outputText("Confirm Quickload: <font color=\"#008000\"><b>ON</b></font> (Quickload confirmation dialog is enabled).");
+	}
+	else
+		outputText("Confirm Quickload: <font color=\"#800000\"><b>OFF</b></font> (Quickload confirmation dialog is disabled).");
+
+	outputText("\n\n");
+
+	if (flags[kFLAGS.DISABLE_QUICKSAVE_CONFIRM] == 0)
+	{
+		outputText("Confirm Quicksave: <font color=\"#008000\"><b>ON</b></font> (Quicksave confirmation dialog is enabled).");
+	}
+	else
+		outputText("Confirm Quicksave: <font color=\"#800000\"><b>OFF</b></font> (Quicksave confirmation dialog is disabled).");
+
 	menu();
 	addButton(0, "Side Bar Font", toggleFont, null, null, null, "Toggle between old and new font for side bar.");
 	addButton(1, "Main BG", menuMainBackground, null, null, null, "Choose a background for main game interface.");
@@ -547,6 +565,9 @@ public function settingsScreenInterfaceSettings():void {
 	addButton(5, "Toggle Images", toggleImages, null, null, null, "Enable or disable image pack.");
 	addButton(6, "Time Format", toggleTimeFormat, null, null, null, "Toggles between 12-hour and 24-hour format.");
 	addButton(7, "Measurements", toggleMeasurements, null, null, null, "Switch between imperial and metric measurements.  \n\nNOTE: Only applies to your appearance screen.");
+
+	addButton(10, "Confirm Load", toggleQuickLoadConfirm, null, null, null, "Toggles the confirmation dialog for Quickload.", "Confirm Quickload");
+	addButton(11, "Confirm Save", toggleQuickSaveConfirm, null, null, null, "Toggles the confirmation dialog for Quicksave.", "Confirm Quicksave");
 	addButton(14, "Back", settingsScreenMain);
 }
 
@@ -650,6 +671,15 @@ public function toggleTimeFormat():void {
 	settingsScreenInterfaceSettings();
 }
 
+public function toggleQuickLoadConfirm():void {
+	flags[kFLAGS.DISABLE_QUICKLOAD_CONFIRM] ^= 1; // Bitwise XOR. Neat trick to toggle between 0 and 1
+	settingsScreenInterfaceSettings();
+}
+
+public function toggleQuickSaveConfirm():void {
+	flags[kFLAGS.DISABLE_QUICKSAVE_CONFIRM] ^= 1; // Bitwise XOR. Neat trick to toggle between 0 and 1
+	settingsScreenInterfaceSettings();
+}
 public function toggleMeasurements():void {
 	if (flags[kFLAGS.USE_METRICS] < 1) flags[kFLAGS.USE_METRICS] = 1;
 	else flags[kFLAGS.USE_METRICS] = 0;


### PR DESCRIPTION
### Gameplay changes
- If you hit the hotkey for quickload or quicksave, the game asks you to confirm this.
- The confirmation dialogs for Quicksave and Quickload can be toggled on and off.
 - Defaults to **ON** (enabled) for both dialogues
 - You'll find these two settings in **Main Menu → Settings → Interface**.
 - This is stored in the permanent save-file, thus making these settings global.

### Internal changes
- Added the classfile `Bindings.as` in order to relocate the copy&paste-mess in `ControlBindings.as` into function calls.
- Added two new flags:
```as3
public static const DISABLE_QUICKLOAD_CONFIRM:int = 1298; // Disable the confirmation-dialog on quickload
public static const DISABLE_QUICKSAVE_CONFIRM:int = 1299; // Disable the confirmation-dialog on quicksave
```

### Notes
- **Fixes issue #313: Quickload and especially quicksave is a little too quick for me**.
- If you're not in a game session, quickload obviously won't have a confirmation dialog.
- Testing done by me and @Darth-Cthoras.