### PR TITLE
Reworked restoreLegs() to use tfSource

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -4380,7 +4380,7 @@
 			// MAJOR TRANSFORMATIONS
 			//-----------------------
 			//1st priority: Change lower body to bipedal.
-			if (rand(4) == 0) restoreLegs(null, RESTORELEGS_FIX_BIPED);
+			if (rand(4) == 0 && changes < changeLimit) restoreLegs(tfSource);
 			//Remove Oviposition Perk
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Remove Incorporeality Perk
@@ -6808,7 +6808,7 @@
 				updateClaws();
 				changes++;
 			}
-			if (rand(4) == 0) restoreLegs(null, RESTORELEGS_EXCLUDE_DRIDER);
+			if (rand(4) == 0 && changes < changeLimit) restoreLegs(tfSource);
 			//Drider butt
 			if (type == 1 && player.findPerk(PerkLib.SpiderOvipositor) < 0 && player.isDrider() && player.tailType == TAIL_TYPE_SPIDER_ADBOMEN && changes < changeLimit && rand(3) == 0 && (player.hasVagina || rand(2) == 0)) {
 				outputText("\n\nAn odd swelling sensation floods your spider half.  Curling your abdomen underneath you for a better look, you gasp in recognition at your new 'equipment'!  Your semi-violent run-ins with the swamp's population have left you <i>intimately</i> familiar with the new appendage.  <b>It's a drider ovipositor!</b>  A few light prods confirm that it's just as sensitive as any of your other sexual organs.  You idly wonder what laying eggs with this thing will feel like...");

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -11,18 +11,8 @@ package classes.Items
 	{
 		include "../../../includes/appearanceDefs.as";
 
-		// I tend to use bitfields rather than lots of optional boolean params.
-		// If I consider a method to be finalized and has only one option I'll refactor this to use a boolean value.
-
 		// restoreArms options
 		public static const RESTOREARMS_FROMGOOSKINTF:int = 1;
-
-		// restoreLegs options
-		public static const RESTORELEGS_EXCLUDE_TAUR:int   =  1;
-		public static const RESTORELEGS_EXCLUDE_GOO:int    =  2;
-		public static const RESTORELEGS_EXCLUDE_NAGA:int   =  4;
-		public static const RESTORELEGS_EXCLUDE_DRIDER:int =  8;
-		public static const RESTORELEGS_FIX_BIPED:int      = 16;
 
 		public var changes:int = 0;
 		public var changeLimit:int = 1;
@@ -99,33 +89,33 @@ package classes.Items
 			return false;
 		}
 
-		public function restoreLegs(keepFeet:Array = null, options:int = 0):Boolean
+		public function restoreLegs(tfSource:String):Boolean
 		{
+			trace('called restoreLegs("' + tfSource + '")');
 			var doRestore:Boolean = false;
-			
-			if (keepFeet == null) keepFeet = [];
-			if (keepFeet.indexOf(player.lowerBody) >= 0) return false; // For future TFs
+			var tsParts:Array = tfSource.split("-");
+			tfSource = tsParts[0];
 
 			//(Centaurs -> Normal Human Legs)
-			if (!(options & RESTORELEGS_EXCLUDE_TAUR) && player.isTaur() && changes < changeLimit) {
+			if (player.isTaur()) {
 				outputText("\n\nYour quadrupedal hind-quarters seizes, overbalancing your surprised front-end and causing you to stagger and fall to your side.  Pain lances throughout, contorting your body into a tightly clenched ball of pain while tendons melt and bones break, melt, and regrow.  When it finally stops, <b>you look down to behold your new pair of human legs</b>!");
 				doRestore = true;
 			}
 
 			//(Goo -> Normal Human Legs)
-			if (!(options & RESTORELEGS_EXCLUDE_GOO) && player.isGoo() && changes < changeLimit) {
+			if (player.isGoo()) {
 				outputText("\n\nYour lower body rushes inward, molding into two leg-like shapes that gradually stiffen up.  In moments they solidify into normal-looking legs, complete with regular, human feet.  <b>You now have normal feet!</b>");
 				doRestore = true;
 			}
 
 			//(Naga -> Normal Human Legs)
-			if (!(options & RESTORELEGS_EXCLUDE_NAGA) && player.isNaga() && changes < changeLimit) {
+			if (player.isNaga()) {
 				outputText("\n\nYou collapse as your sinuous snake-tail tears in half, shifting into legs.  The pain is immense, particularly where your new feet are forming.  <b>You have human legs again.</b>");
 				doRestore = true;
 			}
 
 			//(Drider -> Normal Human Legs)
-			if (!(options & RESTORELEGS_EXCLUDE_DRIDER) && player.isDrider() && changes < changeLimit) {
+			if (tfSource != "sweetGossamer" && player.isDrider()) {
 				outputText("\n\nYour legs buckle under you and you fall, smashing your abdomen on the ground."
 				          +"  Though your control deserts and you cannot see behind you,"
 				          +" still you feel the disgusting sensation of chitin loosening and sloughing off your body,"
@@ -139,7 +129,7 @@ package classes.Items
 			}
 
 			//(Non-human -> Normal Human Legs)
-			if ((options & RESTORELEGS_FIX_BIPED) && player.isBiped() && player.lowerBody != LOWER_BODY_TYPE_HUMAN && changes < changeLimit) {
+			if (tfSource == "regularHummus" && player.isBiped() && player.lowerBody != LOWER_BODY_TYPE_HUMAN) {
 				outputText("\n\nYou collapse as your legs shift and twist.  By the time the pain subsides, you notice that you have normal legs and normal feet.  <b>You now have normal feet!</b>");
 				doRestore = true;
 			}


### PR DESCRIPTION
### Gameplay changes
None!

### Internal changes
Checks for changes < changeLimit were moved out of the method. Saves us from some unnecessary method-calls

### Notes
Same reasoning as for `MutationsHelper.restoreArms`: we have tfSource all over the codebase, so we should use it.