### PR TITLE
Removed explored variables from `Player.as`

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -207,7 +207,6 @@
 			//Exploration
 			player.explored = 0;
 			player.exploredForest = 0;
-			player.exploredDesert = 0;
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] == 0) {
 				//Inventory clear
 				player.itemSlot1.unlocked = true;

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -206,7 +206,6 @@
 			player.beardStyle = 0;
 			//Exploration
 			player.explored = 0;
-			player.exploredForest = 0;
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] == 0) {
 				//Inventory clear
 				player.itemSlot1.unlocked = true;

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -209,7 +209,6 @@
 			player.exploredForest = 0;
 			player.exploredDesert = 0;
 			player.exploredMountain = 0;
-			player.exploredLake = 0;
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] == 0) {
 				//Inventory clear
 				player.itemSlot1.unlocked = true;

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -208,7 +208,6 @@
 			player.explored = 0;
 			player.exploredForest = 0;
 			player.exploredDesert = 0;
-			player.exploredMountain = 0;
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] == 0) {
 				//Inventory clear
 				player.itemSlot1.unlocked = true;

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -205,7 +205,6 @@
 			player.beardLength = 0;
 			player.beardStyle = 0;
 			//Exploration
-			player.explored = 0;
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] == 0) {
 				//Inventory clear
 				player.itemSlot1.unlocked = true;
@@ -392,7 +391,8 @@
 		private function chooseName():void {
 			if (mainView.nameBox.text == "") {
 				//If part of newgame+, don't fully wipe.
-				if (player.XP > 0 && player.explored == 0) {
+				// Isn't this redundant? This is covered in `newGameGo`.
+				if (player.XP > 0) {
 					flags[kFLAGS.NEW_GAME_PLUS_BONUS_STORED_XP] = player.XP;
 					if (flags[kFLAGS.NEW_GAME_PLUS_BONUS_STORED_XP] == 0) flags[kFLAGS.NEW_GAME_PLUS_BONUS_STORED_XP] = 1;
 					while (player.level > 1) {

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -2302,11 +2302,11 @@ public static const UNKNOWN_FLAG_NUMBER_02293:int                               
 public static const UNKNOWN_FLAG_NUMBER_02294:int                                   = 2294;
 public static const SANDWITCH_SERVICED:int                                          = 2295;	// Number of times, the player has serviced a sand witch.
 public static const JOJO_STATUS:int                                                 = 2296; // Replacement for `CoC.monk` variable.
-public static const TIMES_EXPLORED:int                                   			= 2297; // Replaces `player.explored`
-public static const TIMES_EXPLORED_FOREST:int                                   	= 2298; // Replaces `player.exploredForest`
-public static const TIMES_EXPLORED_DESERT:int                                   	= 2299; // Replaces `player.exploredDesert`
-public static const TIMES_EXPLORED_MOUNTAIN:int                                 	= 2300; // Replaces `player.exploredMountain`
-public static const TIMES_EXPLORED_LAKE:int                                   		= 2301; // Replaces `player.exploredLake`
+public static const TIMES_EXPLORED:int                                              = 2297; // Replaces `player.explored`
+public static const TIMES_EXPLORED_FOREST:int                                       = 2298; // Replaces `player.exploredForest`
+public static const TIMES_EXPLORED_DESERT:int                                       = 2299; // Replaces `player.exploredDesert`
+public static const TIMES_EXPLORED_MOUNTAIN:int                                     = 2300; // Replaces `player.exploredMountain`
+public static const TIMES_EXPLORED_LAKE:int                                         = 2301; // Replaces `player.exploredLake`
 public static const UNKNOWN_FLAG_NUMBER_02302:int                                   = 2302;
 public static const UNKNOWN_FLAG_NUMBER_02303:int                                   = 2303;
 public static const UNKNOWN_FLAG_NUMBER_02304:int                                   = 2304;

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -2302,11 +2302,11 @@ public static const UNKNOWN_FLAG_NUMBER_02293:int                               
 public static const UNKNOWN_FLAG_NUMBER_02294:int                                   = 2294;
 public static const SANDWITCH_SERVICED:int                                          = 2295;	// Number of times, the player has serviced a sand witch.
 public static const JOJO_STATUS:int                                                 = 2296; // Replacement for `CoC.monk` variable.
-public static const UNKNOWN_FLAG_NUMBER_02297:int                                   = 2297;
-public static const UNKNOWN_FLAG_NUMBER_02298:int                                   = 2298;
-public static const UNKNOWN_FLAG_NUMBER_02299:int                                   = 2299;
-public static const UNKNOWN_FLAG_NUMBER_02300:int                                   = 2300;
-public static const UNKNOWN_FLAG_NUMBER_02301:int                                   = 2301;
+public static const TIMES_EXPLORED:int                                   			= 2297; // Replaces `player.explored`
+public static const TIMES_EXPLORED_FOREST:int                                   	= 2298; // Replaces `player.exploredForest`
+public static const TIMES_EXPLORED_DESERT:int                                   	= 2299; // Replaces `player.exploredDesert`
+public static const TIMES_EXPLORED_MOUNTAIN:int                                 	= 2300; // Replaces `player.exploredMountain`
+public static const TIMES_EXPLORED_LAKE:int                                   		= 2301; // Replaces `player.exploredLake`
 public static const UNKNOWN_FLAG_NUMBER_02302:int                                   = 2302;
 public static const UNKNOWN_FLAG_NUMBER_02303:int                                   = 2303;
 public static const UNKNOWN_FLAG_NUMBER_02304:int                                   = 2304;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -78,7 +78,6 @@ use namespace kGAMECLASS;
 		public var tempInt:Number = 0;
 		//Number of times explored for new areas
 		public var explored:Number = 0;
-		public var exploredForest:Number = 0;
 
 		//Player pregnancy variables and functions
 		override public function pregnancyUpdate():Boolean {

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -76,8 +76,6 @@ use namespace kGAMECLASS;
 		public var tempTou:Number = 0;
 		public var tempSpe:Number = 0;
 		public var tempInt:Number = 0;
-		//Number of times explored for new areas
-		public var explored:Number = 0;
 
 		//Player pregnancy variables and functions
 		override public function pregnancyUpdate():Boolean {

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -80,7 +80,6 @@ use namespace kGAMECLASS;
 		public var explored:Number = 0;
 		public var exploredForest:Number = 0;
 		public var exploredDesert:Number = 0;
-		public var exploredMountain:Number = 0;
 
 		//Player pregnancy variables and functions
 		override public function pregnancyUpdate():Boolean {

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -79,7 +79,6 @@ use namespace kGAMECLASS;
 		//Number of times explored for new areas
 		public var explored:Number = 0;
 		public var exploredForest:Number = 0;
-		public var exploredDesert:Number = 0;
 
 		//Player pregnancy variables and functions
 		override public function pregnancyUpdate():Boolean {

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -81,7 +81,6 @@ use namespace kGAMECLASS;
 		public var exploredForest:Number = 0;
 		public var exploredDesert:Number = 0;
 		public var exploredMountain:Number = 0;
-		public var exploredLake:Number = 0;
 
 		//Player pregnancy variables and functions
 		override public function pregnancyUpdate():Boolean {

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1028,9 +1028,8 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.ass.analWetness = player.ass.analWetness;
 		saveFile.data.ass.analLooseness = player.ass.analLooseness;
 		saveFile.data.ass.fullness = player.ass.fullness;
-		//EXPLORED
-		saveFile.data.explored = player.explored;
-		saveFile.data.gameState = gameStateGet();
+
+		saveFile.data.gameState = gameStateGet(); // Saving game state?
 		
 		//Time and Items
 		saveFile.data.minutes = model.time.minutes;
@@ -2113,13 +2112,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		player.ass.analWetness = saveFile.data.ass.analWetness;
 		player.ass.fullness = saveFile.data.ass.fullness;
 		
-		//Shit
-		gameStateSet(saveFile.data.gameState);
-		flags[kFLAGS.TIMES_EXPLORED_LAKE]     = (flags[kFLAGS.TIMES_EXPLORED_LAKE] || saveFile.data.exploredLake);
-		flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] || saveFile.data.exploredMountain);
-		flags[kFLAGS.TIMES_EXPLORED_FOREST]   = (flags[kFLAGS.TIMES_EXPLORED_FOREST] || saveFile.data.exploredForest);
-		flags[kFLAGS.TIMES_EXPLORED_DESERT]   = (flags[kFLAGS.TIMES_EXPLORED_DESERT] || saveFile.data.exploredDesert);
-		player.explored = saveFile.data.explored;
+		gameStateSet(saveFile.data.gameState);  // Loading game state
 		
 		//Days
 		//Time and Items
@@ -2131,7 +2124,13 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		else
 			player.autoSave = saveFile.data.autoSave;
 		
-		//PLOTZ
+		// Fix possible old save for Plot & Exploration
+		flags[kFLAGS.TIMES_EXPLORED_LAKE]     = (flags[kFLAGS.TIMES_EXPLORED_LAKE] || saveFile.data.exploredLake);
+		flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] || saveFile.data.exploredMountain);
+		flags[kFLAGS.TIMES_EXPLORED_FOREST]   = (flags[kFLAGS.TIMES_EXPLORED_FOREST] || saveFile.data.exploredForest);
+		flags[kFLAGS.TIMES_EXPLORED_DESERT]   = (flags[kFLAGS.TIMES_EXPLORED_DESERT] || saveFile.data.exploredDesert);
+		flags[kFLAGS.TIMES_EXPLORED]          = (flags[kFLAGS.TIMES_EXPLORED] || saveFile.data.exploredDesert);
+ 
 		flags[kFLAGS.JOJO_STATUS]        = (flags[kFLAGS.JOJO_STATUS] || saveFile.data.monk);
 		flags[kFLAGS.SANDWITCH_SERVICED] = (flags[kFLAGS.SANDWITCH_SERVICED] || saveFile.data.sand);
 		flags[kFLAGS.GIACOMO_MET]        = (flags[kFLAGS.GIACOMO_MET] || saveFile.data.giacomo);

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1029,7 +1029,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.ass.analLooseness = player.ass.analLooseness;
 		saveFile.data.ass.fullness = player.ass.fullness;
 		//EXPLORED
-		saveFile.data.exploredLake = player.exploredLake;
 		saveFile.data.exploredMountain = player.exploredMountain;
 		saveFile.data.exploredForest = player.exploredForest;
 		saveFile.data.exploredDesert = player.exploredDesert;
@@ -2119,7 +2118,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		
 		//Shit
 		gameStateSet(saveFile.data.gameState);
-		player.exploredLake = saveFile.data.exploredLake;
+		flags[kFLAGS.TIMES_EXPLORED_LAKE] = (flags[kFLAGS.TIMES_EXPLORED_LAKE] || saveFile.data.exploredLake);
 		player.exploredMountain = saveFile.data.exploredMountain;
 		player.exploredForest = saveFile.data.exploredForest;
 		player.exploredDesert = saveFile.data.exploredDesert;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1029,7 +1029,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.ass.analLooseness = player.ass.analLooseness;
 		saveFile.data.ass.fullness = player.ass.fullness;
 		//EXPLORED
-		saveFile.data.exploredForest = player.exploredForest;
 		saveFile.data.explored = player.explored;
 		saveFile.data.gameState = gameStateGet();
 		
@@ -2118,7 +2117,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		gameStateSet(saveFile.data.gameState);
 		flags[kFLAGS.TIMES_EXPLORED_LAKE]     = (flags[kFLAGS.TIMES_EXPLORED_LAKE] || saveFile.data.exploredLake);
 		flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] || saveFile.data.exploredMountain);
-		player.exploredForest = saveFile.data.exploredForest;
+		flags[kFLAGS.TIMES_EXPLORED_FOREST]   = (flags[kFLAGS.TIMES_EXPLORED_FOREST] || saveFile.data.exploredForest);
 		flags[kFLAGS.TIMES_EXPLORED_DESERT]   = (flags[kFLAGS.TIMES_EXPLORED_DESERT] || saveFile.data.exploredDesert);
 		player.explored = saveFile.data.explored;
 		

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1030,7 +1030,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.ass.fullness = player.ass.fullness;
 		//EXPLORED
 		saveFile.data.exploredForest = player.exploredForest;
-		saveFile.data.exploredDesert = player.exploredDesert;
 		saveFile.data.explored = player.explored;
 		saveFile.data.gameState = gameStateGet();
 		
@@ -2120,7 +2119,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		flags[kFLAGS.TIMES_EXPLORED_LAKE]     = (flags[kFLAGS.TIMES_EXPLORED_LAKE] || saveFile.data.exploredLake);
 		flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] || saveFile.data.exploredMountain);
 		player.exploredForest = saveFile.data.exploredForest;
-		player.exploredDesert = saveFile.data.exploredDesert;
+		flags[kFLAGS.TIMES_EXPLORED_DESERT]   = (flags[kFLAGS.TIMES_EXPLORED_DESERT] || saveFile.data.exploredDesert);
 		player.explored = saveFile.data.explored;
 		
 		//Days

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1029,7 +1029,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.ass.analLooseness = player.ass.analLooseness;
 		saveFile.data.ass.fullness = player.ass.fullness;
 		//EXPLORED
-		saveFile.data.exploredMountain = player.exploredMountain;
 		saveFile.data.exploredForest = player.exploredForest;
 		saveFile.data.exploredDesert = player.exploredDesert;
 		saveFile.data.explored = player.explored;
@@ -2118,8 +2117,8 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		
 		//Shit
 		gameStateSet(saveFile.data.gameState);
-		flags[kFLAGS.TIMES_EXPLORED_LAKE] = (flags[kFLAGS.TIMES_EXPLORED_LAKE] || saveFile.data.exploredLake);
-		player.exploredMountain = saveFile.data.exploredMountain;
+		flags[kFLAGS.TIMES_EXPLORED_LAKE]     = (flags[kFLAGS.TIMES_EXPLORED_LAKE] || saveFile.data.exploredLake);
+		flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] || saveFile.data.exploredMountain);
 		player.exploredForest = saveFile.data.exploredForest;
 		player.exploredDesert = saveFile.data.exploredDesert;
 		player.explored = saveFile.data.explored;

--- a/classes/classes/Scenes/Areas/Desert.as
+++ b/classes/classes/Scenes/Areas/Desert.as
@@ -24,8 +24,8 @@ package classes.Scenes.Areas
 		//Explore desert
 		public function exploreDesert():void
 		{
-			player.exploredDesert++;
-			if ((player.level >= 4 || player.exploredDesert > 45) && player.exploredDesert % 15 == 0 && flags[kFLAGS.DISCOVERED_WITCH_DUNGEON] == 0) {
+			flags[kFLAGS.TIMES_EXPLORED_DESERT]++;
+			if ((player.level >= 4 || flags[kFLAGS.TIMES_EXPLORED_DESERT] > 45) && flags[kFLAGS.TIMES_EXPLORED_DESERT] % 15 == 0 && flags[kFLAGS.DISCOVERED_WITCH_DUNGEON] == 0) {
 				kGAMECLASS.dungeons.desertcave.enterDungeon();
 //				kGAMECLASS.inDungeon = true;
 //				kGAMECLASS.dungeonLoc = 23;
@@ -41,7 +41,7 @@ package classes.Scenes.Areas
 				kGAMECLASS.helScene.helSexualAmbush();
 				return;
 			}
-			if ((player.exploredDesert == 20 && player.findStatusEffect(StatusEffects.TelAdre) < 0) || (rand(20) == 0 && player.statusEffectv1(StatusEffects.TelAdre) == 0)) {
+			if ((flags[kFLAGS.TIMES_EXPLORED_DESERT] == 20 && player.findStatusEffect(StatusEffects.TelAdre) < 0) || (rand(20) == 0 && player.statusEffectv1(StatusEffects.TelAdre) == 0)) {
 				kGAMECLASS.telAdre.discoverTelAdre();
 				return;
 			}
@@ -51,7 +51,7 @@ package classes.Scenes.Areas
 				return;
 			}
 			//Ant colony debug chances
-			if (player.level >= 5 && flags[kFLAGS.ANT_WAIFU] == 0 && (player.exploredDesert % 8 == 0) && flags[kFLAGS.ANTS_PC_FAILED_PHYLLA] == 0 && flags[kFLAGS.ANT_COLONY_KEPT_HIDDEN] == 0) {
+			if (player.level >= 5 && flags[kFLAGS.ANT_WAIFU] == 0 && (flags[kFLAGS.TIMES_EXPLORED_DESERT] % 8 == 0) && flags[kFLAGS.ANTS_PC_FAILED_PHYLLA] == 0 && flags[kFLAGS.ANT_COLONY_KEPT_HIDDEN] == 0) {
 				antsScene.antColonyEncounter();
 				return;
 			}

--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -147,7 +147,7 @@ package classes.Scenes.Areas
 		{
 			clearOutput();
 			//Increment forest exploration counter.
-			player.exploredForest++;
+			flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
 
 			var choice:Array = [];
 			var select:int;
@@ -172,7 +172,7 @@ package classes.Scenes.Areas
 				return;
 			}
 			//Chance to discover deepwoods
-			if ((player.exploredForest >= 20) && player.findStatusEffect(StatusEffects.ExploredDeepwoods) < 0) {
+			if ((flags[kFLAGS.TIMES_EXPLORED_FOREST] >= 20) && player.findStatusEffect(StatusEffects.ExploredDeepwoods) < 0) {
 				player.createStatusEffect(StatusEffects.ExploredDeepwoods, 0, 0, 0, 0);
 				outputText("After exploring the forest so many times, you decide to really push it, and plunge deeper and deeper into the woods.  The further you go the darker it gets, but you courageously press on.  The plant-life changes too, and you spot more and more lichens and fungi, many of which are luminescent.  Finally, a wall of tree-trunks as wide as houses blocks your progress.  There is a knot-hole like opening in the center, and a small sign marking it as the entrance to the 'Deepwoods'.  You don't press on for now, but you could easily find your way back to explore the Deepwoods.\n\n<b>Deepwoods exploration unlocked!</b>", true);
 				doNext(camp.returnToCampUseOneHour);
@@ -191,7 +191,7 @@ package classes.Scenes.Areas
 				return;
 			}
 			//Marble randomness
-			if (player.exploredForest % 50 == 0 && player.exploredForest > 0 && player.findStatusEffect(StatusEffects.MarbleRapeAttempted) < 0 && player.findStatusEffect(StatusEffects.NoMoreMarble) < 0 && player.findStatusEffect(StatusEffects.Marble) >= 0 && flags[kFLAGS.MARBLE_WARNING] == 0) {
+			if (flags[kFLAGS.TIMES_EXPLORED_FOREST] % 50 == 0 && flags[kFLAGS.TIMES_EXPLORED_FOREST] > 0 && player.findStatusEffect(StatusEffects.MarbleRapeAttempted) < 0 && player.findStatusEffect(StatusEffects.NoMoreMarble) < 0 && player.findStatusEffect(StatusEffects.Marble) >= 0 && flags[kFLAGS.MARBLE_WARNING] == 0) {
 				//can be triggered one time after Marble has been met, but before the addiction quest starts.
 				clearOutput();
 				outputText("While you're moving through the trees, you suddenly hear yelling ahead, followed by a crash and a scream as an imp comes flying at high speed through the foliage and impacts a nearby tree.  The small demon slowly slides down the tree before landing at the base, still.  A moment later, a familiar-looking cow-girl steps through the bushes brandishing a huge two-handed hammer with an angry look on her face.");

--- a/classes/classes/Scenes/Areas/Lake.as
+++ b/classes/classes/Scenes/Areas/Lake.as
@@ -27,7 +27,7 @@ package classes.Scenes.Areas
 		public function exploreLake():void
 		{
 			//Increment exploration count
-			player.exploredLake++;
+			flags[kFLAGS.TIMES_EXPLORED_LAKE]++;
 			if (kGAMECLASS.aprilFools.poniesYN()) return;
 
 			//Helia monogamy fucks
@@ -35,7 +35,7 @@ package classes.Scenes.Areas
 				kGAMECLASS.helScene.helSexualAmbush();
 				return;
 			}
-			if (player.exploredLake % 20 == 0 || (flags[kFLAGS.HUNGER_ENABLED] > 0 && player.hunger < 10 && rand(5) == 0)) {
+			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] % 20 == 0 || (flags[kFLAGS.HUNGER_ENABLED] > 0 && player.hunger < 10 && rand(5) == 0)) {
 				calluScene.ottahGirl();
 				return;
 			}
@@ -71,7 +71,7 @@ package classes.Scenes.Areas
 			if (player.level >= 2)
 				choice[choice.length] = 4;
 			//Izma
-			if (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00230] > 0 && (player.exploredLake >= 10) && (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00233] == 0 || player.findStatusEffect(StatusEffects.Infested) < 0) && flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00238] <= 0)
+			if (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00230] > 0 && (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 10) && (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00233] == 0 || player.findStatusEffect(StatusEffects.Infested) < 0) && flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00238] <= 0)
 				choice[choice.length] = 5;
 			//Rathazul
 			if (player.findStatusEffect(StatusEffects.CampRathazul) < 0)

--- a/classes/classes/Scenes/Areas/Mountain.as
+++ b/classes/classes/Scenes/Areas/Mountain.as
@@ -27,7 +27,7 @@ package classes.Scenes.Areas
 		//Explore Mountain
 		public function exploreMountain():void
 		{
-			player.exploredMountain++;
+			flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]++;
 			var chooser:Number = rand(5);
 			if (chooser == 5 && player.level < 3 && model.time.days < 20) //Disable mimic if requirements not met (Can still be encountered in level 1 run)
 				chooser = rand(4);
@@ -37,7 +37,7 @@ package classes.Scenes.Areas
 				return;
 			}
 			//Discover 'high mountain' at level 5 or 40 explores of mountain
-			if ((player.level >= 5 || player.exploredMountain >= 40) && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] == 0) {
+			if ((player.level >= 5 || flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 40) && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] == 0) {
 				outputText("While exploring the mountain, you come across a relatively safe way to get at its higher reaches.  You judge that with this route you'll be able to get about two thirds of the way up the mountain.  With your newfound discovery fresh in your mind, you return to camp.\n\n(<b>High Mountain exploration location unlocked!</b>)", true);
 				flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN]++;
 				doNext(camp.returnToCampUseOneHour);
@@ -75,12 +75,12 @@ package classes.Scenes.Areas
 			}
 			//Rarer 'nice' Ceraph encounter
 			//Overlaps half the old encounters once pierced.
-			if (!kGAMECLASS.ceraphFollowerScene.ceraphIsFollower() && player.level > 2 && (player.exploredMountain % 30 == 0) && flags[kFLAGS.PC_FETISH] > 0) {
+			if (!kGAMECLASS.ceraphFollowerScene.ceraphIsFollower() && player.level > 2 && (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] % 30 == 0) && flags[kFLAGS.PC_FETISH] > 0) {
 				kGAMECLASS.ceraphScene.friendlyNeighborhoodSpiderManCeraph();
 				return;
 			}
 			//15% chance of Ceraph
-			if (!kGAMECLASS.ceraphFollowerScene.ceraphIsFollower() && player.level > 2 && (player.exploredMountain % 15 == 0) && flags[kFLAGS.PC_FETISH] != 1) {
+			if (!kGAMECLASS.ceraphFollowerScene.ceraphIsFollower() && player.level > 2 && (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] % 15 == 0) && flags[kFLAGS.PC_FETISH] != 1) {
 				kGAMECLASS.ceraphScene.encounterCeraph();
 				return;
 			}
@@ -104,8 +104,8 @@ package classes.Scenes.Areas
 			if (player.findPerk(PerkLib.MinotaurCumAddict) >= 0 && rand(10) == 0) {
 				chooser = 1;
 			}
-			//Every 15 explorations chance at mino bad-end!
-			if (player.exploredMountain % 16 == 0 && player.findPerk(PerkLib.MinotaurCumAddict) >= 0 && rand(3) == 0) {
+			//Every 16 explorations chance at mino bad-end!
+			if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] % 16 == 0 && player.findPerk(PerkLib.MinotaurCumAddict) >= 0 && rand(3) == 0) {
 				spriteSelect(44);
 				minotaurScene.minoAddictionBadEndEncounter();
 				return;

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2740,13 +2740,13 @@ private function updateAchievements():void {
 	if (flags[kFLAGS.LETHICE_DEFEATED] > 0) awardAchievement("Demon Slayer", kACHIEVEMENTS.STORY_FINALBOSS);
 	
 	//Zones
-	if (player.exploredForest > 0 && flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0 && player.exploredDesert > 0 && player.exploredMountain > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
+	if (player.exploredForest > 0 && flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0 && player.exploredDesert > 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
 	if (placesCount() >= 10) awardAchievement("Sightseer", kACHIEVEMENTS.ZONE_SIGHTSEER);
 	if (player.explored >= 1) awardAchievement("Where am I?", kACHIEVEMENTS.ZONE_WHERE_AM_I);
 	if (player.exploredDesert >= 100) awardAchievement("Dehydrated", kACHIEVEMENTS.ZONE_DEHYDRATED);
 	if (player.exploredForest >= 100) awardAchievement("Forest Ranger", kACHIEVEMENTS.ZONE_FOREST_RANGER);
 	if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 100) awardAchievement("Vacationer", kACHIEVEMENTS.ZONE_VACATIONER);
-	if (player.exploredMountain >= 100) awardAchievement("Mountaineer", kACHIEVEMENTS.ZONE_MOUNTAINEER);
+	if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 100) awardAchievement("Mountaineer", kACHIEVEMENTS.ZONE_MOUNTAINEER);
 	if (flags[kFLAGS.TIMES_EXPLORED_PLAINS] >= 100) awardAchievement("Rolling Hills", kACHIEVEMENTS.ZONE_ROLLING_HILLS);
 	if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] >= 100) awardAchievement("Wet All Over", kACHIEVEMENTS.ZONE_WET_ALL_OVER);
 	if (player.statusEffectv1(StatusEffects.ExploredDeepwoods) >= 100) awardAchievement("We Need to Go Deeper", kACHIEVEMENTS.ZONE_WE_NEED_TO_GO_DEEPER);

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2740,12 +2740,12 @@ private function updateAchievements():void {
 	if (flags[kFLAGS.LETHICE_DEFEATED] > 0) awardAchievement("Demon Slayer", kACHIEVEMENTS.STORY_FINALBOSS);
 	
 	//Zones
-	if (player.exploredForest > 0 && player.exploredLake > 0 && player.exploredDesert > 0 && player.exploredMountain > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
+	if (player.exploredForest > 0 && flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0 && player.exploredDesert > 0 && player.exploredMountain > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
 	if (placesCount() >= 10) awardAchievement("Sightseer", kACHIEVEMENTS.ZONE_SIGHTSEER);
 	if (player.explored >= 1) awardAchievement("Where am I?", kACHIEVEMENTS.ZONE_WHERE_AM_I);
 	if (player.exploredDesert >= 100) awardAchievement("Dehydrated", kACHIEVEMENTS.ZONE_DEHYDRATED);
 	if (player.exploredForest >= 100) awardAchievement("Forest Ranger", kACHIEVEMENTS.ZONE_FOREST_RANGER);
-	if (player.exploredLake >= 100) awardAchievement("Vacationer", kACHIEVEMENTS.ZONE_VACATIONER);
+	if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 100) awardAchievement("Vacationer", kACHIEVEMENTS.ZONE_VACATIONER);
 	if (player.exploredMountain >= 100) awardAchievement("Mountaineer", kACHIEVEMENTS.ZONE_MOUNTAINEER);
 	if (flags[kFLAGS.TIMES_EXPLORED_PLAINS] >= 100) awardAchievement("Rolling Hills", kACHIEVEMENTS.ZONE_ROLLING_HILLS);
 	if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] >= 100) awardAchievement("Wet All Over", kACHIEVEMENTS.ZONE_WET_ALL_OVER);

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2742,7 +2742,7 @@ private function updateAchievements():void {
 	//Zones
 	if (flags[kFLAGS.TIMES_EXPLORED_FOREST] > 0 && flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0 && flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
 	if (placesCount() >= 10) awardAchievement("Sightseer", kACHIEVEMENTS.ZONE_SIGHTSEER);
-	if (player.explored >= 1) awardAchievement("Where am I?", kACHIEVEMENTS.ZONE_WHERE_AM_I);
+	if (flags[kFLAGS.TIMES_EXPLORED] >= 1) awardAchievement("Where am I?", kACHIEVEMENTS.ZONE_WHERE_AM_I);
 	if (flags[kFLAGS.TIMES_EXPLORED_DESERT] >= 100) awardAchievement("Dehydrated", kACHIEVEMENTS.ZONE_DEHYDRATED);
 	if (flags[kFLAGS.TIMES_EXPLORED_FOREST] >= 100) awardAchievement("Forest Ranger", kACHIEVEMENTS.ZONE_FOREST_RANGER);
 	if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 100) awardAchievement("Vacationer", kACHIEVEMENTS.ZONE_VACATIONER);

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2740,11 +2740,11 @@ private function updateAchievements():void {
 	if (flags[kFLAGS.LETHICE_DEFEATED] > 0) awardAchievement("Demon Slayer", kACHIEVEMENTS.STORY_FINALBOSS);
 	
 	//Zones
-	if (player.exploredForest > 0 && flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0 && flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
+	if (flags[kFLAGS.TIMES_EXPLORED_FOREST] > 0 && flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0 && flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
 	if (placesCount() >= 10) awardAchievement("Sightseer", kACHIEVEMENTS.ZONE_SIGHTSEER);
 	if (player.explored >= 1) awardAchievement("Where am I?", kACHIEVEMENTS.ZONE_WHERE_AM_I);
 	if (flags[kFLAGS.TIMES_EXPLORED_DESERT] >= 100) awardAchievement("Dehydrated", kACHIEVEMENTS.ZONE_DEHYDRATED);
-	if (player.exploredForest >= 100) awardAchievement("Forest Ranger", kACHIEVEMENTS.ZONE_FOREST_RANGER);
+	if (flags[kFLAGS.TIMES_EXPLORED_FOREST] >= 100) awardAchievement("Forest Ranger", kACHIEVEMENTS.ZONE_FOREST_RANGER);
 	if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 100) awardAchievement("Vacationer", kACHIEVEMENTS.ZONE_VACATIONER);
 	if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 100) awardAchievement("Mountaineer", kACHIEVEMENTS.ZONE_MOUNTAINEER);
 	if (flags[kFLAGS.TIMES_EXPLORED_PLAINS] >= 100) awardAchievement("Rolling Hills", kACHIEVEMENTS.ZONE_ROLLING_HILLS);

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2740,10 +2740,10 @@ private function updateAchievements():void {
 	if (flags[kFLAGS.LETHICE_DEFEATED] > 0) awardAchievement("Demon Slayer", kACHIEVEMENTS.STORY_FINALBOSS);
 	
 	//Zones
-	if (player.exploredForest > 0 && flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0 && player.exploredDesert > 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
+	if (player.exploredForest > 0 && flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0 && flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
 	if (placesCount() >= 10) awardAchievement("Sightseer", kACHIEVEMENTS.ZONE_SIGHTSEER);
 	if (player.explored >= 1) awardAchievement("Where am I?", kACHIEVEMENTS.ZONE_WHERE_AM_I);
-	if (player.exploredDesert >= 100) awardAchievement("Dehydrated", kACHIEVEMENTS.ZONE_DEHYDRATED);
+	if (flags[kFLAGS.TIMES_EXPLORED_DESERT] >= 100) awardAchievement("Dehydrated", kACHIEVEMENTS.ZONE_DEHYDRATED);
 	if (player.exploredForest >= 100) awardAchievement("Forest Ranger", kACHIEVEMENTS.ZONE_FOREST_RANGER);
 	if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 100) awardAchievement("Vacationer", kACHIEVEMENTS.ZONE_VACATIONER);
 	if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 100) awardAchievement("Mountaineer", kACHIEVEMENTS.ZONE_MOUNTAINEER);

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -46,7 +46,7 @@ package classes.Scenes
 			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0) addButton(2, "Lake", kGAMECLASS.lake.exploreLake, null, null, null, "Visit the lake and explore the beach. \n\nRecommended level: 1" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_LAKE] : ""));
 			if (player.exploredDesert > 0) addButton(3, "Desert", kGAMECLASS.desert.exploreDesert, null, null, null, "Visit the dry desert. \n\nRecommended level: 2" + (debug ? "\n\nTimes explored: " + player.exploredDesert : ""));
 
-			if (player.exploredMountain > 0) addButton(5, "Mountain", kGAMECLASS.mountain.exploreMountain, null, null, null, "Visit the mountain. \n\nRecommended level: 5" + (debug ? "\n\nTimes explored: " + player.exploredMountain : ""));
+			if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0) addButton(5, "Mountain", kGAMECLASS.mountain.exploreMountain, null, null, null, "Visit the mountain. \n\nRecommended level: 5" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] : ""));
 			if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0) addButton(6, "Swamp", kGAMECLASS.swamp.exploreSwamp, null, null, null, "Visit the wet swamplands. \n\nRecommended level: 12" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_SWAMP] : ""));
 			if (flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0) addButton(7, "Plains", kGAMECLASS.plains.explorePlains, null, null, null, "Visit the plains. \n\nRecommended level: 10" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_PLAINS] : ""));
 			if (player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0) addButton(8, "Deepwoods", kGAMECLASS.forest.exploreDeepwoods, null, null, null, "Visit the dark, bioluminescent deepwoods. \n\nRecommended level: 5" + (debug ? "\n\nTimes explored: " + player.statusEffectv1(StatusEffects.ExploredDeepwoods) : ""));
@@ -244,14 +244,14 @@ package classes.Scenes
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
-				if (player.exploredDesert >= 1 && rand(3) == 0 && player.exploredMountain <= 0) {
+				if (player.exploredDesert >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] <= 0) {
 					outputText("Thunder booms overhead, shaking you out of your thoughts.  High above, dark clouds encircle a distant mountain peak.  You get an ominous feeling in your gut as you gaze up at it.\n\n<b>You've discovered the Mountain!</b>", true);
 					player.explored++;
-					player.exploredMountain = 1;
+					flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = 1;
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
-				if (player.exploredMountain >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] <= 0) {
+				if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] <= 0) {
 					flags[kFLAGS.TIMES_EXPLORED_PLAINS] = 1;
 					player.explored++;
 					outputText("You find yourself standing in knee-high grass, surrounded by flat plains on all sides.  Though the mountain, forest, and lake are all visible from here, they seem quite distant.\n\n<b>You've discovered the plains!</b>", true);

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -31,7 +31,7 @@ package classes.Scenes
 			} else if (player.explored == 1) {
 				outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You have discovered the Forest!</b>", true);
 				tryDiscover();
-				player.exploredForest++;
+				flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
 				return;
 			} else if (player.explored > 1) outputText("You can continue to search for new locations, or explore your previously discovered locations.", true);
 
@@ -42,7 +42,7 @@ package classes.Scenes
 			hideMenus();
 			menu();
 			addButton(0, "Explore", tryDiscover, null, null, null, "Explore to find new regions and visit any discovered regions.");
-			if (player.exploredForest > 0) addButton(1, "Forest", kGAMECLASS.forest.exploreForest, null, null, null, "Visit the lush forest. \n\nRecommended level: 1" + (player.level < 6 ? "\n\nBeware of Tentacle Beasts!" : "") + (debug ? "\n\nTimes explored: " + player.exploredForest : ""));
+			if (flags[kFLAGS.TIMES_EXPLORED_FOREST] > 0) addButton(1, "Forest", kGAMECLASS.forest.exploreForest, null, null, null, "Visit the lush forest. \n\nRecommended level: 1" + (player.level < 6 ? "\n\nBeware of Tentacle Beasts!" : "") + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_FOREST] : ""));
 			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0) addButton(2, "Lake", kGAMECLASS.lake.exploreLake, null, null, null, "Visit the lake and explore the beach. \n\nRecommended level: 1" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_LAKE] : ""));
 			if (flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0) addButton(3, "Desert", kGAMECLASS.desert.exploreDesert, null, null, null, "Visit the dry desert. \n\nRecommended level: 2" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_DESERT] : ""));
 
@@ -218,10 +218,10 @@ package classes.Scenes
 			}
 			if (player.explored > 1) {
 				
-				if (player.exploredForest <= 0) {
+				if (flags[kFLAGS.TIMES_EXPLORED_FOREST] <= 0) {
 					outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You've discovered the Forest!</b>", true);
-					player.exploredForest == 1;
-					player.exploredForest++;
+					flags[kFLAGS.TIMES_EXPLORED_FOREST] == 1;
+					flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -44,7 +44,7 @@ package classes.Scenes
 			addButton(0, "Explore", tryDiscover, null, null, null, "Explore to find new regions and visit any discovered regions.");
 			if (player.exploredForest > 0) addButton(1, "Forest", kGAMECLASS.forest.exploreForest, null, null, null, "Visit the lush forest. \n\nRecommended level: 1" + (player.level < 6 ? "\n\nBeware of Tentacle Beasts!" : "") + (debug ? "\n\nTimes explored: " + player.exploredForest : ""));
 			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0) addButton(2, "Lake", kGAMECLASS.lake.exploreLake, null, null, null, "Visit the lake and explore the beach. \n\nRecommended level: 1" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_LAKE] : ""));
-			if (player.exploredDesert > 0) addButton(3, "Desert", kGAMECLASS.desert.exploreDesert, null, null, null, "Visit the dry desert. \n\nRecommended level: 2" + (debug ? "\n\nTimes explored: " + player.exploredDesert : ""));
+			if (flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0) addButton(3, "Desert", kGAMECLASS.desert.exploreDesert, null, null, null, "Visit the dry desert. \n\nRecommended level: 2" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_DESERT] : ""));
 
 			if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0) addButton(5, "Mountain", kGAMECLASS.mountain.exploreMountain, null, null, null, "Visit the mountain. \n\nRecommended level: 5" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] : ""));
 			if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0) addButton(6, "Swamp", kGAMECLASS.swamp.exploreSwamp, null, null, null, "Visit the wet swamplands. \n\nRecommended level: 12" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_SWAMP] : ""));
@@ -232,19 +232,19 @@ package classes.Scenes
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
-				if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 1 && rand(3) == 0 && player.exploredDesert <= 0) {
+				if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_DESERT] <= 0) {
 					outputText("You stumble as the ground shifts a bit underneath you.  Groaning in frustration, you straighten up and discover the rough feeling of sand ", true);
 					if (player.lowerBody == LOWER_BODY_TYPE_HUMAN) outputText("inside your footwear, between your toes", false);
 					if (player.lowerBody == LOWER_BODY_TYPE_HOOFED) outputText("in your hooves", false);
 					if (player.lowerBody == LOWER_BODY_TYPE_DOG) outputText("in your paws", false);
 					if (player.lowerBody == LOWER_BODY_TYPE_NAGA) outputText("in your scales", false);
 					outputText(".\n\n<b>You've discovered the Desert!</b>", false);
-					player.exploredDesert = 1;
+					flags[kFLAGS.TIMES_EXPLORED_DESERT] = 1;
 					player.explored++;
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
-				if (player.exploredDesert >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] <= 0) {
+				if (flags[kFLAGS.TIMES_EXPLORED_DESERT] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] <= 0) {
 					outputText("Thunder booms overhead, shaking you out of your thoughts.  High above, dark clouds encircle a distant mountain peak.  You get an ominous feeling in your gut as you gaze up at it.\n\n<b>You've discovered the Mountain!</b>", true);
 					player.explored++;
 					flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = 1;

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -24,17 +24,24 @@ package classes.Scenes
 		//const BOG_EXPLORED:int = 1016;
 		public function doExplore():void
 		{
+			// Clear 
+			clearOutput();
+	
 			// Introductions to exploration //
 			if (flags[kFLAGS.TIMES_EXPLORED] <= 0) {
-				clearOutput();
 				outputText("You tentatively step away from your campsite, alert and scanning the ground and sky for danger.  You walk for the better part of an hour, marking the rocks you pass for a return trip to your camp.  It worries you that the portal has an opening on this side, and it was totally unguarded...\n\n...Wait a second, why is your campsite in front of you? The portal's glow is clearly visible from inside the tall rock formation.   Looking carefully you see your footprints leaving the opposite side of your camp, then disappearing.  You look back the way you came and see your markings vanish before your eyes.  The implications boggle your mind as you do your best to mull over them.  Distance, direction, and geography seem to have little meaning here, yet your campsite remains exactly as you left it.  A few things click into place as you realize you found your way back just as you were mentally picturing the portal!  Perhaps memory influences travel here, just like time, distance, and speed would in the real world!\n\nThis won't help at all with finding new places, but at least you can get back to camp quickly.  You are determined to stay focused the next time you explore and learn how to traverse this gods-forsaken realm.", true);
 				flags[kFLAGS.TIMES_EXPLORED]++;
+				doNext(camp.returnToCampUseOneHour);
+				return;
+			} else if (flags[kFLAGS.TIMES_EXPLORED_FOREST] <= 0) {
+				outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You have discovered the Forest!</b>", true);
+				flags[kFLAGS.TIMES_EXPLORED]++;
+				flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
 				doNext(camp.returnToCampUseOneHour);
 				return;
 			}
 
 			// Exploration Menu //
-			clearOutput();
 			outputText("You can continue to search for new locations, or explore your previously discovered locations.");
 
 			/*if (flags[kFLAGS.EXPLORATION_PAGE] == 2) {
@@ -218,11 +225,7 @@ package classes.Scenes
 			clearOutput();
 
 			flags[kFLAGS.TIMES_EXPLORED]++;
-			if (flags[kFLAGS.TIMES_EXPLORED_FOREST] <= 0) {
-				outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You have discovered the Forest!</b>", true);
-				flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
-				doNext(camp.returnToCampUseOneHour);
-			} else if (flags[kFLAGS.TIMES_EXPLORED_LAKE] <= 0) {
+			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] <= 0) {
 				// Discover Lake
 				flags[kFLAGS.TIMES_EXPLORED_LAKE] = 1;
 				outputText("Your wanderings take you far and wide across the barren wasteland that surrounds the portal, until the smell of humidity and fresh water alerts you to the nearby lake.  With a few quick strides you find a lake so massive the distant shore cannot be seen.  Grass and a few sparse trees grow all around it.\n\n<b>You've discovered the Lake!</b>");

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -211,118 +211,84 @@ package classes.Scenes
 		}
 		
 		//Try to find a new location - called from doExplore once the first location is found
-		public function tryDiscover():void
-		{
+		public function tryDiscover():void {
 
-			// kGAMECLASS.goblinAssassinScene.goblinAssassinEncounter();
-			// return;
-
-			if (flags[kFLAGS.PC_PROMISED_HEL_MONOGAMY_FUCKS] == 1 && flags[kFLAGS.HEL_RAPED_TODAY] == 0 && rand(10) == 0 && player.gender > 0 && !kGAMECLASS.helFollower.followerHel()) {
+			if (flags[kFLAGS.PC_PROMISED_HEL_MONOGAMY_FUCKS] == 1 && flags[kFLAGS.HEL_RAPED_TODAY] == 0 && rand(10) == 0 && (player.cocks.length > 0 || player.vaginas.length > 0) && !kGAMECLASS.helFollower.followerHel()) {
 				kGAMECLASS.helScene.helSexualAmbush();
 				return;
 			}
 
+			clearOutput();
+
 			flags[kFLAGS.TIMES_EXPLORED]++;
-			if (true) {  // TODO: Fix this method, and expecially this block.
-				
-				if (flags[kFLAGS.TIMES_EXPLORED_FOREST] <= 0) { // TODO: Remove this block
-					outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You've discovered the Forest!</b>", true);
-					flags[kFLAGS.TIMES_EXPLORED_FOREST] = 1;
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				if (flags[kFLAGS.TIMES_EXPLORED_LAKE] <= 0) {
-					outputText("Your wanderings take you far and wide across the barren wasteland that surrounds the portal, until the smell of humidity and fresh water alerts you to the nearby lake.  With a few quick strides you find a lake so massive the distant shore cannot be seen.  Grass and a few sparse trees grow all around it.\n\n<b>You've discovered the Lake!</b>", true);
-					flags[kFLAGS.TIMES_EXPLORED_LAKE] = 1;
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_DESERT] <= 0) {
-					outputText("You stumble as the ground shifts a bit underneath you.  Groaning in frustration, you straighten up and discover the rough feeling of sand ", true);
-					if (player.lowerBody == LOWER_BODY_TYPE_HUMAN) outputText("inside your footwear, between your toes", false);
-					if (player.lowerBody == LOWER_BODY_TYPE_HOOFED) outputText("in your hooves", false);
-					if (player.lowerBody == LOWER_BODY_TYPE_DOG) outputText("in your paws", false);
-					if (player.lowerBody == LOWER_BODY_TYPE_NAGA) outputText("in your scales", false);
-					outputText(".\n\n<b>You've discovered the Desert!</b>", false);
-					flags[kFLAGS.TIMES_EXPLORED_DESERT] = 1;
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				if (flags[kFLAGS.TIMES_EXPLORED_DESERT] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] <= 0) {
-					outputText("Thunder booms overhead, shaking you out of your thoughts.  High above, dark clouds encircle a distant mountain peak.  You get an ominous feeling in your gut as you gaze up at it.\n\n<b>You've discovered the Mountain!</b>", true);
-					flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = 1;
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] <= 0) {
-					flags[kFLAGS.TIMES_EXPLORED_PLAINS] = 1;
-					outputText("You find yourself standing in knee-high grass, surrounded by flat plains on all sides.  Though the mountain, forest, and lake are all visible from here, they seem quite distant.\n\n<b>You've discovered the plains!</b>", true);
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				//EXPLOOOOOOORE
-				if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] <= 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && rand(3) <= 0) {
-					flags[kFLAGS.TIMES_EXPLORED_SWAMP] = 1;
-					clearOutput();
-					outputText("All things considered, you decide you wouldn't mind a change of scenery.  Gathering up your belongings, you begin a journey into the wasteland.  The journey begins in high spirits, and you whistle a little traveling tune to pass the time.  After an hour of wandering, however, your wanderlust begins to whittle away.  Another half-hour ticks by.  Fed up with the fruitless exploration, you're nearly about to head back to camp when a faint light flits across your vision.  Startled, you whirl about to take in three luminous will-o'-the-wisps, swirling around each other whimsically.  As you watch, the three ghostly lights begin to move off, and though the thought of a trap crosses your mind, you decide to follow.\n\n", false);
-					outputText("Before long, you start to detect traces of change in the environment.  The most immediate difference is the increasingly sweltering heat.  A few minutes pass, then the will-o'-the-wisps plunge into the boundaries of a dark, murky, stagnant swamp; after a steadying breath you follow them into the bog.  Once within, however, the gaseous balls float off in different directions, causing you to lose track of them.  You sigh resignedly and retrace your steps, satisfied with your discovery.  Further exploration can wait.  For now, your camp is waiting.\n\n", false);
-					outputText("<b>You've discovered the Swamp!</b>", false);
-					doNext(camp.returnToCampUseTwoHours);
-					return;
-				}
-				//Discover Glacial Rift!
-				if (flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] <= 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && rand(4) <= 0 && (player.level >= 10 || model.time.days >= 60) ) {
-					flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] = 1;
-					clearOutput();
-					outputText("You walk for some time, roaming the hard-packed and pink-tinged earth of the demon-realm of Mareth. As you progress, a cool breeze suddenly brushes your cheek, steadily increasing in intensity and power until your clothes are whipping around your body in a frenzy. Every gust of wind seems to steal away part of your strength, the cool breeze having transformed into a veritable arctic gale. You wrap your arms around yourself tightly, shivering fiercely despite yourself as the hard pink dirt slowly turns to white; soon you’re crunching through actual snow, thick enough to make you stumble with every other step. You come to a stop suddenly as the ground before you gives way to a grand ocean, many parts of it frozen in great crystal islands larger than any city.\n\n", false);
-					outputText("<b>You've discovered the Glacial Rift!</b>", false);
-					doNext(camp.returnToCampUseTwoHours);
-					return;
-				}
-				//Discover Volcanic Crag!
-				if (flags[kFLAGS.DISCOVERED_VOLCANO_CRAG] <= 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && rand(4) <= 0 && (player.level >= 15 || model.time.days >= 90) ) {
-					flags[kFLAGS.DISCOVERED_VOLCANO_CRAG] = 1;
-					clearOutput();
-					outputText("You walk for some time, roaming the hard-packed and pink-tinged earth of the demon-realm of Mareth. As you progress, you can feel the air getting warm. It gets hotter as you progress until you finally stumble across a blackened landscape. You reward yourself with a sight of the endless series of a volcanic landscape. Crags dot the landscape.\n\n", false);
-					outputText("<b>You've discovered the Volcanic Crag!</b>", false);
-					doNext(camp.returnToCampUseTwoHours);
-					return;
-				}
-				//Used for chosing 'repeat' encounters.
-				var choosey:Number = rand(6);
-				//2 (gargoyle) is never chosen once cathedral is discovered.
-				if (choosey == 2 && flags[kFLAGS.FOUND_CATHEDRAL] == 1)
-				{
-					choosey = rand(5);
-					if (choosey >= 2) choosey++;
-				}
-				//Chance of encountering Giacomo!
+			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] <= 0) {
+				// Discover Lake
+				flags[kFLAGS.TIMES_EXPLORED_LAKE] = 1;
+				outputText("Your wanderings take you far and wide across the barren wasteland that surrounds the portal, until the smell of humidity and fresh water alerts you to the nearby lake.  With a few quick strides you find a lake so massive the distant shore cannot be seen.  Grass and a few sparse trees grow all around it.\n\n<b>You've discovered the Lake!</b>");
+				doNext(camp.returnToCampUseOneHour);
+			} else if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_DESERT] <= 0) {
+				// Discover Desert
+				flags[kFLAGS.TIMES_EXPLORED_DESERT] = 1;
+				outputText("You stumble as the ground shifts a bit underneath you.  Groaning in frustration, you straighten up and discover the rough feeling of sand ");
+				if      (player.lowerBody == LOWER_BODY_TYPE_HUMAN)   outputText("inside your footwear, between your toes");
+				else if (player.lowerBody == LOWER_BODY_TYPE_HOOFED)  outputText("in your hooves");
+				else if (player.lowerBody == LOWER_BODY_TYPE_DOG)     outputText("in your paws");
+				else if (player.lowerBody == LOWER_BODY_TYPE_NAGA)    outputText("in your scales");
+				outputText(".\n\n<b>You've discovered the Desert!</b>");
+				doNext(camp.returnToCampUseOneHour);
+			} else if (flags[kFLAGS.TIMES_EXPLORED_DESERT] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] <= 0) {
+				// Discover Mountain
+				flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = 1;
+				outputText("Thunder booms overhead, shaking you out of your thoughts.  High above, dark clouds encircle a distant mountain peak.  You get an ominous feeling in your gut as you gaze up at it.\n\n<b>You've discovered the Mountain!</b>");
+				doNext(camp.returnToCampUseOneHour);
+			} else if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] <= 0) {
+				// Discover Plains
+				flags[kFLAGS.TIMES_EXPLORED_PLAINS] = 1;
+				outputText("You find yourself standing in knee-high grass, surrounded by flat plains on all sides.  Though the mountain, forest, and lake are all visible from here, they seem quite distant.\n\n<b>You've discovered the plains!</b>");
+				doNext(camp.returnToCampUseOneHour);
+			} else if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] <= 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && rand(3) <= 0) {
+				// Discover Swamp
+				flags[kFLAGS.TIMES_EXPLORED_SWAMP] = 1;
+				outputText("All things considered, you decide you wouldn't mind a change of scenery.  Gathering up your belongings, you begin a journey into the wasteland.  The journey begins in high spirits, and you whistle a little traveling tune to pass the time.  After an hour of wandering, however, your wanderlust begins to whittle away.  Another half-hour ticks by.  Fed up with the fruitless exploration, you're nearly about to head back to camp when a faint light flits across your vision.  Startled, you whirl about to take in three luminous will-o'-the-wisps, swirling around each other whimsically.  As you watch, the three ghostly lights begin to move off, and though the thought of a trap crosses your mind, you decide to follow.\n\n");
+				outputText("Before long, you start to detect traces of change in the environment.  The most immediate difference is the increasingly sweltering heat.  A few minutes pass, then the will-o'-the-wisps plunge into the boundaries of a dark, murky, stagnant swamp; after a steadying breath you follow them into the bog.  Once within, however, the gaseous balls float off in different directions, causing you to lose track of them.  You sigh resignedly and retrace your steps, satisfied with your discovery.  Further exploration can wait.  For now, your camp is waiting.\n\n");
+				outputText("<b>You've discovered the Swamp!</b>");
+				doNext(camp.returnToCampUseTwoHours);
+			} else if (flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] <= 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && rand(4) <= 0 && (player.level >= 10 || model.time.days >= 60) ) {
+				// Discover Glacial Rift!
+				flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] = 1;
+				outputText("You walk for some time, roaming the hard-packed and pink-tinged earth of the demon-realm of Mareth. As you progress, a cool breeze suddenly brushes your cheek, steadily increasing in intensity and power until your clothes are whipping around your body in a frenzy. Every gust of wind seems to steal away part of your strength, the cool breeze having transformed into a veritable arctic gale. You wrap your arms around yourself tightly, shivering fiercely despite yourself as the hard pink dirt slowly turns to white; soon you’re crunching through actual snow, thick enough to make you stumble with every other step. You come to a stop suddenly as the ground before you gives way to a grand ocean, many parts of it frozen in great crystal islands larger than any city.\n\n");
+				outputText("<b>You've discovered the Glacial Rift!</b>");
+				doNext(camp.returnToCampUseTwoHours);
+			} else if (flags[kFLAGS.DISCOVERED_VOLCANO_CRAG] <= 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && rand(4) <= 0 && (player.level >= 15 || model.time.days >= 90) ) {
+				// Discover Volcanic Crag!
+				flags[kFLAGS.DISCOVERED_VOLCANO_CRAG] = 1;
+				outputText("You walk for some time, roaming the hard-packed and pink-tinged earth of the demon-realm of Mareth. As you progress, you can feel the air getting warm. It gets hotter as you progress until you finally stumble across a blackened landscape. You reward yourself with a sight of the endless series of a volcanic landscape. Crags dot the landscape.\n\n");
+				outputText("<b>You've discovered the Volcanic Crag!</b>");
+				doNext(camp.returnToCampUseTwoHours);
+			} else {
+				// Random Encounter
+
+				var choosey:Number = rand(5 + flags[kFLAGS.FOUND_CATHEDRAL]);
+				//5 (gargoyle) is never chosen once cathedral is discovered.
+
 				if (choosey == 0) {
 					kGAMECLASS.giacomoShop.giacomoEncounter();
-				}
-				else if (choosey == 1) {
+				} else if (choosey == 1) {
 					kGAMECLASS.lumi.lumiEncounter();
-				}
-				else if (choosey == 2) {
-					if (flags[kFLAGS.GAR_NAME] == 0) kGAMECLASS.gargoyle.gargoylesTheShowNowOnWBNetwork();
-					else kGAMECLASS.gargoyle.returnToCathedral();
-				}
-				else if (choosey == 3 && flags[kFLAGS.PRISON_CAPTURE_COUNTER] < 1 && rand(4) == 0) {
-					clearOutput();
+				} else if (choosey == 5) {
+					if   (flags[kFLAGS.GAR_NAME] == 0)  kGAMECLASS.gargoyle.gargoylesTheShowNowOnWBNetwork();
+					else                                kGAMECLASS.gargoyle.returnToCathedral();
+				} else if (choosey == 3 && flags[kFLAGS.PRISON_CAPTURE_COUNTER] < 1 && rand(4) == 0) {
 					outputText("Your curiosity draws you towards the smoke of a campfire on the edges of the forest. In the gloom ahead you see what appears to be a cage wagon surrounded by several tents, and hear the sounds of guttural voices engaged in boisterous conversation. Inexplicably you find yourself struck by an unwholesome sense of foreboding. <b>Even from here that cage looks like it is designed to carry people off to somewhere very unpleasant, some place where your life could be turned upside down and the rules you have become accustomed to in this world may no longer apply.</b> You take a long moment to consider turning back. Do you throw caution to the wind and investigate further?");
 					//outputText("\n\n(<b>NOTE:</b> Prisoner mod is currently under development and not all scenes are available.)");
 					doYesNo(kGAMECLASS.prison.goDirectlyToPrisonDoNotPassGoDoNotCollect200Gems, camp.returnToCampUseOneHour);
+				} else if (rand(100) < 99) {
+					genericGobImpEncounters(true); //Monster - 50/50 imp/gob split.
+				} else { //Easter egg!
+					outputText("You wander around, fruitlessly searching for new places.");
+					doNext(camp.returnToCampUseOneHour);
 				}
-				//Monster - 50/50 imp/gob split.
-				else if (rand(100) < 99) {
-					genericGobImpEncounters(true);
-				}
-				else { //Easter egg!
-					outputText("You wander around, fruitlessly searching for new places.", true);
-				}
-				return;
 			}
-			doNext(camp.returnToCampUseOneHour);
 		}
 
 

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -43,7 +43,7 @@ package classes.Scenes
 			menu();
 			addButton(0, "Explore", tryDiscover, null, null, null, "Explore to find new regions and visit any discovered regions.");
 			if (player.exploredForest > 0) addButton(1, "Forest", kGAMECLASS.forest.exploreForest, null, null, null, "Visit the lush forest. \n\nRecommended level: 1" + (player.level < 6 ? "\n\nBeware of Tentacle Beasts!" : "") + (debug ? "\n\nTimes explored: " + player.exploredForest : ""));
-			if (player.exploredLake > 0) addButton(2, "Lake", kGAMECLASS.lake.exploreLake, null, null, null, "Visit the lake and explore the beach. \n\nRecommended level: 1" + (debug ? "\n\nTimes explored: " + player.exploredLake : ""));
+			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0) addButton(2, "Lake", kGAMECLASS.lake.exploreLake, null, null, null, "Visit the lake and explore the beach. \n\nRecommended level: 1" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_LAKE] : ""));
 			if (player.exploredDesert > 0) addButton(3, "Desert", kGAMECLASS.desert.exploreDesert, null, null, null, "Visit the dry desert. \n\nRecommended level: 2" + (debug ? "\n\nTimes explored: " + player.exploredDesert : ""));
 
 			if (player.exploredMountain > 0) addButton(5, "Mountain", kGAMECLASS.mountain.exploreMountain, null, null, null, "Visit the mountain. \n\nRecommended level: 5" + (debug ? "\n\nTimes explored: " + player.exploredMountain : ""));
@@ -225,14 +225,14 @@ package classes.Scenes
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
-				if (player.exploredLake <= 0) {
+				if (flags[kFLAGS.TIMES_EXPLORED_LAKE] <= 0) {
 					outputText("Your wanderings take you far and wide across the barren wasteland that surrounds the portal, until the smell of humidity and fresh water alerts you to the nearby lake.  With a few quick strides you find a lake so massive the distant shore cannot be seen.  Grass and a few sparse trees grow all around it.\n\n<b>You've discovered the Lake!</b>", true);
-					player.exploredLake = 1;
+					flags[kFLAGS.TIMES_EXPLORED_LAKE] = 1;
 					player.explored++;
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
-				if (player.exploredLake >= 1 && rand(3) == 0 && player.exploredDesert <= 0) {
+				if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 1 && rand(3) == 0 && player.exploredDesert <= 0) {
 					outputText("You stumble as the ground shifts a bit underneath you.  Groaning in frustration, you straighten up and discover the rough feeling of sand ", true);
 					if (player.lowerBody == LOWER_BODY_TYPE_HUMAN) outputText("inside your footwear, between your toes", false);
 					if (player.lowerBody == LOWER_BODY_TYPE_HOOFED) outputText("in your hooves", false);

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -24,16 +24,21 @@ package classes.Scenes
 		//const BOG_EXPLORED:int = 1016;
 		public function doExplore():void
 		{
-			if (player.explored <= 0) {
+			// Introductions to exploration //
+			if (flags[kFLAGS.TIMES_EXPLORED] == 0) {
 				outputText("You tentatively step away from your campsite, alert and scanning the ground and sky for danger.  You walk for the better part of an hour, marking the rocks you pass for a return trip to your camp.  It worries you that the portal has an opening on this side, and it was totally unguarded...\n\n...Wait a second, why is your campsite in front of you? The portal's glow is clearly visible from inside the tall rock formation.   Looking carefully you see your footprints leaving the opposite side of your camp, then disappearing.  You look back the way you came and see your markings vanish before your eyes.  The implications boggle your mind as you do your best to mull over them.  Distance, direction, and geography seem to have little meaning here, yet your campsite remains exactly as you left it.  A few things click into place as you realize you found your way back just as you were mentally picturing the portal!  Perhaps memory influences travel here, just like time, distance, and speed would in the real world!\n\nThis won't help at all with finding new places, but at least you can get back to camp quickly.  You are determined to stay focused the next time you explore and learn how to traverse this gods-forsaken realm.", true);
-				tryDiscover();
+				flags[kFLAGS.TIMES_EXPLORED] = 1;
 				return;
-			} else if (player.explored == 1) {
+			} else if (flags[kFLAGS.TIMES_EXPLORED] == 1) {
 				outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You have discovered the Forest!</b>", true);
-				tryDiscover();
+				flags[kFLAGS.TIMES_EXPLORED] = 2;
 				flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
 				return;
-			} else if (player.explored > 1) outputText("You can continue to search for new locations, or explore your previously discovered locations.", true);
+			}
+
+			// Exploration Menu //
+			clearOutput();
+			outputText("You can continue to search for new locations, or explore your previously discovered locations.");
 
 			/*if (flags[kFLAGS.EXPLORATION_PAGE] == 2) {
 				explorePageII();
@@ -216,19 +221,19 @@ package classes.Scenes
 				kGAMECLASS.helScene.helSexualAmbush();
 				return;
 			}
-			if (player.explored > 1) {
+
+			flags[kFLAGS.TIMES_EXPLORED]++;
+			if (true) {  // TODO: Fix this method, and expecially this block.
 				
-				if (flags[kFLAGS.TIMES_EXPLORED_FOREST] <= 0) {
+				if (flags[kFLAGS.TIMES_EXPLORED_FOREST] <= 0) { // TODO: Remove this block
 					outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You've discovered the Forest!</b>", true);
-					flags[kFLAGS.TIMES_EXPLORED_FOREST] == 1;
-					flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
+					flags[kFLAGS.TIMES_EXPLORED_FOREST] = 1;
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
 				if (flags[kFLAGS.TIMES_EXPLORED_LAKE] <= 0) {
 					outputText("Your wanderings take you far and wide across the barren wasteland that surrounds the portal, until the smell of humidity and fresh water alerts you to the nearby lake.  With a few quick strides you find a lake so massive the distant shore cannot be seen.  Grass and a few sparse trees grow all around it.\n\n<b>You've discovered the Lake!</b>", true);
 					flags[kFLAGS.TIMES_EXPLORED_LAKE] = 1;
-					player.explored++;
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
@@ -240,20 +245,17 @@ package classes.Scenes
 					if (player.lowerBody == LOWER_BODY_TYPE_NAGA) outputText("in your scales", false);
 					outputText(".\n\n<b>You've discovered the Desert!</b>", false);
 					flags[kFLAGS.TIMES_EXPLORED_DESERT] = 1;
-					player.explored++;
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
 				if (flags[kFLAGS.TIMES_EXPLORED_DESERT] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] <= 0) {
 					outputText("Thunder booms overhead, shaking you out of your thoughts.  High above, dark clouds encircle a distant mountain peak.  You get an ominous feeling in your gut as you gaze up at it.\n\n<b>You've discovered the Mountain!</b>", true);
-					player.explored++;
 					flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = 1;
 					doNext(camp.returnToCampUseOneHour);
 					return;
 				}
 				if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] <= 0) {
 					flags[kFLAGS.TIMES_EXPLORED_PLAINS] = 1;
-					player.explored++;
 					outputText("You find yourself standing in knee-high grass, surrounded by flat plains on all sides.  Though the mountain, forest, and lake are all visible from here, they seem quite distant.\n\n<b>You've discovered the plains!</b>", true);
 					doNext(camp.returnToCampUseOneHour);
 					return;
@@ -261,7 +263,6 @@ package classes.Scenes
 				//EXPLOOOOOOORE
 				if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] <= 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && rand(3) <= 0) {
 					flags[kFLAGS.TIMES_EXPLORED_SWAMP] = 1;
-					player.explored++;
 					clearOutput();
 					outputText("All things considered, you decide you wouldn't mind a change of scenery.  Gathering up your belongings, you begin a journey into the wasteland.  The journey begins in high spirits, and you whistle a little traveling tune to pass the time.  After an hour of wandering, however, your wanderlust begins to whittle away.  Another half-hour ticks by.  Fed up with the fruitless exploration, you're nearly about to head back to camp when a faint light flits across your vision.  Startled, you whirl about to take in three luminous will-o'-the-wisps, swirling around each other whimsically.  As you watch, the three ghostly lights begin to move off, and though the thought of a trap crosses your mind, you decide to follow.\n\n", false);
 					outputText("Before long, you start to detect traces of change in the environment.  The most immediate difference is the increasingly sweltering heat.  A few minutes pass, then the will-o'-the-wisps plunge into the boundaries of a dark, murky, stagnant swamp; after a steadying breath you follow them into the bog.  Once within, however, the gaseous balls float off in different directions, causing you to lose track of them.  You sigh resignedly and retrace your steps, satisfied with your discovery.  Further exploration can wait.  For now, your camp is waiting.\n\n", false);
@@ -272,7 +273,6 @@ package classes.Scenes
 				//Discover Glacial Rift!
 				if (flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] <= 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && rand(4) <= 0 && (player.level >= 10 || model.time.days >= 60) ) {
 					flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] = 1;
-					player.explored++;
 					clearOutput();
 					outputText("You walk for some time, roaming the hard-packed and pink-tinged earth of the demon-realm of Mareth. As you progress, a cool breeze suddenly brushes your cheek, steadily increasing in intensity and power until your clothes are whipping around your body in a frenzy. Every gust of wind seems to steal away part of your strength, the cool breeze having transformed into a veritable arctic gale. You wrap your arms around yourself tightly, shivering fiercely despite yourself as the hard pink dirt slowly turns to white; soon you’re crunching through actual snow, thick enough to make you stumble with every other step. You come to a stop suddenly as the ground before you gives way to a grand ocean, many parts of it frozen in great crystal islands larger than any city.\n\n", false);
 					outputText("<b>You've discovered the Glacial Rift!</b>", false);
@@ -282,7 +282,6 @@ package classes.Scenes
 				//Discover Volcanic Crag!
 				if (flags[kFLAGS.DISCOVERED_VOLCANO_CRAG] <= 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && rand(4) <= 0 && (player.level >= 15 || model.time.days >= 90) ) {
 					flags[kFLAGS.DISCOVERED_VOLCANO_CRAG] = 1;
-					player.explored++;
 					clearOutput();
 					outputText("You walk for some time, roaming the hard-packed and pink-tinged earth of the demon-realm of Mareth. As you progress, you can feel the air getting warm. It gets hotter as you progress until you finally stumble across a blackened landscape. You reward yourself with a sight of the endless series of a volcanic landscape. Crags dot the landscape.\n\n", false);
 					outputText("<b>You've discovered the Volcanic Crag!</b>", false);
@@ -299,41 +298,30 @@ package classes.Scenes
 				}
 				//Chance of encountering Giacomo!
 				if (choosey == 0) {
-					player.explored++;
 					kGAMECLASS.giacomoShop.giacomoEncounter();
-					return;
 				}
 				else if (choosey == 1) {
-					player.explored++;
 					kGAMECLASS.lumi.lumiEncounter();
-					return;
 				}
 				else if (choosey == 2) {
-					player.explored++;
 					if (flags[kFLAGS.GAR_NAME] == 0) kGAMECLASS.gargoyle.gargoylesTheShowNowOnWBNetwork();
 					else kGAMECLASS.gargoyle.returnToCathedral();
-					return;
 				}
 				else if (choosey == 3 && flags[kFLAGS.PRISON_CAPTURE_COUNTER] < 1 && rand(4) == 0) {
-					player.explored++;
 					clearOutput();
 					outputText("Your curiosity draws you towards the smoke of a campfire on the edges of the forest. In the gloom ahead you see what appears to be a cage wagon surrounded by several tents, and hear the sounds of guttural voices engaged in boisterous conversation. Inexplicably you find yourself struck by an unwholesome sense of foreboding. <b>Even from here that cage looks like it is designed to carry people off to somewhere very unpleasant, some place where your life could be turned upside down and the rules you have become accustomed to in this world may no longer apply.</b> You take a long moment to consider turning back. Do you throw caution to the wind and investigate further?");
 					//outputText("\n\n(<b>NOTE:</b> Prisoner mod is currently under development and not all scenes are available.)");
 					doYesNo(kGAMECLASS.prison.goDirectlyToPrisonDoNotPassGoDoNotCollect200Gems, camp.returnToCampUseOneHour);
-					return;
 				}
 				//Monster - 50/50 imp/gob split.
 				else if (rand(100) < 99) {
-					player.explored++;
 					genericGobImpEncounters(true);
-					return;
 				}
 				else { //Easter egg!
 					outputText("You wander around, fruitlessly searching for new places.", true);
 				}
-				
+				return;
 			}
-			player.explored++;
 			doNext(camp.returnToCampUseOneHour);
 		}
 

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -25,14 +25,11 @@ package classes.Scenes
 		public function doExplore():void
 		{
 			// Introductions to exploration //
-			if (flags[kFLAGS.TIMES_EXPLORED] == 0) {
+			if (flags[kFLAGS.TIMES_EXPLORED] <= 0) {
+				clearOutput();
 				outputText("You tentatively step away from your campsite, alert and scanning the ground and sky for danger.  You walk for the better part of an hour, marking the rocks you pass for a return trip to your camp.  It worries you that the portal has an opening on this side, and it was totally unguarded...\n\n...Wait a second, why is your campsite in front of you? The portal's glow is clearly visible from inside the tall rock formation.   Looking carefully you see your footprints leaving the opposite side of your camp, then disappearing.  You look back the way you came and see your markings vanish before your eyes.  The implications boggle your mind as you do your best to mull over them.  Distance, direction, and geography seem to have little meaning here, yet your campsite remains exactly as you left it.  A few things click into place as you realize you found your way back just as you were mentally picturing the portal!  Perhaps memory influences travel here, just like time, distance, and speed would in the real world!\n\nThis won't help at all with finding new places, but at least you can get back to camp quickly.  You are determined to stay focused the next time you explore and learn how to traverse this gods-forsaken realm.", true);
-				flags[kFLAGS.TIMES_EXPLORED] = 1;
-				return;
-			} else if (flags[kFLAGS.TIMES_EXPLORED] == 1) {
-				outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You have discovered the Forest!</b>", true);
-				flags[kFLAGS.TIMES_EXPLORED] = 2;
-				flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
+				flags[kFLAGS.TIMES_EXPLORED]++;
+				doNext(camp.returnToCampUseOneHour);
 				return;
 			}
 
@@ -221,7 +218,11 @@ package classes.Scenes
 			clearOutput();
 
 			flags[kFLAGS.TIMES_EXPLORED]++;
-			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] <= 0) {
+			if (flags[kFLAGS.TIMES_EXPLORED_FOREST] <= 0) {
+				outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You have discovered the Forest!</b>", true);
+				flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
+				doNext(camp.returnToCampUseOneHour);
+			} else if (flags[kFLAGS.TIMES_EXPLORED_LAKE] <= 0) {
 				// Discover Lake
 				flags[kFLAGS.TIMES_EXPLORED_LAKE] = 1;
 				outputText("Your wanderings take you far and wide across the barren wasteland that surrounds the portal, until the smell of humidity and fresh water alerts you to the nearby lake.  With a few quick strides you find a lake so massive the distant shore cannot be seen.  Grass and a few sparse trees grow all around it.\n\n<b>You've discovered the Lake!</b>");

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -272,7 +272,7 @@ package classes.Scenes
 			} else {
 				// Random Encounter
 
-				var choosey:Number = rand(5 + flags[kFLAGS.FOUND_CATHEDRAL]);
+				var choosey:Number = rand(6 - flags[kFLAGS.FOUND_CATHEDRAL]);
 				//5 (gargoyle) is never chosen once cathedral is discovered.
 
 				if (choosey == 0) {

--- a/classes/classes/Scenes/Explore/Gargoyle.as
+++ b/classes/classes/Scenes/Explore/Gargoyle.as
@@ -32,7 +32,7 @@ public function gargoylesTheShowNowOnWBNetwork():void {
 	//(When using the “Explore” option; perhaps a 15-25% chance of discovery per go)
 	outputText("You set off in search of new horizons, setting off from camp in a completely new direction than you've ever tried before.  Away from the parts of Mareth you have thus far discovered, much of the world seems to be a barren wasteland");
 	//if Desert is discovered:
-	if (player.exploredDesert > 0) outputText(", making even the desert seem healthy and full of life");
+	if (flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0) outputText(", making even the desert seem healthy and full of life");
 	outputText(".  Your trip soon begins to seem unproductive, having found no new areas of Mareth or any contact with its inhabitants.  You sigh and turn back towards camp.");
 	
 	outputText("\n\nHowever, soon you catch the faintest glimpse of <b>something</b> in the distance!  Squinting, you shield your eyes from the sun and try to discern the strange glint on the horizon, but it's simply too far away.  Well, whatever it is, it certainly merits a check – it could be anything, perhaps a city, ");

--- a/classes/classes/Scenes/NPCs/SheilaScene.as
+++ b/classes/classes/Scenes/NPCs/SheilaScene.as
@@ -2742,7 +2742,7 @@ private function forcedSheilaOral(dick:Boolean = true):void {
 		//[(no horse)
 		if (!player.isTaur()) outputText("pinch her nipple for emphasis, then grind your hips across her face, mauling her nose with your ass.  \"<i>I could fuck a tree and it wouldn't be as wooden as you in the sack");
 		//[(PC has found corrupt glade)
-		if (player.exploredForest >= 40) outputText(" - in fact, there are quite a few I've seen who look like better lovers than you.  Maybe I should carry you to the forest and tie you to a nice pussy-shaped giant flower to give you lessons");
+		if (flags[kFLAGS.TIMES_EXPLORED_FOREST] >= 40) outputText(" - in fact, there are quite a few I've seen who look like better lovers than you.  Maybe I should carry you to the forest and tie you to a nice pussy-shaped giant flower to give you lessons");
 		outputText(".  ");
 		//[(minotaur addiction score =/= 0%)
 		if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] > 0 || player.findPerk(PerkLib.MinotaurCumAddict) >= 0) {


### PR DESCRIPTION
In an continued effort to remove plot related variables from where they shouldn't be, and generally standardize them, I've removed all the "explored" variables from `Player.as`, and replaced them with appropriate flags:

- `player.explored` replaced with `TIMES_EXPLORED`.
- `player.exploredForest` replaced with `TIMES_EXPLORED_FOREST`.
- `player.exploredDesert` replaced with `TIMES_EXPLORED_DESERT`.
- `player.exploredMountain` replaced with `TIMES_EXPLORED_MOUNTAIN`.
- `player.exploredLake` replaced with `TIMES_EXPLORED_LAKE`.

Logic for updating game save have been implemented.

This PL also includes some fixes to some broken logic in `Exploration.as` which became apparent during the work.