### PR TITLE
Gills rework

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -357,8 +357,9 @@ package classes
 		//ArmType
 		public var armType:Number = ARM_TYPE_HUMAN;
 
-		//Gills
-		public var gills:Boolean = false;
+		//GillType
+		public var gillType:int = GILLS_NONE;
+		public function hasGills():Boolean { return gillType != GILLS_NONE; }
 
 		//Sexual Stuff		
 		//MALE STUFF

--- a/classes/classes/Items/Consumables/BeeHoney.as
+++ b/classes/classes/Items/Consumables/BeeHoney.as
@@ -231,11 +231,9 @@ package classes.Items.Consumables
 				player.wingType = CoC.WING_TYPE_NONE;
 				player.wingDesc = "";
 			}
-			if (Utils.rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.");
-				player.gills = false;
-				changes++;
-			}
+			//Remove gills!
+			if (Utils.rand(4) == 0 && player.hasGills() && changes < changeLimit) mutations.updateGills();
+
 			if (special) { //All the speical honey effects occur after any normal bee transformations (if the player wasn't a full bee morph)
 				//Cock growth multiplier.
 				var mult:int = 1.0;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -3941,6 +3941,7 @@
 		public function sharkTooth(type:Number,player:Player):void
 		{
 			var tfSource:String = "sharkTooth";
+			if (type == 1) tfSource += "-tigershark";
 			changes = 0;
 			changeLimit = 2;
 			if (rand(2) == 0) changeLimit++;
@@ -4037,7 +4038,7 @@
 				changes++;
 			}
 			//Remove odd eyes
-			if (changes < changeLimit && rand(5) == 0 && player.eyeType > EYES_HUMAN) {
+			if (changes < changeLimit && rand(5) == 0 && player.eyeType != EYES_HUMAN) {
 				if (player.eyeType == EYES_BLACK_EYES_SAND_TRAP) {
 					outputText("\n\nYou feel a twinge in your eyes and you blink.  It feels like black cataracts have just fallen away from you, and you know without needing to see your reflection that your eyes have gone back to looking human.");
 				}
@@ -4056,6 +4057,9 @@
 				else outputText("\n\nJets of pain shoot down your spine into your tail.  You feel the tail bulging out until it explodes into a large and flexible shark-tail.  You swish it about experimentally, and find it quite easy to control.", false);
 				player.tailType = TAIL_TYPE_SHARK;
 			}
+			//Gills TF
+			if (player.gillType != GILLS_FISH && player.tailType == TAIL_TYPE_SHARK && player.faceType == FACE_SHARK_TEETH && changes < changeLimit && rand(3) == 0)
+				updateGills(GILLS_FISH);
 			//Hair
 			if (player.hairColor != "silver" && rand(4) == 0 && changes < changeLimit) {
 				changes++;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -800,11 +800,9 @@
 				player.tailType = TAIL_TYPE_COW;
 				changes++;
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
+
 			if (changes < changeLimit && rand(4) == 0 && ((player.ass.analWetness > 0 && player.findPerk(PerkLib.MaraesGiftButtslut) < 0) || player.ass.analWetness > 1)) {
 				outputText("\n\nYou feel a tightening up in your colon and your [asshole] sucks into itself.  You feel sharp pain at first but that thankfully fades.  Your ass seems to have dried and tightened up.");
 				player.ass.analWetness--;
@@ -1300,11 +1298,9 @@
 				player.tailRecharge = 0;
 				changes++;
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
+
 			if (rand(3) == 0) outputText(player.modTone(60, 1), false);
 			//FAILSAFE CHANGE
 			if (changes == 0) {
@@ -2239,11 +2235,9 @@
 				player.tailType = TAIL_TYPE_DOG;
 				outputText("<b>You now have a dog-tail.</b>", false);
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
+
 			if (player.skinType == SKIN_TYPE_FUR && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nYou become more... solid.  Sinewy.  A memory comes unbidden from your youth of a grizzled wolf you encountered while hunting, covered in scars, yet still moving with an easy grace.  You imagine that must have felt something like this.", false);
 				dynStats("tou", 4, "sen", -3);
@@ -3467,11 +3461,9 @@
 					changes++;
 				}
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
+
 			//Increase the size of the player's ass (less likely then hips), if it is not already somewhat big
 			if (rand(2) == 0 && player.buttRating < 13 && changes < changeLimit) {
 				if (!tainted && player.buttRating < 8 || tainted) {
@@ -3776,11 +3768,9 @@
 				changes++;
 				player.earType = EARS_ELFIN;
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
+
 			//Nipples Turn Back:
 			if (player.findStatusEffect(StatusEffects.BlackNipples) >= 0 && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nSomething invisible brushes against your " + player.nippleDescript(0) + ", making you twitch.  Undoing your clothes, you take a look at your chest and find that your nipples have turned back to their natural flesh colour.");
@@ -4197,11 +4187,8 @@
 				player.legCount = 1;
 				changes++;
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
 
 			//9e) Penis
 			/*
@@ -4348,7 +4335,7 @@
 				player.breastRows[0].breastRating = 2;
 			}
 			else player.breastRows[0].breastRating = 0;
-			player.gills = false;
+			player.gillType = GILLS_NONE;
 			player.removeStatusEffect(StatusEffects.Uniball);
 			player.removeStatusEffect(StatusEffects.BlackNipples);
 			player.vaginaType(0);
@@ -4453,11 +4440,7 @@
 				changes++;
 			}
 			//Removes gills
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
 			//Nipples Turn Back:
 			if (player.findStatusEffect(StatusEffects.BlackNipples) >= 0 && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nSomething invisible brushes against your " + player.nippleDescript(0) + ", making you twitch.  Undoing your clothes, you take a look at your chest and find that your nipples have turned back to their natural flesh colour.");
@@ -4972,11 +4955,8 @@
 				player.faceType = FACE_CAT;
 				changes++;
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
 			//FAILSAFE CHANGE
 			if (changes == 0) {
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n", false);
@@ -5313,11 +5293,7 @@
 			//-Snake tongue
 			if (player.hasReptileFace() && rand(3) == 0) gainSnakeTongue();
 			//-Remove Gills
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
 			//<mod name="Reptile eyes" author="Stadler76">
 			//-Lizard eyes
 			if (!player.hasLizardEyes() && player.faceType == FACE_LIZARD && player.hasScales() && player.earType == EARS_LIZARD && changes < changeLimit && rand(4) == 0) {
@@ -5590,11 +5566,7 @@
 				changes++;
 			}
 			//Removing gills
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
 			//FAILSAFE CHANGE
 			if (changes == 0) {
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n", false);
@@ -5903,11 +5875,8 @@
 				player.tailType = TAIL_TYPE_RABBIT;
 				changes++;
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
 			//Bunny Breeder Perk?
 			//FAILSAAAAFE
 			if (changes == 0) {
@@ -6275,11 +6244,8 @@
 				player.earType = EARS_HUMAN;
 				changes++;
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
 			//SPECIAL:
 			//Harpy Womb – All eggs are automatically upgraded to large, requires legs + tail to be harpy.
 			if (player.findPerk(PerkLib.HarpyWomb) < 0 && player.lowerBody == LOWER_BODY_TYPE_HARPY && player.tailType == TAIL_TYPE_HARPY && rand(4) == 0 && changes < changeLimit) {
@@ -6527,11 +6493,8 @@
 				changes++;
 				//trigger effect: Your body reacts to the influx of nutrition, accelerating your pregnancy. Your belly bulges outward slightly.
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
 			if (changes == 0) {
 				outputText("\n\nIt did not seem to have any effects, but you do feel better rested.", false);
 				player.changeFatigue(-40);
@@ -6797,11 +6760,9 @@
 				player.legCount = 8;
 				changes++;
 			}
-			if (rand(4) == 0 && player.gills && changes < changeLimit) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin.", false);
-				player.gills = false;
-				changes++;
-			}
+			// Remove gills
+			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
+
 			if (changes == 0) {
 				outputText("\n\nThe sweet silk energizes you, leaving you feeling refreshed.", false);
 				player.changeFatigue(-33);
@@ -7159,7 +7120,7 @@
 				changes++;
 			}
 			//-hair morphs to anemone tentacles, retains color, hair shrinks back to med-short('shaggy') and stops growing, lengthening treatments don't work and goblins won't cut it, but more anemone items can lengthen it one level at a time
-			if (player.gills && player.hairType != 4 && changes < changeLimit && rand(5) == 0) {
+			if (player.gillType == GILLS_ANEMONE && player.hairType != 4 && changes < changeLimit && rand(5) == 0) {
 				outputText("\n\nYour balance slides way off, and you plop down on the ground as mass concentrates on your head.  Reaching up, you give a little shriek as you feel a disturbingly thick, squirming thing where your hair should be.  Pulling it down in front of your eyes, you notice it's still attached to your head; what's more, it's the same color as your hair used to be.  <b>You now have squirming tentacles in place of hair!</b>  As you gaze at it, a gentle heat starts to suffuse your hand.  The tentacles must be developing their characteristic stingers!  You quickly let go; you'll have to take care to keep them from rubbing on your skin at all hours.  On the other hand, they're quite short and you find you can now flex and extend them as you would any other muscle, so that shouldn't be too hard.  You settle on a daring, windswept look for now.", false);
 				player.hairType = 4;
 				player.hairLength = 5;
@@ -7174,11 +7135,8 @@
 				//appearance screen: replace 'hair' with 'tentacle-hair'
 			}
 			//-feathery gills sprout from chest and drape sensually over nipples (cumulative swimming power boost with fin, if swimming is implemented)
-			if (rand(5) == 0 && !player.gills && player.skinTone == "aphotic blue-black" && changes < changeLimit) {
-				outputText("\n\nYou feel a pressure in your lower esophageal region and pull your garments down to check the area.  <b>Before your eyes a pair of feathery gills start to push out of the center of your chest, just below your neckline, parting sideways and draping over your " + player.nippleDescript(0) + "s.</b>  They feel a bit uncomfortable in the open air at first, but soon a thin film of mucus covers them and you hardly notice anything at all.  You redress carefully.", false);
-				player.gills = true;
-				changes++;
-			}
+			if (rand(5) == 0 && player.gillType != GILLS_ANEMONE && player.skinTone == "aphotic blue-black" && changes < changeLimit)
+				updateGills(GILLS_ANEMONE);
 			//-[aphotic] skin tone (blue-black)
 			if (rand(5) == 0 && changes < changeLimit && player.skinTone != "aphotic blue-black") {
 				outputText("\n\nYou absently bite down on the last of the tentacle, then pull your hand away, wincing in pain.  How did you bite your finger so hard?  Looking down, the answer becomes obvious; <b>your hand, along with the rest of your skin, is now the same aphotic color as the dormant tentacle was!</b>", false);
@@ -9236,12 +9194,8 @@
 				changes++;
 			}
 			//If the PC has gills:
-			if (player.gills && rand(4) == 0 && changes < changeLimit)
-			{
-				outputText("\n\nYou grit your teeth as a stinging sensation arises in your gills.  Within moments, the sensation passes, and <b>your gills are gone!</b>");
-				player.gills = false;
-				changes++;
-			}
+			if (player.hasGills() && rand(4) == 0 && changes < changeLimit) updateGills();
+			//	outputText("\n\nYou grit your teeth as a stinging sensation arises in your gills.  Within moments, the sensation passes, and <b>your gills are gone!</b>");
 			//If the PC has tentacle hair:
 			if (player.hairType == HAIR_ANEMONE && rand(4) == 0 && changes < changeLimit)
 			{

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -211,6 +211,38 @@ package classes.Items
 			return oldClawTone;
 		}
 
+		public function updateGills(newGillType:int = GILLS_NONE):int
+		{
+			trace("Called updateGills(" + newGillType + ")");
+			var oldgillType:int = player.gillType;
+			if (player.gillType == newGillType) return 0; // no change
+
+			player.gillType = newGillType;
+			changes++;
+
+			// for now, we only have anemone gills on the chest
+			switch (newGillType) {
+				case GILLS_NONE:
+					output.text("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin."
+					           +" <b>You no longer have gills!</b>");
+					return -1; // Gills lost
+
+				case GILLS_ANEMONE:
+					output.text("\n\nYou feel a pressure in your lower esophageal region and pull your garments down to check the area."
+					           +"  <b>Before your eyes a pair of feathery gills start to push out of the center of your chest,"
+					           +" just below your neckline, parting sideways and draping over your " + player.nippleDescript(0) + "s.</b>"
+					           +"  They feel a bit uncomfortable in the open air at first, but soon a thin film of mucus covers them and you hardly"
+					           +" notice anything at all.  You redress carefully.");
+					return 1; // Gained gills or gillType changed
+
+				default:
+					player.gillType = oldgillType;
+					changes--;
+					trace("ERROR: Unimplemented new gillType (" + newGillType + ") used");
+					return 0; // failsafe, should hopefully never happen
+			}
+		}
+
 		/**
 		 * Updates the perk Oviposition depending on the class/method stored in tfSource, that called it.
 		 * @param	tfSource	The method- or classname plus additional info seperated by the '-'-character

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -211,69 +211,6 @@ package classes.Items
 			return oldClawTone;
 		}
 
-		public function updateGills(newGillType:int = GILLS_NONE):int
-		{
-			trace("Called updateGills(" + newGillType + ")");
-			var oldgillType:int = player.gillType;
-			if (player.gillType == newGillType) return 0; // no change
-
-			player.gillType = newGillType;
-			changes++;
-
-			// for now, we only have anemone gills on the chest
-			switch (newGillType) {
-				case GILLS_NONE:
-					if (oldgillType == GILLS_ANEMONE) {
-						output.text("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your"
-						           +" skin.");
-					} else { // losing fish gills
-						output.text("\n\nYou feel your gills tighten, the slits seeming to close all at once. As you let out a choked gasp your"
-						           +" gills shrink into nothingness, leaving only smooth skin behind. Seems you won't be able to stay in the water"
-						           +" quite so long anymore.");
-					}
-					output.text("  <b>You no longer have gills!</b>");
-					return -1; // Gills lost
-
-				case GILLS_ANEMONE:
-					if (oldgillType == GILLS_FISH) {
-						output.text("\n\nYou feel your gills tighten, the slits seeming to close all at once. As you let out a choked gasp your"
-						           +" gills shrink into nothingness, leaving only smooth skin behind. When you think it's over you feel something"
-						           +" emerge from under your neck, flowing down over your chest and brushing your nipples. You look in surprise as"
-						           +" your new feathery gills finish growing out, a film of mucus forming over them shoftly after.");
-					} else { // if no gills
-						output.text("\n\nYou feel a pressure in your lower esophageal region and pull your garments down to check the area."
-						           +" Before your eyes a pair of feathery gills start to push out of the center of your chest,"
-						           +" just below your neckline, parting sideways and draping over your " + player.nippleDescript(0) + "s."
-						           +" They feel a bit uncomfortable in the open air at first, but soon a thin film of mucus covers them and you"
-						           +" hardly notice anything at all. You redress carefully.");
-					}
-					output.text("\n\n<b>You now have feathery gills!</b>");
-					return 1; // Gained gills or gillType changed
-
-				case GILLS_FISH:
-					if (oldgillType == GILLS_ANEMONE) {
-						output.text("\n\nYou feel your gills tingle, a vague numbness registering across thier feathery exterior. You watch in awe as"
-						           +" your gill's feathery folds dry out and fall off like crisp autumn leaves. The slits of your gills then"
-						           +" rearrange themselves, becoming thinner and shorter, as they shift to the sides of your neck. They now close in"
-						           +" a way that makes them almost invisible. As you run a finger over your neck you feel little more than several"
-						           +" small raised lines where they meet your skin.");
-					} else { // if no gills
-						output.text("\n\nYou feel a sudden tingle on your neck. You reach up to it to feel, whats the source of it. When you touch"
-						           +" your neck, you feel that it begins to grow serveral narrow slits which slowly grow longer. After the changes"
-						           +" have stopped you quickly head to a nearby puddle to take a closer look at your neck. You realize,"
-						           +" that your neck has grown gills allowing you to breathe under water as if you were standing on land.");
-					}
-					output.text("\n\n<b>You now have fish like gills!</b>");
-					return 1; // Gained gills or gillType changed
-
-				default:
-					player.gillType = oldgillType;
-					changes--;
-					trace("ERROR: Unimplemented new gillType (" + newGillType + ") used");
-					return 0; // failsafe, should hopefully never happen
-			}
-		}
-
 		/**
 		 * Updates the perk Oviposition depending on the class/method stored in tfSource, that called it.
 		 * @param	tfSource	The method- or classname plus additional info seperated by the '-'-character
@@ -336,6 +273,69 @@ package classes.Items
 					}
 					player.removePerk(PerkLib.Oviposition);
 					return -1; // Lost it
+			}
+		}
+
+		public function updateGills(newGillType:int = GILLS_NONE):int
+		{
+			trace("Called updateGills(" + newGillType + ")");
+			var oldgillType:int = player.gillType;
+			if (player.gillType == newGillType) return 0; // no change
+
+			player.gillType = newGillType;
+			changes++;
+
+			// for now, we only have anemone gills on the chest
+			switch (newGillType) {
+				case GILLS_NONE:
+					if (oldgillType == GILLS_ANEMONE) {
+						output.text("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your"
+						           +" skin.");
+					} else { // losing fish gills
+						output.text("\n\nYou feel your gills tighten, the slits seeming to close all at once. As you let out a choked gasp your"
+						           +" gills shrink into nothingness, leaving only smooth skin behind. Seems you won't be able to stay in the water"
+						           +" quite so long anymore.");
+					}
+					output.text("  <b>You no longer have gills!</b>");
+					return -1; // Gills lost
+
+				case GILLS_ANEMONE:
+					if (oldgillType == GILLS_FISH) {
+						output.text("\n\nYou feel your gills tighten, the slits seeming to close all at once. As you let out a choked gasp your"
+						           +" gills shrink into nothingness, leaving only smooth skin behind. When you think it's over you feel something"
+						           +" emerge from under your neck, flowing down over your chest and brushing your nipples. You look in surprise as"
+						           +" your new feathery gills finish growing out, a film of mucus forming over them shoftly after.");
+					} else { // if no gills
+						output.text("\n\nYou feel a pressure in your lower esophageal region and pull your garments down to check the area."
+						           +" Before your eyes a pair of feathery gills start to push out of the center of your chest,"
+						           +" just below your neckline, parting sideways and draping over your " + player.nippleDescript(0) + "s."
+						           +" They feel a bit uncomfortable in the open air at first, but soon a thin film of mucus covers them and you"
+						           +" hardly notice anything at all. You redress carefully.");
+					}
+					output.text("\n\n<b>You now have feathery gills!</b>");
+					return 1; // Gained gills or gillType changed
+
+				case GILLS_FISH:
+					if (oldgillType == GILLS_ANEMONE) {
+						output.text("\n\nYou feel your gills tingle, a vague numbness registering across thier feathery exterior. You watch in awe as"
+						           +" your gill's feathery folds dry out and fall off like crisp autumn leaves. The slits of your gills then"
+						           +" rearrange themselves, becoming thinner and shorter, as they shift to the sides of your neck. They now close in"
+						           +" a way that makes them almost invisible. As you run a finger over your neck you feel little more than several"
+						           +" small raised lines where they meet your skin.");
+					} else { // if no gills
+						output.text("\n\nYou feel a sudden tingle on your neck. You reach up to it to feel, whats the source of it. When you touch"
+						           +" your neck, you feel that it begins to grow serveral narrow slits which slowly grow longer. After the changes"
+						           +" have stopped you quickly head to a nearby puddle to take a closer look at your neck. You realize,"
+						           +" that your neck has grown gills allowing you to breathe under water as if you were standing on land.");
+					}
+					output.text("\n\n<b>You now have fish like gills!</b>");
+					return 1; // Gained gills or gillType changed
+
+				default:
+					player.gillType = oldgillType;
+					changes--;
+					trace("ERROR: Unimplemented new gillType (" + newGillType + ") used");
+					return 0; // failsafe, should hopefully never happen
 			}
 		}
 

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -223,16 +223,47 @@ package classes.Items
 			// for now, we only have anemone gills on the chest
 			switch (newGillType) {
 				case GILLS_NONE:
-					output.text("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin."
-					           +" <b>You no longer have gills!</b>");
+					if (oldgillType == GILLS_ANEMONE) {
+						output.text("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your"
+						           +" skin.");
+					} else { // losing fish gills
+						output.text("\n\nYou feel your gills tighten, the slits seeming to close all at once. As you let out a choked gasp your"
+						           +" gills shrink into nothingness, leaving only smooth skin behind. Seems you won't be able to stay in the water"
+						           +" quite so long anymore.");
+					}
+					output.text("  <b>You no longer have gills!</b>");
 					return -1; // Gills lost
 
 				case GILLS_ANEMONE:
-					output.text("\n\nYou feel a pressure in your lower esophageal region and pull your garments down to check the area."
-					           +"  <b>Before your eyes a pair of feathery gills start to push out of the center of your chest,"
-					           +" just below your neckline, parting sideways and draping over your " + player.nippleDescript(0) + "s.</b>"
-					           +"  They feel a bit uncomfortable in the open air at first, but soon a thin film of mucus covers them and you hardly"
-					           +" notice anything at all.  You redress carefully.");
+					if (oldgillType == GILLS_FISH) {
+						output.text("\n\nYou feel your gills tighten, the slits seeming to close all at once. As you let out a choked gasp your"
+						           +" gills shrink into nothingness, leaving only smooth skin behind. When you think it's over you feel something"
+						           +" emerge from under your neck, flowing down over your chest and brushing your nipples. You look in surprise as"
+						           +" your new feathery gills finish growing out, a film of mucus forming over them shoftly after.");
+					} else { // if no gills
+						output.text("\n\nYou feel a pressure in your lower esophageal region and pull your garments down to check the area."
+						           +" Before your eyes a pair of feathery gills start to push out of the center of your chest,"
+						           +" just below your neckline, parting sideways and draping over your " + player.nippleDescript(0) + "s."
+						           +" They feel a bit uncomfortable in the open air at first, but soon a thin film of mucus covers them and you"
+						           +" hardly notice anything at all. You redress carefully.");
+					}
+					output.text("\n\n<b>You now have feathery gills!</b>");
+					return 1; // Gained gills or gillType changed
+
+				case GILLS_FISH:
+					if (oldgillType == GILLS_ANEMONE) {
+						output.text("\n\nYou feel your gills tingle, a vague numbness registering across thier feathery exterior. You watch in awe as"
+						           +" your gill's feathery folds dry out and fall off like crisp autumn leaves. The slits of your gills then"
+						           +" rearrange themselves, becoming thinner and shorter, as they shift to the sides of your neck. They now close in"
+						           +" a way that makes them almost invisible. As you run a finger over your neck you feel little more than several"
+						           +" small raised lines where they meet your skin.");
+					} else { // if no gills
+						output.text("\n\nYou feel a sudden tingle on your neck. You reach up to it to feel, whats the source of it. When you touch"
+						           +" your neck, you feel that it begins to grow serveral narrow slits which slowly grow longer. After the changes"
+						           +" have stopped you quickly head to a nearby puddle to take a closer look at your neck. You realize,"
+						           +" that your neck has grown gills allowing you to breathe under water as if you were standing on land.");
+					}
+					output.text("\n\n<b>You now have fish like gills!</b>");
 					return 1; // Gained gills or gillType changed
 
 				default:

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -965,7 +965,7 @@ package classes
 				outputText("\n", false);
 			}
 			outputText("\n", false);
-			if (player.gills) 
+			if (player.gillType == GILLS_ANEMONE) 
 				outputText("A pair of feathery gills are growing out just below your neck, spreading out horizontally and draping down your chest.  They allow you to stay in the water for quite a long time.  ", false);
 			//Chesticles..I mean bewbz.
 			if (player.breastRows.length == 1) 

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -370,6 +370,12 @@ package classes
 				else if (player.earType == EARS_DEER) 
 					outputText("  The " + player.hairDescript() + " on your head parts around a pair of deer-like ears that grow up from your head.", false);
 				//</mod>
+				if (player.gillType == GILLS_FISH) 
+				{
+					output.text("  A set of fish like gills reside on your neck, several small slits that can close flat against your skin."
+					           +" They allow you to stay in the water for quite a long time.");
+				}
+				// GILLS_ANEMONE are handled below
 				if (player.antennae == ANTENNAE_BEE) 
 				{
 					if (player.earType == EARS_BUNNY) 

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -835,7 +835,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.furColor = player.furColor;
 		saveFile.data.hairColor = player.hairColor;
 		saveFile.data.hairType = player.hairType;
-		saveFile.data.gills = player.gills;
+		saveFile.data.gillType = player.gillType;
 		saveFile.data.armType = player.armType;
 		saveFile.data.hairLength = player.hairLength;
 		saveFile.data.beardLength = player.beardLength;
@@ -1624,10 +1624,12 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			player.hairType = 0;
 		else
 			player.hairType = saveFile.data.hairType;
-		if (saveFile.data.gills == undefined)
-			player.gills = false;
+		if (saveFile.data.gillType != undefined)
+			player.gillType = saveFile.data.gillType;
+		else if (saveFile.data.gills == undefined)
+			player.gillType = GILLS_NONE;
 		else
-			player.gills = saveFile.data.gills;
+			player.gillType = saveFile.data.gills ? GILLS_ANEMONE : GILLS_NONE;
 		if (saveFile.data.armType == undefined)
 			player.armType = ARM_TYPE_HUMAN;
 		else

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -1685,11 +1685,7 @@ package classes.Scenes.Places.Bazaar
 				changes++;
 			}
 			//Remove gills
-			if (rand(4) == 0 && changes < changeLimit && player.gills) {
-				outputText("\n\nYour chest itches, and as you reach up to scratch it, you realize your gills have withdrawn into your skin. <b>You no longer have gills!</b>");
-				player.gills = false;
-				changes++;
-			}
+			if (rand(4) == 0 && changes < changeLimit && player.hasGills()) mutations.updateGills();
 			// Rhino TFs
 			//------------
 			//Change a cock to rhino.
@@ -1867,11 +1863,9 @@ package classes.Scenes.Places.Bazaar
 				player.armType = ARM_TYPE_HUMAN;
 				changes++;
 			}
-			if (rand(3) == 0 && changes < changeLimit && player.gills) {
-				outputText("\n\nYou grit your teeth as a stinging sensation arises in your gills. Within moments, the sensation passes, <b>and your gills are gone!</b>");
-				player.gills = false;
-				changes++;
-			}
+			//Remove gills
+			if (rand(3) == 0 && changes < changeLimit && player.hasGills()) mutations.updateGills();
+
 			if (rand(3) == 0 && changes < changeLimit && player.eyeType == EYES_FOUR_SPIDER_EYES) {
 				outputText("\n\nYour two forehead eyes start throbbing painfully, your sight in them eventually going dark. You touch your forehead to inspect your eyes, only to find out that they have disappeared. <b>You only have two eyes now!</b>");
 				player.eyeType == EYES_HUMAN;

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -111,7 +111,7 @@ public static const ANTENNAE_BEE:int                                            
 // gillType
 public static const GILLS_NONE:int                                                  =   0;
 public static const GILLS_ANEMONE:int                                               =   1;
-public static const GILLS_FISH:int                                                  =   2; // NYI: For upcoming races
+public static const GILLS_FISH:int                                                  =   2;
 
 // armType
 public static const ARM_TYPE_HUMAN:int                                              =   0;

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -108,6 +108,11 @@ public static const HORNS_RHINO:int                                             
 public static const ANTENNAE_NONE:int                                               =   0;
 public static const ANTENNAE_BEE:int                                                =   2;
 
+// gillType
+public static const GILLS_NONE:int                                                  =   0;
+public static const GILLS_ANEMONE:int                                               =   1;
+public static const GILLS_FISH:int                                                  =   2; // NYI: For upcoming races
+
 // armType
 public static const ARM_TYPE_HUMAN:int                                              =   0;
 public static const ARM_TYPE_HARPY:int                                              =   1;


### PR DESCRIPTION
### Gameplay changes
- Shark-morphs now gain fish gills

### Internal changes
- Deprecated `Creature.gills` in favor of `Creature.gillType`
- Implemented `Creature.gillType` and `Creature.hasGills()`
- Added the new Method `MutationsHelper.updateGills(newGillType:int = GILLS_NONE):int`
- Saving and loading tested and working for `player.gillType`

### Notes
- Player.gills limited us to one gill type (anemone gills), but fishes have different gills. The new gillType allows us to have different gills e. g. for shark-morphs.
- Thanks again to MissBlackthorne for providing texts for the fish gills and the transitions between both of them.
- Code snippet for the new body part constants:
```as3
// gillType
public static const GILLS_NONE:int                                                  =   0;
public static const GILLS_ANEMONE:int                                               =   1;
public static const GILLS_FISH:int                                                  =   2;
```