### PR TITLE
Relocated code to gain four draconic horns into MutationsHelper.as

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -5202,63 +5202,8 @@
 
 			//Physical changes:
 			//-Existing horns become draconic, max of 4, max length of 1'
-			if (player.hornType != HORNS_DRACONIC_X4_12_INCH_LONG && changes < changeLimit && rand(5) == 0) {
-				//No dragon horns yet.
-				if (player.hornType != HORNS_DRACONIC_X2 && player.hornType != HORNS_DRACONIC_X4_12_INCH_LONG) {
-					//Already have horns
-					if (player.horns > 0) {
-						//High quantity demon horns
-						if (player.hornType == HORNS_DEMON && player.horns > 4) {
-							outputText("\n\nYour horns condense, twisting around each other and merging into larger, pointed protrusions.  By the time they finish you have four draconic-looking horns, each about twelve inches long.", false);
-							player.horns = 12;
-							player.hornType = HORNS_DRACONIC_X4_12_INCH_LONG;
-						}
-						else {
-							outputText("\n\nYou feel your horns changing and warping, and reach back to touch them.  They have a slight curve and a gradual taper.  They must look something like the horns the dragons in your village's legends always had.", false);
-							player.hornType = HORNS_DRACONIC_X2;
-							if (player.horns > 13) {
-								outputText("  The change seems to have shrunken the horns, they're about a foot long now.", false);
-								player.horns = 12;
-							}
-
-						}
-						changes++;
-					}
-					//No horns
-					else {
-						//-If no horns, grow a pair
-						outputText("\n\nWith painful pressure, the skin on the sides of your forehead splits around two tiny nub-like horns.  They're angled back in such a way as to resemble those you saw on the dragons in your village's legends.  A few inches of horn sprout from your head before stopping.  <b>You have about four inches of dragon-like horn.</b>", false);
-						player.horns = 4;
-						player.hornType = HORNS_DRACONIC_X2;
-
-						changes++;
-					}
-				}
-				//ALREADY DRAGON
-				else {
-					if (player.hornType == HORNS_DRACONIC_X2) {
-						if (player.horns < 12) {
-							if (rand(2) == 0) {
-								outputText("\n\nYou get a headache as an inch of fresh horn escapes from your pounding skull.", false);
-								player.horns += 1;
-							}
-							else {
-								outputText("\n\nYour head aches as your horns grow a few inches longer.  They get even thicker about the base, giving you a menacing appearance.", false);
-								player.horns += 2 + rand(4);
-							}
-							if (player.horns >= 12) outputText("  <b>Your horns settle down quickly, as if they're reached their full size.</b>", false);
-							changes++;
-						}
-						//maxxed out, new row
-						else {
-							//--Next horn growth adds second row and brings length up to 12\"
-							outputText("\n\nA second row of horns erupts under the first, and though they are narrower, they grow nearly as long as your first row before they stop.  A sense of finality settles over you.  <b>You have as many horns as a lizan can grow.</b>", false);
-							player.hornType = HORNS_DRACONIC_X4_12_INCH_LONG;
-							changes++;
-						}
-					}
-				}
-			}
+			if (!player.hasDragonHorns(true) && changes < changeLimit && rand(5) == 0)
+				gainDraconicHorns(tfSource);
 			//-Hair stops growing!
 			if (flags[kFLAGS.HAIR_GROWTH_STOPPED_BECAUSE_LIZARD] == 0 && changes < changeLimit && rand(4) == 0) {
 				outputText("\n\nYour scalp tingles oddly.  In a panic, you reach up to your " + player.hairDescript() + ", but thankfully it appears unchanged.\n\n", false);

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -311,5 +311,74 @@ package classes.Items
 			return false;
 		}
 
+		public function gainDraconicHorns(tfSource:String):void
+		{
+			trace('called gainDraconicHorns("' + tfSource + '")');
+			var tsParts:Array = tfSource.split("-");
+			var race:String;
+
+			if (tsParts[0] == "emberTFs")
+				race = "dragon";
+			else if (tsParts[0] == "reptilum" && tsParts.length > 1)
+				race = tsParts[1];
+			else
+				throw new Error("Unimplemented tfSource: '" + tfSource + "' used in gainDraconicHorns!");
+
+			//No dragon horns yet.
+			if (player.hornType != HORNS_DRACONIC_X2 && player.hornType != HORNS_DRACONIC_X4_12_INCH_LONG) {
+				//Already have horns
+				if (player.horns > 0) {
+					//High quantity demon horns
+					if (player.hornType == HORNS_DEMON && player.horns > 4) {
+						outputText("\n\nYour horns condense, twisting around each other and merging into larger, pointed protrusions.  By the time they finish you have four draconic-looking horns, each about twelve inches long.");
+						player.horns = 12;
+						player.hornType = HORNS_DRACONIC_X4_12_INCH_LONG;
+					}
+					else {
+						outputText("\n\nYou feel your horns changing and warping, and reach back to touch them.  They have a slight curve and a gradual taper.  They must look something like the horns the dragons in your village's legends always had.");
+						player.hornType = HORNS_DRACONIC_X2;
+						if (player.horns > 13) {
+							outputText("  The change seems to have shrunken the horns, they're about a foot long now.");
+							player.horns = 12;
+						}
+
+					}
+					changes++;
+				}
+				//No horns
+				else {
+					//-If no horns, grow a pair
+					outputText("\n\nWith painful pressure, the skin on the sides of your forehead splits around two tiny nub-like horns.  They're angled back in such a way as to resemble those you saw on the dragons in your village's legends.  A few inches of horn sprout from your head before stopping.  <b>You have about four inches of dragon-like horn.</b>");
+					player.horns = 4;
+					player.hornType = HORNS_DRACONIC_X2;
+
+					changes++;
+				}
+			}
+			//ALREADY DRAGON
+			else {
+				if (player.hornType == HORNS_DRACONIC_X2) {
+					if (player.horns < 12) {
+						if (rand(2) == 0) {
+							outputText("\n\nYou get a headache as an inch of fresh horn escapes from your pounding skull.");
+							player.horns += 1;
+						}
+						else {
+							outputText("\n\nYour head aches as your horns grow a few inches longer.  They get even thicker about the base, giving you a menacing appearance.");
+							player.horns += 2 + rand(4);
+						}
+						if (player.horns >= 12) outputText("  <b>Your horns settle down quickly, as if they're reached their full size.</b>");
+						changes++;
+					}
+					//maxxed out, new row
+					else {
+						//--Next horn growth adds second row and brings length up to 12\"
+						outputText("\n\nA second row of horns erupts under the first, and though they are narrower, they grow nearly as long as your first row before they stop.  A sense of finality settles over you.  <b>You have as many horns as a " + race + " can grow.</b>");
+						player.hornType = HORNS_DRACONIC_X4_12_INCH_LONG;
+						changes++;
+					}
+				}
+			}
+		}
 	}
 }

--- a/classes/classes/PlayerHelper.as
+++ b/classes/classes/PlayerHelper.as
@@ -21,9 +21,9 @@ package classes
 			return skinType == SKIN_TYPE_FUR || hasScales();
 		}
 
-		public function hasDragonHorns():Boolean
+		public function hasDragonHorns(fourHorns:Boolean = false):Boolean
 		{
-			return (horns > 0 && hornType == HORNS_DRACONIC_X2) || hornType == HORNS_DRACONIC_X4_12_INCH_LONG;
+			return (!fourHorns && horns > 0 && hornType == HORNS_DRACONIC_X2) || hornType == HORNS_DRACONIC_X4_12_INCH_LONG;
 		}
 
 		public function hasReptileEyes():Boolean

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -1611,63 +1611,8 @@ package classes.Scenes.NPCs
 				changes++;
 			}
 			//-Existing horns become draconic, max of 4, max length of 1'
-			if (player.hornType != HORNS_DRACONIC_X4_12_INCH_LONG && changes < changeLimit && rand(5) == 0) {
-				//No dragon horns yet.
-				if (player.hornType != HORNS_DRACONIC_X2 && player.hornType != HORNS_DRACONIC_X4_12_INCH_LONG) {
-					//Already have horns
-					if (player.horns > 0) {
-						//High quantity demon horns
-						if (player.hornType == HORNS_DEMON && player.horns > 4) {
-							outputText("\n\nYour horns condense, twisting around each other and merging into larger, pointed protrusions.  By the time they finish you have four draconic-looking horns, each about twelve inches long.", false);
-							player.horns = 12;
-							player.hornType = HORNS_DRACONIC_X4_12_INCH_LONG;
-						}
-						else {
-							outputText("\n\nYou feel your horns changing and warping, and reach back to touch them.  They have a slight curve and a gradual taper.  They must look something like the horns the dragons in your village's legends always had.", false);
-							player.hornType = HORNS_DRACONIC_X2;
-							if (player.horns > 13) {
-								outputText("  The change seems to have shrunken the horns, they're about a foot long now.", false);
-								player.horns = 12;
-							}
-
-						}
-						changes++;
-					}
-					//No horns
-					else {
-						//-If no horns, grow a pair
-						outputText("\n\nWith painful pressure, the skin on the sides of your forehead splits around two tiny nub-like horns.  They're angled back in such a way as to resemble those you saw on the dragons in your village's legends.  A few inches of horn sprout from your head before stopping.  <b>You have about four inches of dragon-like horn.</b>", false);
-						player.horns = 4;
-						player.hornType = HORNS_DRACONIC_X2;
-
-						changes++;
-					}
-				}
-				//ALREADY DRAGON
-				else {
-					if (player.hornType == HORNS_DRACONIC_X2) {
-						if (player.horns < 12) {
-							if (rand(2) == 0) {
-								outputText("\n\nYou get a headache as an inch of fresh horn escapes from your pounding skull.", false);
-								player.horns += 1;
-							}
-							else {
-								outputText("\n\nYour head aches as your horns grow a few inches longer.  They get even thicker about the base, giving you a menacing appearance.", false);
-								player.horns += 2 + rand(4);
-							}
-							if (player.horns >= 12) outputText("  <b>Your horns settle down quickly, as if they're reached their full size.</b>", false);
-							changes++;
-						}
-						//maxxed out, new row
-						else {
-							//--Next horn growth adds second row and brings length up to 12\"
-							outputText("\n\nA second row of horns erupts under the first, and though they are narrower, they grow nearly as long as your first row before they stop.  A sense of finality settles over you.  <b>You have as many horns as a dragon can grow.</b>", false);
-							player.hornType = HORNS_DRACONIC_X4_12_INCH_LONG;
-							changes++;
-						}
-					}
-				}
-			}
+			if (!player.hasDragonHorns(true) && changes < changeLimit && rand(5) == 0)
+				mutations.gainDraconicHorns(tfSource);
 			//Gain Dragon Ears
 			if (changes < changeLimit && rand(3) == 0 && player.earType != EARS_DRAGON) {
 				player.earType = EARS_DRAGON;


### PR DESCRIPTION
Fixes issue #327

### Gameplay change
If you've gained 4 horns the text now shows the lizan subraces, too and not just lizan or dragon.

### Internal changes
- hasDragonicHorns now has a param you can set to true to check for four draconic horns only (defaults to false)
- added the Method `gainDraconicHorns(tfSource:String):void` to `MutationsHelper.as`

### Note
Exactly 57 lines were copied 1 by 1 from reptilum to emberTFs. Less copy&paste ftw :-)