### PR TITLE
Reworked restoreArms() to use tfSource

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -514,7 +514,7 @@
 			}
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Restore arms to become human arms again
-			restoreArms();
+			if (rand(4) == 0) restoreArms(tfSource);
 			//+hooves
 			if (player.lowerBody != LOWER_BODY_TYPE_HOOFED) {
 				if (changes < changeLimit && rand(3) == 0) {
@@ -971,7 +971,7 @@
 			}
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Restore arms to become human arms again
-			restoreArms();
+			if (rand(4) == 0) restoreArms(tfSource);
 			//Remove feathery hair
 			removeFeatheryHair();
 			//
@@ -1686,7 +1686,7 @@
 			}
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Restore arms to become human arms again
-			restoreArms();
+			if (rand(4) == 0) restoreArms(tfSource);
 			//Remove feathery hair
 			removeFeatheryHair();
 			//if (type != 2 && type != 4 && type != 5) outputText("\n", false);
@@ -3663,7 +3663,7 @@
 			}
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Restore arms to become human arms again
-			restoreArms();
+			if (rand(4) == 0) restoreArms(tfSource);
 			//SEXYTIEMS
 			//Multidick killa!
 			if (player.cocks.length > 1 && rand(3) == 0 && changes < changeLimit) {
@@ -3890,7 +3890,7 @@
 					else if (blaht <= 8) player.skinTone = "cerulean";
 					else player.skinTone = "emerald";
 					outputText(player.skinTone + "!");
-					restoreArms(null, RESTOREARMS_FROMGOOSKINTF);
+					if (player.armType != ARM_TYPE_HUMAN || player.clawType != CLAW_TYPE_NORMAL) restoreArms(tfSource);
 				}
 				return;
 			}
@@ -4416,7 +4416,7 @@
 				changes++;
 			}
 			//Restore arms to become human arms again
-			restoreArms();
+			if (rand(4) == 0) restoreArms(tfSource);
 			//-----------------------
 			// MINOR TRANSFORMATIONS
 			//-----------------------
@@ -6444,7 +6444,7 @@
 				changes++;
 			}
 			//-Restore arms to become human arms again
-			restoreArms();
+			if (rand(4) == 0) restoreArms(tfSource);
 			//-Remove feathery hair
 			removeFeatheryHair();
 			//Remove odd eyes
@@ -8053,7 +8053,7 @@
 				changes++;
 			}
 			// Kitsunes should have normal arms. exspecially skinny arms with claws are somewhat weird (Stadler76).
-			if (player.skinType == SKIN_TYPE_PLAIN) restoreArms();
+			if (player.skinType == SKIN_TYPE_PLAIN && rand(4) == 0) restoreArms(tfSource);
 
 			if (changes == 0) {
 				outputText("\n\nOdd.  You don't feel any different.");

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -4412,6 +4412,7 @@
 				outputText(" falling to the ground, revealing flawless skin below.  <b>You now have normal skin.</b>", false);
 
 				player.skinType = SKIN_TYPE_PLAIN;
+				player.skinAdj = "";
 				player.skinDesc = "skin";
 				changes++;
 			}

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -14,9 +14,6 @@ package classes.Items
 		// I tend to use bitfields rather than lots of optional boolean params.
 		// If I consider a method to be finalized and has only one option I'll refactor this to use a boolean value.
 
-		// restoreArms options
-		public static const RESTOREARMS_FROMGOOSKINTF:int = 1;
-
 		// restoreLegs options
 		public static const RESTORELEGS_EXCLUDE_TAUR:int   =  1;
 		public static const RESTORELEGS_EXCLUDE_GOO:int    =  2;
@@ -29,12 +26,11 @@ package classes.Items
 
 		public function MutationsHelper() {}
 
-		public function restoreArms(keepArms:Array = null, options:int = 0):Boolean
+		public function restoreArms(tfSource:String):int
 		{
-			if (keepArms == null) keepArms = [];
-			if (keepArms.indexOf(player.armType) >= 0) return false; // For future TFs. Tested and working, but I'm not using it so far (Stadler76)
+			trace('called restoreArms("' + tfSource + '")');
 
-			if (options & RESTOREARMS_FROMGOOSKINTF) {
+			if (tfSource == "gooGasmic") {
 				// skin just turned gooey. Now lets fix unusual arms.
 				var hasClaws:Boolean = player.clawType != CLAW_TYPE_NORMAL;
 
@@ -49,11 +45,11 @@ package classes.Items
 
 				updateClaws();
 				player.armType = ARM_TYPE_HUMAN;
-				return true;
+				return 1;
 			}
 
 
-			if (changes < changeLimit && player.armType != ARM_TYPE_HUMAN && rand(4) == 0) {
+			if (changes < changeLimit && player.armType != ARM_TYPE_HUMAN) {
 				if ([ARM_TYPE_HARPY, ARM_TYPE_SPIDER, ARM_TYPE_SALAMANDER].indexOf(player.armType) >= 0)
 					outputText("\n\nYou scratch at your biceps absentmindedly, but no matter how much you scratch, it isn't getting rid of the itch.  Glancing down in irritation, you discover that");
 
@@ -93,10 +89,10 @@ package classes.Items
 				updateClaws();
 				player.armType = ARM_TYPE_HUMAN;
 				changes++;
-				return true;
+				return 1;
 			}
 
-			return false;
+			return 0;
 		}
 
 		public function restoreLegs(keepFeet:Array = null, options:int = 0):Boolean


### PR DESCRIPTION
### Gameplay fixes
- hummus now reverts your skinAdj, too. No more humans with 'slimy, light skin'
- in addition to that you won't show up as a goo-girl anymore after munching lots of hummus, since an all solid goo-girl is no goo-girl anymore IMHO.

### Internal changes
- `restoreArms(...)` now uses tfSource as a single, required parameter. My next victim will be `restoreLegs(...)`

### Notes
- The old version was implemented, before we had tfSource and calls to it looked too cluttered for me. Hence I reworked it.
- I've tested this with hummus and wet cloth among others. Eating hummus after TFing to a goo girl left me with 'slimy, [skintone] skin' and I doubt, that this was intended.
- The message states "[...], revealing flawless skin below **You now have normal skin.**" and slimy skin is neither flawless, nor normal by all means.
 - I didn't want to file a seperate PR just to add one single line to the codebase. Thats, why this change is included here.
- *TODO*: Rework `Player.gooScore()` in a seperate commit. Checking for skinAdj == 'slimy' is outdated, since we have `SKIN_TYPE_GOO`