### PR TITLE
Basilisk eyes phase 3 (Allow to petrify Imps instead of just killing them)

### DIFF
--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -1308,8 +1308,8 @@ public static const DISABLE_QUICKSAVE_CONFIRM:int                               
 public static const BENOIT_EYES_TALK_UNLOCKED:int                                   = 1300; // Player has talked to Benoit(e) about basilisk eyes
 public static const BENOIT_BASIL_EYES_GRANTED:int                                   = 1301; // Counter to keep track, how often you gained them
 public static const BENOIT_HAIRPIN_TALKED_TODAY:int                                 = 1302; // Talked to Benoit(e) about the hairpin today
-public static const UNKNOWN_FLAG_NUMBER_01303:int                                   = 1303;
-public static const UNKNOWN_FLAG_NUMBER_01304:int                                   = 1304;
+public static const IMPS_PETRIFIED:int                                              = 1303; // Total imps petrified
+public static const CAMP_WALL_STATUES:int                                           = 1304; // Total imp statues at camp wall
 public static const UNKNOWN_FLAG_NUMBER_01305:int                                   = 1305;
 public static const UNKNOWN_FLAG_NUMBER_01306:int                                   = 1306;
 public static const UNKNOWN_FLAG_NUMBER_01307:int                                   = 1307;

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -220,10 +220,12 @@ package classes {
 			if (flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] >= 100 && player.findPerk(PerkLib.BasiliskResistance) < 0) {
 				outputText("\nYou notice that you feel a bit stiff and your skin is a bit harder.  Something clicks in your mind as you finally unlock the potential to protect yourself from the goddamn basilisks! \n\n(<b>Gained Perk: Basilisk Resistance - Your maximum speed is permanently decreased but you are now immune to the basilisk's gaze!</b>)\n");
 				player.createPerk(PerkLib.BasiliskResistance, 0, 0, 0, 0);
+				needNext = true;
 			}
 			if (flags[kFLAGS.TIMES_TRANSFORMED] >= 100 && player.findPerk(PerkLib.TransformationResistance) < 0) {
 				outputText("\nYou feel a strange tingling sensation. It seems as if you've finally adapted to the transformative properties of the food in Mareth and your body has finally built up enough resistance! You suspect that you can still transform but at somewhat diminished rate. \n\n(<b>Gained Perk: Transformation Resistance - Transformative items now have less chance to transform you. In addition, any Bad Ends related to overdose of certain transformative items are now disabled.</b>)\n");
 				player.createPerk(PerkLib.TransformationResistance, 0, 0, 0, 0);
+				needNext = true;
 			}
 			if ((player.findPerk(PerkLib.EnlightenedNinetails) >= 0 && player.perkv4(PerkLib.EnlightenedNinetails) == 0) || (player.findPerk(PerkLib.CorruptedNinetails) >= 0 && player.perkv4(PerkLib.CorruptedNinetails) == 0)) { //Check ninetails perks!
 				if (player.tailType != TAIL_TYPE_FOX || player.tailVenom < 9) {

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -606,11 +606,11 @@ private function doCamp():void { //Only called by playerMenu
 			else outputText("There are currently " + num2Text(flags[kFLAGS.CAMP_WALL_SKULLS]) + " skulls.  ");
 		}
 		if (flags[kFLAGS.CAMP_WALL_STATUES] > 0) {
-			var message:String = "Dotted around and on the wall that surrounds your camp you spy ";
 			if (flags[kFLAGS.CAMP_WALL_STATUES] == 1)
-				output.text(message + "a single marble imp statue.  ");
+				output.text("Looking around the perimeter of your camp you spy a single marble imp statue.  ");
 			else
-				output.text(message + num2Text(flags[kFLAGS.CAMP_WALL_STATUES]) + " marble imp statues.  ");
+				output.text("Dotted around and on the wall that surrounds your camp you spy "
+				            + num2Text(flags[kFLAGS.CAMP_WALL_STATUES]) + " marble imp statues.  ");
 		}
 		outputText("\n\n");
 	}

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -605,6 +605,13 @@ private function doCamp():void { //Only called by playerMenu
 			if (flags[kFLAGS.CAMP_WALL_SKULLS] == 1) outputText("There is currently one skull.  ");
 			else outputText("There are currently " + num2Text(flags[kFLAGS.CAMP_WALL_SKULLS]) + " skulls.  ");
 		}
+		if (flags[kFLAGS.CAMP_WALL_STATUES] > 0) {
+			var message:String = "Dotted around and on the wall that surrounds your camp you spy ";
+			if (flags[kFLAGS.CAMP_WALL_STATUES] == 1)
+				output.text(message + "a single marble imp statue.  ");
+			else
+				output.text(message + num2Text(flags[kFLAGS.CAMP_WALL_STATUES]) + " marble imp statues.  ");
+		}
 		outputText("\n\n");
 	}
 	else outputText("You have a number of traps surrounding your makeshift home, but they are fairly simple and may not do much to deter a demon.  ");

--- a/classes/classes/Scenes/Monsters/ImpScene.as
+++ b/classes/classes/Scenes/Monsters/ImpScene.as
@@ -34,11 +34,8 @@ package classes.Scenes.Monsters
 			}
 			else {
 				outputText("You smile in satisfaction as " + monster.a + monster.short + " collapses and begins masturbating feverishly.", true);
-				if (monster.HP <= 0) {
-					addButton(0, "Kill Him", killImp);
-					addButton(4, "Leave", combat.cleanupAfterCombat);
-				}
-				else combat.cleanupAfterCombat();
+				addKillPetrifyButtons();
+				addButton(4, "Leave", combat.cleanupAfterCombat);
 				return;
 			}
 			if (player.lust > 33) {
@@ -65,7 +62,7 @@ package classes.Scenes.Monsters
 			if (canFeed) addButton(3, "Breastfeed", areImpsLactoseIntolerant);
 			if (canBikiniTits) addButton(4, "B.Titfuck", (player.armor as LustyMaidensArmor).lustyMaidenPaizuri);
 			if (maleRape == rapeImpWithDick && player.hasItem(useables.CONDOM)) addButton(5, "Use Condom", rapeImpWithDick, true);
-			addButton(6, "Kill Him", killImp);
+			addKillPetrifyButtons(6);
 			if (player.canOvipositBee()) addButton(8, "Oviposit", putBeeEggsInAnImpYouMonster);
 			addButton(14, "Leave", combat.cleanupAfterCombat);
 		}
@@ -1544,7 +1541,7 @@ package classes.Scenes.Monsters
 			clearOutput();
 			if (monster.HP < 1) {
 				outputText("The greater imp falls to the ground panting and growling in anger.  He quickly submits however, the thoroughness of his defeat obvious.  You walk towards the imp who gives one last defiant snarl before slipping into unconsciousness.");
-				if (monster.short != "imp overlord") addButton(0, "Kill Him", killImp);
+				if (monster.short != "imp overlord") addKillPetrifyButtons();
 				else {
 					combat.cleanupAfterCombat();
 					return;
@@ -1556,6 +1553,7 @@ package classes.Scenes.Monsters
 				//Leave // Rape]
 				menu();
 				if (player.lust >= 33 && flags[kFLAGS.SFW_MODE] <= 0) addButton(0, "Sex", sexAnImpLord);
+				if (monster.short != "imp overlord") addKillPetrifyButtons(1);
 				addButton(4, "Leave", combat.cleanupAfterCombat);
 			}
 		}
@@ -2002,7 +2000,153 @@ package classes.Scenes.Monsters
 			player.dumpEggs();
 			combat.cleanupAfterCombat();
 		}
-				
+
+		private function addKillPetrifyButtons(killButtonPos:Number = NaN, petriButtonPos:Number = NaN):void
+		{
+			if (isNaN(killButtonPos)) killButtonPos = 0;
+			if (isNaN(petriButtonPos)) petriButtonPos = killButtonPos + 1;
+			if (killButtonPos >= 0) addButton(killButtonPos, "Kill Him", killImp);
+			if (player.isBasilisk() && flags[kFLAGS.CAMP_WALL_PROGRESS] >= 100) {
+				addButton(petriButtonPos, "Petrify Him", petrifyImp);
+			}
+		}
+
+		private function petrifyImp():void
+		{
+			var winText:String = "";
+			var winText2:String = "";
+			var skullText:String = "";
+			var benoitE:String = getGame().bazaar.benoit.benoitMF("Benoit", "Benoite");
+
+			output.clear();
+			if (flags[kFLAGS.IMPS_PETRIFIED] <= 0) { // First time
+				flags[kFLAGS.IMPS_PETRIFIED] = 0; // Failsafe
+
+				if (monster.HP < 1) {
+					winText = "the beaten and bruised creature cowering teary-eyed,";
+					winText2 = "";
+				} else { // won by lust texts
+					winText = "the pathetically masturbating creature too focused on his blighted cock,";
+					winText2 = "though his hand remains on his prick,";
+				}
+				if (flags[kFLAGS.CAMP_WALL_SKULLS] > 0)
+					skullText = "heedless of the clear warning your wall presents.";
+				else
+					skullText = "no matter how many you beat.";
+
+				output.text("As you look at the imp before you, " + winText + " you feel disgusted. These vermin keep trying to invade your camp and"
+				           +" fuck you senseless " + skullText)
+				      .text("\n\nYou think back to your explorations in the high mountains, the dangers of the peaks keeping these creatures far"
+				           +" away. Even you have been deterred by the shrill harpies with their talons and the treacherous basilisks petrification."
+				           +" You then smirk, a brilliant [if (corruption >= 30) malicious] idea coming to mind. Thanks to " + benoitE
+				           +" you have basilisk eyes, surely the petrification you suffered at their hands before would deter these corrupt spawn as"
+				           +" it has you.")
+				      .text("\n\nYou blink slowly and ready yourself, grabbing the imp by the scruff of his neck. He seems confused " + winText2
+				           +" as you align him with your gaze. As you make direct eye contact he flinches and freezes, mesmerised by your gaze."
+				           +" You feel a link form from the edge of your mind to the imps, like a slowly flowing waterfall, it crashing into him"
+				           +" full force.")
+				      .text("\n\nYou remember how the basilisks used this compulsion to keep your gaze while your body slowly turned to stone,"
+				           +" the soothing feeling and the hushed and raspy whisper swaddling you as the stone did. You start to feed your thoughts"
+				           +" over to the imp, calming him with your words, telling him to keep looking into your eyes and to let all his worries"
+				           +" just fade away. To embrace the feeling of being cocooned and the warmth your gaze brings from the cold he feels."
+				           +" You watch somewhat surprised as he shudders when he tries to look away,"
+				           +" as if a bitter winter wind had rushed against him.")
+				      .text("\n\nYou see his eyes start to become glassy and know it is time. You blink once, the small loss of eye contact making"
+				           +" him whine pitifully. As you meet his eyes again, a layer of marble starting to form at his feet. You let go of him and"
+				           +" he remains in front of you, as if supported by puppet strings, and you are the stage master. The stone continues to"
+				           +" creep up his frame, his limbs hardening into place as it does."
+				           +" Soon his legs are covered and his midsection follows swiftly.")
+				      .text("\n\nYou shut the link between you with a smirk, watching as his dazed expression fades. When he groggily looks down he"
+				           +" begins to shout, trying to free himself with all his might, though with his legs completely turned and the stone"
+				           +" rapidly rising you know he has no chance. The stone has almost formed up to his shoulders now, his arms feeling leaden"
+				           +" as he struggles fruitlessly. You watch in fascination as the imp is consumed by the stone, his cursing fading into"
+				           +" nothingness, while his expression of rage and terror is trapped on his face for eternity.")
+				      .text("\n\nOnce you are sure the imp is truly transfigured you reach out to touch the statue. Your fingers are met with smooth,"
+				           +" cool stone and as you push it gently, you realise the statue is quite solid.");
+			} else {
+				output.text("You decide to teach this imp and his buddies a lesson that won't be forgotten. You grab the imp roughly, making sure you"
+				           +" have his attention as you make eye contact. The imp struggles in your grasp but as you slowly blink, your gaze now"
+				           +" fully on him, you feel him stiffen. He becomes sluggish and finds it hard to resist as your mind reaches into his. As"
+				           +" you soothe the imp with nonsense you see his will to fight begin to ebb away. Your calming speech washes over him as"
+				           +" his gaze becomes unfocused, his eyes not leaving yours out of imagined consequences.")
+				      .text("\n\nYou blink and let your gaze reach its full power, the imp making a pathetic whimper as you leave its mind silent for"
+				           +" that split second. A layer of marble starts to engulf his feet, crawling up his frame the longer he looks into those"
+				           +" glossy eyes of yours. You see the stone begin to harden as it creeps over his legs and let the link to his mind go"
+				           +" with a sudden jolt. He comes back around as the stone begins to coat his midsection, startled into a panic by the sight"
+				           +" of his now solidified lower body.")
+				      .text("\n\nNo matter how much he struggles against the stone, it won't budge, his eyes wide as he look at you. He curses and"
+				           +" rants at you before lapsing into begging, pleading with you to let him go. His pleas fall upon deaf ears of course, a"
+				           +" champion would never give perverted vermin mercy when they would never offer it back. As the stone reaches his neck you"
+				           +" simply watch, curious of what expression the statue will have when it's all over. As your gaze finishes petrifying the"
+				           +" imp you ready yourself for the [if (strength < 90) long] trip back.");
+			}
+			flags[kFLAGS.IMPS_PETRIFIED]++;
+			flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] += 10;
+			//if (player.cor < 25) dynStats("cor", -0.5);
+			menu();
+			var toolTipText:String = "Carry the statue back to your camp to place it on or in front of your wall";
+			var toolTipHeader:String = "Carry the statue to the camp";
+			addButton(0, "Take Statue", takeStatue, null, null, null, toolTipText, toolTipHeader);
+			addButton(1, "Leave", combat.cleanupAfterCombat);
+		}
+
+		private function takeStatue():void
+		{
+			var timeToReturn:int = 1;
+			if (player.str < 90) timeToReturn++;
+			if (player.str < 70) timeToReturn++;
+			if (player.str < 40) timeToReturn++;
+			trace("player.str:", player.str);
+			trace("timeToReturn:", timeToReturn);
+
+			var timeText:String = "";
+			timeText = timeToReturn > 1 ? num2Text(timeToReturn) + " hours" : "hour";
+
+			if (false && flags[kFLAGS.IMPS_PETRIFIED] <= 1) {
+				switch (timeToReturn) {
+					case 1: // str 90+ --> 1 hour
+						output.text("\n\nYou heft the statue onto your shoulder with a practised ease, as it is as light as a small wooden log for"
+						           +" you. As you spend the next hour carrying it back to camp, you feel frustrated at the land for making your"
+						           +" journey so long. You put the statue down near your camp wall as you wonder how effective it will be at keeping"
+						           +" these pests away.");
+						break;
+
+					case 2: // str 70-89 --> 2 hours
+						output.text("\n\nYou heft the statue onto your back with a practised ease, though maneuvering with the bulky thing is harder"
+						           +" than you expected. For something so small, it sure is heavy. As you spend the next couple of hours carrying it"
+						           +" back to camp, you feel frustrated at the land for making your journey so long. You put the statue down near"
+						           +" your camp wall, stretching and rubbing at the sore spots on your back and shoulders as you wonder how"
+						           +" effective it will be at keeping these pests away.");
+						break;
+
+					case 3: // str 40-69 --> 3 hours, 25 fatigue
+					case 4: // str < 40  --> 4 hours, 50 fatigue
+						output.text("\n\nYou try to lift the statue, but are simply unable to. You huff angrily as you pace around it, trying to"
+						           +" figure out how you can get it back to camp. You look through your belongings and around the area for something"
+						           +" to help you move the damned thing. After 20 minutes of searching you manage to find enough resources to make a"
+						           +" small sled that you can pull along with some rope. You position it behind the statue and kick the statue over,"
+						           +" smiling a little as you let out some of that anger. With the statue soon secured in place you begin the long"
+						           +" trek home, dragging the statue behind you. By the time you reach the camp you are exhausted, your arms and"
+						           +" legs burning in protest of the excessive labour transporting this thing took. Panting, you untie the statue"
+						           +" and drag it up to lean against the camp wall, hoping the damned thing was worth dragging here.");
+					// default: // there is no default. All possible cases are handled ...
+				}
+			} else {
+				output.text("\n\nIn the " + timeText + " it takes to [if (strength >= 70) carry|drag] the statue back to camp, you don't encounter"
+				           +" any further trouble, though you're sure the sight of the statue, which you now place around your wall,"
+				           +" helped with that. Maybe it'll help here too.");
+			}
+			flags[kFLAGS.CAMP_WALL_STATUES]++;
+			if (flags[kFLAGS.CAMP_WALL_STATUES] == 1) {
+				output.text("\n\n<b>You now have a marble imp statue at camp!</b>");
+			} else {
+				output.text("\n\n<b>You now have " + num2Text(flags[kFLAGS.CAMP_WALL_STATUES]) + " marble imp statues at camp!</b>");
+			}
+			if (timeToReturn >= 3) player.changeFatigue(25);
+			if (timeToReturn >= 4) player.changeFatigue(25);
+			combat.cleanupAfterCombat(curry(camp.returnToCamp, timeToReturn));
+		}
+
 		private function killImp():void {
 			clearOutput();
 			flags[kFLAGS.IMPS_KILLED]++;

--- a/classes/classes/Scenes/Monsters/ImpScene.as
+++ b/classes/classes/Scenes/Monsters/ImpScene.as
@@ -34,8 +34,9 @@ package classes.Scenes.Monsters
 			}
 			else {
 				outputText("You smile in satisfaction as " + monster.a + monster.short + " collapses and begins masturbating feverishly.", true);
-				addKillPetrifyButtons();
-				addButton(4, "Leave", combat.cleanupAfterCombat);
+				if (addKillPetrifyButtons())
+					addButton(4, "Leave", combat.cleanupAfterCombat);
+				else combat.cleanupAfterCombat();
 				return;
 			}
 			if (player.lust > 33) {
@@ -1541,8 +1542,7 @@ package classes.Scenes.Monsters
 			clearOutput();
 			if (monster.HP < 1) {
 				outputText("The greater imp falls to the ground panting and growling in anger.  He quickly submits however, the thoroughness of his defeat obvious.  You walk towards the imp who gives one last defiant snarl before slipping into unconsciousness.");
-				if (monster.short != "imp overlord") addKillPetrifyButtons();
-				else {
+				if (!addKillPetrifyButtons()) {
 					combat.cleanupAfterCombat();
 					return;
 				}
@@ -1553,7 +1553,7 @@ package classes.Scenes.Monsters
 				//Leave // Rape]
 				menu();
 				if (player.lust >= 33 && flags[kFLAGS.SFW_MODE] <= 0) addButton(0, "Sex", sexAnImpLord);
-				if (monster.short != "imp overlord") addKillPetrifyButtons(1);
+				addKillPetrifyButtons(1);
 				addButton(4, "Leave", combat.cleanupAfterCombat);
 			}
 		}
@@ -2001,14 +2001,30 @@ package classes.Scenes.Monsters
 			combat.cleanupAfterCombat();
 		}
 
-		private function addKillPetrifyButtons(killButtonPos:Number = NaN, petriButtonPos:Number = NaN):void
+		private function impPetrifyable():Boolean
 		{
+			return player.isBasilisk() && flags[kFLAGS.CAMP_WALL_PROGRESS] >= 100;
+		}
+
+		private function addKillPetrifyButtons(killButtonPos:Number = NaN, petriButtonPos:Number = NaN):Boolean
+		{
+			var buttonCount:int = 0;
+
+			if (monster.short == "imp overlord") return false;
+
 			if (isNaN(killButtonPos)) killButtonPos = 0;
-			if (isNaN(petriButtonPos)) petriButtonPos = killButtonPos + 1;
-			if (killButtonPos >= 0) addButton(killButtonPos, "Kill Him", killImp);
-			if (player.isBasilisk() && flags[kFLAGS.CAMP_WALL_PROGRESS] >= 100) {
-				addButton(petriButtonPos, "Petrify Him", petrifyImp);
+			if (killButtonPos >= 0 && monster.HP < 1) {
+				addButton(killButtonPos, "Kill Him", killImp);
+				buttonCount++;
 			}
+
+			if (isNaN(petriButtonPos)) petriButtonPos = killButtonPos + 1;
+			if (impPetrifyable()) {
+				addButton(petriButtonPos, "Petrify Him", petrifyImp);
+				buttonCount++;
+			}
+
+			return buttonCount > 0;
 		}
 
 		private function petrifyImp():void

--- a/classes/classes/Scenes/Monsters/ImpScene.as
+++ b/classes/classes/Scenes/Monsters/ImpScene.as
@@ -2103,7 +2103,8 @@ package classes.Scenes.Monsters
 			timeText = timeToReturn > 1 ? num2Text(timeToReturn) + " hours" : "hour";
 
 			output.clear();
-			if (flags[kFLAGS.IMPS_PETRIFIED] <= 1) {
+			if (flags[kFLAGS.CAMP_WALL_STATUES] <= 0) { // First time carrying it back
+				flags[kFLAGS.CAMP_WALL_STATUES] = 0; // Failsafe
 				switch (timeToReturn) {
 					case 1: // str 90+ --> 1 hour
 						output.text("You heft the statue onto your shoulder with a practised ease, as it is as light as a small wooden log for"

--- a/classes/classes/Scenes/Monsters/ImpScene.as
+++ b/classes/classes/Scenes/Monsters/ImpScene.as
@@ -2035,6 +2035,15 @@ package classes.Scenes.Monsters
 			var benoitE:String = getGame().bazaar.benoit.benoitMF("Benoit", "Benoite");
 
 			output.clear();
+			if (monster.HP >= 1 && (50 + 50 * (1 - monster.HPRatio())) < rand(100)) {
+				output.text("You decide to teach this imp and his buddies a lesson that won't be forgotten. You grab the imp roughly, making sure you"
+				           +" have his attention as you make eye contact. The imp struggles in your grasp and manages to struggle himself free.");
+				output.text("\n\nPerhaps your should have beaten him down a little" + (monster.HPRatio() < 1 ? " more" : "") 
+				           +", before you've attempted the turn him into a statue?");
+				doNext(combat.cleanupAfterCombat);
+				return;
+			}
+
 			if (flags[kFLAGS.IMPS_PETRIFIED] <= 0) { // First time
 				flags[kFLAGS.IMPS_PETRIFIED] = 0; // Failsafe
 

--- a/classes/classes/Scenes/Monsters/ImpScene.as
+++ b/classes/classes/Scenes/Monsters/ImpScene.as
@@ -2086,7 +2086,7 @@ package classes.Scenes.Monsters
 			menu();
 			var toolTipText:String = "Carry the statue back to your camp to place it on or in front of your wall";
 			var toolTipHeader:String = "Carry the statue to the camp";
-			addButton(0, "Take Statue", takeStatue, null, null, null, toolTipText, toolTipHeader);
+			addButton(0, "Take Statue", curry(combat.cleanupAfterCombat, takeStatue), null, null, null, toolTipText, toolTipHeader);
 			addButton(1, "Leave", combat.cleanupAfterCombat);
 		}
 
@@ -2102,26 +2102,27 @@ package classes.Scenes.Monsters
 			var timeText:String = "";
 			timeText = timeToReturn > 1 ? num2Text(timeToReturn) + " hours" : "hour";
 
-			if (false && flags[kFLAGS.IMPS_PETRIFIED] <= 1) {
+			output.clear();
+			if (flags[kFLAGS.IMPS_PETRIFIED] <= 1) {
 				switch (timeToReturn) {
 					case 1: // str 90+ --> 1 hour
-						output.text("\n\nYou heft the statue onto your shoulder with a practised ease, as it is as light as a small wooden log for"
+						output.text("You heft the statue onto your shoulder with a practised ease, as it is as light as a small wooden log for"
 						           +" you. As you spend the next hour carrying it back to camp, you feel frustrated at the land for making your"
-						           +" journey so long. You put the statue down near your camp wall as you wonder how effective it will be at keeping"
+						           +" trip so long. You put the statue down near your camp wall as you wonder how effective it will be at keeping"
 						           +" these pests away.");
 						break;
 
 					case 2: // str 70-89 --> 2 hours
-						output.text("\n\nYou heft the statue onto your back with a practised ease, though maneuvering with the bulky thing is harder"
+						output.text("You heft the statue onto your back with a practised ease, though maneuvering with the bulky thing is harder"
 						           +" than you expected. For something so small, it sure is heavy. As you spend the next couple of hours carrying it"
 						           +" back to camp, you feel frustrated at the land for making your journey so long. You put the statue down near"
 						           +" your camp wall, stretching and rubbing at the sore spots on your back and shoulders as you wonder how"
 						           +" effective it will be at keeping these pests away.");
 						break;
 
-					case 3: // str 40-69 --> 3 hours, 25 fatigue
-					case 4: // str < 40  --> 4 hours, 50 fatigue
-						output.text("\n\nYou try to lift the statue, but are simply unable to. You huff angrily as you pace around it, trying to"
+					case 3: // str 40-69 --> 3 hours, 10 fatigue
+					case 4: // str < 40  --> 4 hours, 20 fatigue
+						output.text("You try to lift the statue, but are simply unable to. You huff angrily as you pace around it, trying to"
 						           +" figure out how you can get it back to camp. You look through your belongings and around the area for something"
 						           +" to help you move the damned thing. After 20 minutes of searching you manage to find enough resources to make a"
 						           +" small sled that you can pull along with some rope. You position it behind the statue and kick the statue over,"
@@ -2132,7 +2133,7 @@ package classes.Scenes.Monsters
 					// default: // there is no default. All possible cases are handled ...
 				}
 			} else {
-				output.text("\n\nIn the " + timeText + " it takes to [if (strength >= 70) carry|drag] the statue back to camp, you don't encounter"
+				output.text("In the " + timeText + " it takes to [if (strength >= 70) carry|drag] the statue back to camp, you don't encounter"
 				           +" any further trouble, though you're sure the sight of the statue, which you now place around your wall,"
 				           +" helped with that. Maybe it'll help here too.");
 			}
@@ -2142,9 +2143,9 @@ package classes.Scenes.Monsters
 			} else {
 				output.text("\n\n<b>You now have " + num2Text(flags[kFLAGS.CAMP_WALL_STATUES]) + " marble imp statues at camp!</b>");
 			}
-			if (timeToReturn >= 3) player.changeFatigue(25);
-			if (timeToReturn >= 4) player.changeFatigue(25);
-			combat.cleanupAfterCombat(curry(camp.returnToCamp, timeToReturn));
+			if (timeToReturn >= 3) player.changeFatigue(10);
+			if (timeToReturn >= 4) player.changeFatigue(10);
+			doNext(curry(camp.returnToCamp, timeToReturn));
 		}
 
 		private function killImp():void {

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -158,9 +158,12 @@ public function goNext(time:Number, needNext:Boolean):Boolean  {
 		if (player.inHeat) temp += 2;
 		if (vapula.vapulaSlave()) temp += 7;
 		//Reduce chance
+		var scarePercent:Number = 0;
+		scarePercent += flags[kFLAGS.CAMP_WALL_SKULLS] + flags[kFLAGS.CAMP_WALL_STATUES] * 2;
+		if (scarePercent > 100) scarePercent = 100;
 		if (flags[kFLAGS.CAMP_WALL_PROGRESS] > 0) temp /= 1 + (flags[kFLAGS.CAMP_WALL_PROGRESS] / 100);
 		if (flags[kFLAGS.CAMP_WALL_GATE] > 0) temp /= 2;
-		if (flags[kFLAGS.CAMP_WALL_SKULLS] > 0) temp *= 1 - (flags[kFLAGS.CAMP_WALL_SKULLS] / 100);
+		temp *= 1 - (scarePercent / 100);
 		if (model.time.hours == 2) {
 			if (model.time.days % 30 == 0 && flags[kFLAGS.ANEMONE_KID] > 0 && player.hasCock() && flags[kFLAGS.ANEMONE_WATCH] > 0 && flags[kFLAGS.TAMANI_NUMBER_OF_DAUGHTERS] >= 40) {
 				anemoneScene.goblinNightAnemone();

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -159,7 +159,7 @@ public function goNext(time:Number, needNext:Boolean):Boolean  {
 		if (vapula.vapulaSlave()) temp += 7;
 		//Reduce chance
 		var scarePercent:Number = 0;
-		scarePercent += flags[kFLAGS.CAMP_WALL_SKULLS] + flags[kFLAGS.CAMP_WALL_STATUES] * 2;
+		scarePercent += flags[kFLAGS.CAMP_WALL_SKULLS] + flags[kFLAGS.CAMP_WALL_STATUES] * 4;
 		if (scarePercent > 100) scarePercent = 100;
 		if (flags[kFLAGS.CAMP_WALL_PROGRESS] > 0) temp /= 1 + (flags[kFLAGS.CAMP_WALL_PROGRESS] / 100);
 		if (flags[kFLAGS.CAMP_WALL_GATE] > 0) temp /= 2;


### PR DESCRIPTION
### Gameplay changes
- **[Fixed]** Returning to the camp didn't always show, if you've gained the Basilisk Resistance and/or Transformation Resistance Perk.
- ~~**[Fixed]** If you've won by lust you weren't able to kill imps for certain imp types.~~ **[Revert]** That was intended.
- **[New]** As per @Kitteh6660's suggestion, there's now a chance, that the imp struggles himself free, if he isn't beaten by damage.
- If you've won against an imp by lust or by damage you now have the option to petrify the imp instead of 'just' killing him, if you meet the following requirements:
 - You have basilisk eyes (and meet the requirements to gain them).
 - Your camp wall is completed, camp gate excluded.
- After that, You can carry the imp statue to your camp or leave it in the wild.
- If you choose to carry it to your camp it depends on your strength how long it takes and if it causes fatigue:

| Strength | Duration | Fatigue |
|----------|----------|---------|
| 90+      | 1 hour   | 0       |
| 70-89    | 2 hours  | 0       |
| 40-69    | 3 hours  | 10      |
| < 40     | 4 hours  | 20      |
- Even, if your strength is low and your fatigue is very high or at maximum, you'll still be able to carry the statue back with no additional drawbacks.
- 1 imp statue is as scary as 4 imp skulls, reducing the chance of an imp raid by 4% per statue.
- When you petrify an imp, you'll gain 10 points towards basilisk resistance. If you use them, you'll get used to them, right?

### Credits
- MissBlackthorne (Scene texts)

### Internal changes
Added the new flags:
```as3
public static const IMPS_PETRIFIED:int    = 1303; // Total imps petrified
public static const CAMP_WALL_STATUES:int = 1304; // Total imp statues at camp wall
```

### Notes
- In some cases you couldn't kill (or petrify) an imp after winning by lust. I assumed, that this was not intended, so I fixed this. @Kitteh6660: Tell me, if it was actually intended and I'll revert that and limit it to petrify only. **[Edit:]** Reverted that, because it **was** intended. See the comments below.
- In the next phase, I plan use the flag BASILISK_RESISTANCE_TRACKER for your bassy eyes training (higher success chance and higher effect). Probably at 100% you'll even be better at being a basilisk as those you'll encounter at the high mountains.
- I've found out, that gaining the perks '**Basilisk Resistance**' and '**Transformation Resistance**' didn't always show up, when returning to the camp due to a missing `needNext = true;` hence I fixed that.
- The fatigue gains are there, because the texts suggest it when your strength is below 70. I just didn't want to add no fatigue, when the text reads, that you're exhausted.
