### PR TITLE
Basilisk Eyes Phase 4 (Stare combat ability)

### DIFF
--- a/classes/classes/Appearance.as
+++ b/classes/classes/Appearance.as
@@ -2227,7 +2227,9 @@
 					[HAIR_GHOST, "transparent"],
 					[HAIR_GOO, "goopy"],
 					[HAIR_ANEMONE, "tentacle"],
-					[HAIR_QUILL, "quill"]
+					[HAIR_QUILL, "quill"],
+					[HAIR_BASILISK_SPINES, "spiny basilisk"],
+					[HAIR_BASILISK_PLUME, "feathery plume"],
 				]
 		);
 		public static const DEFAULT_BEARD_NAMES:Object = createMapFromPairs(

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1984,7 +1984,12 @@ package classes
 			return _wingType == 2 || _wingType == 7 || _wingType == 9 || _wingType == 11 || _wingType == 12;
 
 		}
-		
+
+		public function canCombatStare():Boolean
+		{
+			return eyeType == EYES_BASILISK;
+		}
+
 		//check for vagoo
 		public function hasVagina():Boolean
 		{

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1985,7 +1985,7 @@ package classes
 
 		}
 
-		public function canCombatStare():Boolean
+		public function canUseStare():Boolean
 		{
 			return eyeType == EYES_BASILISK;
 		}

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -2447,7 +2447,7 @@ use namespace kGAMECLASS;
 				if (maxSpe < 50) maxSpe = 50;
 			}
 			//Perks ahoy
-			if (findPerk(PerkLib.BasiliskResistance) >= 0)
+			if (findPerk(PerkLib.BasiliskResistance) >= 0 && !isBasilisk())
 			{
 				maxSpe -= 5;
 			}
@@ -2476,6 +2476,11 @@ use namespace kGAMECLASS;
 			}
 			if (lizardScore() >= 4) {
 				maxInt += 10;
+				if (isBasilisk()) {
+					// Needs more balancing, especially other races, since dracolisks are quite OP right now!
+					maxTou += 5;
+					maxInt += 5;
+				}
 			}
 			if (dragonScore() >= 4) {
 				maxStr += 5;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -589,11 +589,8 @@ use namespace kGAMECLASS;
 			var returnDamage:int = (damage>0 && damage<1)?1:damage;
 			if (damage>0){
 				//game.HPChange(-damage, display);
-				HP -= damage
-				if (display) {
-					if (damage > 0) outputText("<b>(<font color=\"#800000\">" + damage + "</font>)</b>", false)
-					else outputText("<b>(<font color=\"#000080\">" + damage + "</font>)</b>", false)
-				}
+				HP -= damage;
+				if (display) game.output.text(game.combat.getDamageText(damage));
 				game.mainView.statsView.showStatDown('hp');
 				game.dynStats("lus", 0); //Force display arrow.
 				if (flags[kFLAGS.MINOTAUR_CUM_REALLY_ADDICTED_STATE] > 0) {

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -2447,7 +2447,7 @@ use namespace kGAMECLASS;
 				if (maxSpe < 50) maxSpe = 50;
 			}
 			//Perks ahoy
-			if (findPerk(PerkLib.BasiliskResistance) >= 0 && !isBasilisk())
+			if (findPerk(PerkLib.BasiliskResistance) >= 0 && !canUseStare())
 			{
 				maxSpe -= 5;
 			}

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -218,7 +218,7 @@ package classes {
 				}
 			}*/
 			if (flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] >= 100 && player.findPerk(PerkLib.BasiliskResistance) < 0) {
-				outputText("\nYou notice that you feel a bit stiff and your skin is a bit harder.  Something clicks in your mind as you finally unlock the potential to protect yourself from the goddamn basilisks! \n\n(<b>Gained Perk: Basilisk Resistance - Your maximum speed is permanently decreased but you are now immune to the basilisk's gaze!</b>)\n");
+				outputText("\nYou notice that you feel a bit stiff and your skin is a bit harder.  Something clicks in your mind as you finally unlock the potential to protect yourself from the goddamn basilisks! \n\n(<b>Gained Perk: Basilisk Resistance - Your maximum speed is permanently decreased unless you are a basilisk, but you are now immune to the basilisk's gaze!</b>)\n");
 				player.createPerk(PerkLib.BasiliskResistance, 0, 0, 0, 0);
 				needNext = true;
 			}

--- a/classes/classes/Scenes/Areas/HighMountains/Basilisk.as
+++ b/classes/classes/Scenes/Areas/HighMountains/Basilisk.as
@@ -32,7 +32,7 @@ package classes.Scenes.Areas.HighMountains
 			//Success:
 			if (player.inte / 5 + rand(20) < 24 + player.newGamePlusMod() * 5) {
 				//Immune to Basilisk?
-				if (player.findPerk(PerkLib.BasiliskResistance) >= 0) {
+				if (player.findPerk(PerkLib.BasiliskResistance) >= 0 || player.canCombatStare()) {
 					outputText("You can't help yourself... you glimpse the reptile's grey, slit eyes. However, no matter how much you look into the eyes, you do not see anything wrong. All you can see is the basilisk. The basilisk curses as he finds out that you're immune!", false);
 				}
 				else {
@@ -105,11 +105,15 @@ package classes.Scenes.Areas.HighMountains
 			this.hipRating = HIP_RATING_SLENDER+1;
 			this.buttRating = BUTT_RATING_AVERAGE;
 			this.lowerBody = LOWER_BODY_TYPE_LIZARD;
-			this.skinTone = "gray";
+			this.faceType = FACE_LIZARD;
+			this.earType = EARS_LIZARD;
+			this.eyeType = EYES_BASILISK;
+			this.hairType = HAIR_BASILISK_SPINES;
+			this.skinTone = "grey-green";
 			this.skinType = SKIN_TYPE_SCALES;
 			//this.skinDesc = Appearance.Appearance.DEFAULT_SKIN_DESCS[SKIN_TYPE_SCALES];
-			this.hairColor = "none";
-			this.hairLength = 0;
+			this.hairColor = "grey-green";
+			this.hairLength = 2;
 			initStrTouSpeInte(85, 70, 35, 70);
 			initLibSensCor(50, 35, 60);
 			this.weaponName = "claws";
@@ -126,8 +130,9 @@ package classes.Scenes.Areas.HighMountains
 			this.level = 12;
 			this.gems = rand(10) + 10;
 			this.drop = new ChainedDrop().add(consumables.REPTLUM,0.9);
-			this.tailType = TAIL_TYPE_COW;
+			this.tailType = TAIL_TYPE_LIZARD;
 			this.tailRecharge = 0;
+			this.createPerk(PerkLib.BasiliskResistance, 0, 0, 0, 0);
 			checkMonster();
 		}
 		

--- a/classes/classes/Scenes/Areas/HighMountains/Basilisk.as
+++ b/classes/classes/Scenes/Areas/HighMountains/Basilisk.as
@@ -32,7 +32,7 @@ package classes.Scenes.Areas.HighMountains
 			//Success:
 			if (player.inte / 5 + rand(20) < 24 + player.newGamePlusMod() * 5) {
 				//Immune to Basilisk?
-				if (player.findPerk(PerkLib.BasiliskResistance) >= 0 || player.canCombatStare()) {
+				if (player.findPerk(PerkLib.BasiliskResistance) >= 0 || player.canUseStare()) {
 					outputText("You can't help yourself... you glimpse the reptile's grey, slit eyes. However, no matter how much you look into the eyes, you do not see anything wrong. All you can see is the basilisk. The basilisk curses as he finds out that you're immune!", false);
 				}
 				else {

--- a/classes/classes/Scenes/Areas/HighMountains/BasiliskScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/BasiliskScene.as
@@ -234,7 +234,7 @@ package classes.Scenes.Areas.HighMountains
 			}
 			dynStats("spe", player.findPerk(PerkLib.BasiliskResistance) < 0 ? 3 : 1, "lus", 399);
 			//Bad end
-			if (player.spe < 5 && player.findPerk(PerkLib.BasiliskResistance) < 0 && !player.canCombatStare()) {
+			if (player.spe < 5 && player.findPerk(PerkLib.BasiliskResistance) < 0 && !player.canUseStare()) {
 				basiliskBadEnd();
 				return;
 			}

--- a/classes/classes/Scenes/Areas/HighMountains/BasiliskScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/BasiliskScene.as
@@ -234,7 +234,7 @@ package classes.Scenes.Areas.HighMountains
 			}
 			dynStats("spe", player.findPerk(PerkLib.BasiliskResistance) < 0 ? 3 : 1, "lus", 399);
 			//Bad end
-			if (player.spe < 5 && player.findPerk(PerkLib.BasiliskResistance) < 0) {
+			if (player.spe < 5 && player.findPerk(PerkLib.BasiliskResistance) < 0 && !player.canCombatStare()) {
 				basiliskBadEnd();
 				return;
 			}

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1137,11 +1137,7 @@ package classes.Scenes.Combat
 			
 			if (damage < 0) damage = 1;
 			if (apply) monster.HP -= damage;
-			if (display) {
-				if (damage > 0) outputText("<b>(<font color=\"#800000\">" + damage + "</font>)</b>"); //Damage
-				else if (damage == 0) outputText("<b>(<font color=\"#000080\">" + damage + "</font>)</b>"); //Miss/block
-				else if (damage < 0) outputText("<b>(<font color=\"#008000\">" + damage + "</font>)</b>"); //Heal
-			}
+			if (display) output.text(getDamageText(damage));
 			//Isabella gets mad
 			if (monster.short == "Isabella") {
 				flags[kFLAGS.ISABELLA_AFFECTION]--;
@@ -1157,6 +1153,15 @@ package classes.Scenes.Combat
 
 		public function takeDamage(damage:Number, display:Boolean = false):Number {
 			return player.takeDamage(damage, display);
+		}
+
+		public function getDamageText(damage:Number):String
+		{
+			var color:String;
+			if (damage > 0)  color = "#800000";
+			if (damage == 0) color = "#000080";
+			if (damage < 0)  color = "#008000";
+			return "<b>(<font color=\"" + color + "\">" + damage + "</font>)</b>";
 		}
 
 		public function finishCombat():void

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -1338,7 +1338,10 @@ package classes.Scenes.Combat
 				monster.doAI();
 				return;
 			}
-			output.text("The world begins to twist and distort around you as reality bends to your will, " + monster.a + monster.short + "'s mind blanketed in the thick fog of your illusions.");
+			var theMonster:String = monster.a + monster.short;
+			output.text("You open your mouth and, staring at " + theMonster + ", uttering calming words to soothe " + monster.pronoun3 + " mind."
+			           +"  The sounds bore into " + theMonster + "'s mind, working and buzzing at the edges of " + monster.pronoun3 + " resolve,"
+			           +" suggesting, compelling, then demanding " + monster.pronoun2 + " to look into your eyes.  ");
 
 			if (flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] > 100)
 				flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] = 100;
@@ -1350,7 +1353,12 @@ package classes.Scenes.Combat
 			var message:String = "";
 			if (slowEffect < 3 && (monster.inte + 110 - stareTraining * 30 + slowEffect * 10 - player.inte < rand(100))) {
 			//Reduce speed down to -24 (no training) or -36 (full training).
-				message = "  They stumble humorously to and fro, unable to keep pace with the shifting illusions that cloud their perceptions. ";
+				message = monster.Pronoun1 + " can't help " + monster.pronoun2 + "self... " + monster.pronoun1 + " glimpses your eyes. "
+				        + monster.Pronoun1 + " looks away quickly, but " + monster.pronoun1 + " can picture them in " + monster.pronoun3
+				        + " mind's eye, staring in at " + monster.pronoun3 + " thoughts, making " + monster.pronoun2 + " feel sluggish and unable to"
+				        + " coordinate. Something about the helplessness of it feels so good... " + monster.pronoun1 + " can't banish the feeling"
+				        + " that really, " + monster.pronoun1 + " wants to look into your eyes forever, for you to have total control over "
+				        + monster.pronoun2 + ". ";
 				if (slowEffect > 0)
 					monster.addStatusValue(StatusEffects.BasiliskSlow, 1, 1);
 				else
@@ -1362,7 +1370,7 @@ package classes.Scenes.Combat
 				speedDiff = Math.round(oldSpeed - monster.spe);
 				output.text(message + combat.getDamageText(speedDiff) + "\n\n");
 			} else {
-				output.text("  Like the snapping of a rubber band, reality falls back into its rightful place as " + monster.a + monster.short + " resists your compulsion.\n\n");
+				output.text("Like the snapping of a rubber band, reality falls back into its rightful place as " + monster.a + monster.short + " escapes your gaze.\n\n");
 				flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] += 2;
 			}
 			monster.doAI();

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -3,8 +3,10 @@ package classes.Scenes.Combat
 	import classes.*;
 	import classes.GlobalFlags.*;
 	import classes.Items.*;
+	import classes.Scenes.Areas.Forest.TentacleBeast;
 	import classes.Scenes.Areas.GlacialRift.FrostGiant;
 	import classes.Scenes.Dungeons.D3.*;
+	import classes.Scenes.Dungeons.DeepCave.*;
 	import classes.Scenes.Dungeons.HelDungeon.*;
 	import classes.Scenes.NPCs.*;
 	import classes.Scenes.Places.TelAdre.UmasShop;
@@ -1314,6 +1316,15 @@ package classes.Scenes.Combat
 		//Stare
 		public function paralyzingStare():void
 		{
+			var theMonster:String = monster.a + monster.short;
+			var TheMonster:String = monster.capitalA + monster.short;
+			var stareTraining:Number = flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] / 100;
+			var slowEffect:Number = monster.statusEffectv1(StatusEffects.BasiliskSlow);
+			var oldSpeed:Number = monster.spe;
+			var speedDiff:int = 0;
+			var message:String = "";
+			if (stareTraining > 1) stareTraining = 1;
+
 			output.clear();
 			//Fatigue Cost: 20
 			if (player.findPerk(PerkLib.BloodMage) < 0 && player.fatigue + player.spellCost(20) > player.maxFatigue()) {
@@ -1326,39 +1337,44 @@ package classes.Scenes.Combat
 				doNext(magicalSpecials);
 				return;
 			}
-			if (monster.short == "pod" || monster.inte == 0) {
+			if (monster is EncapsulationPod || monster.inte == 0) {
 				output.text("In the tight confines of this pod, there's no use making such an attack!\n\n");
 				player.changeFatigue(1);
 				monster.doAI();
 				return;
 			}
-			player.changeFatigue(20, 1);
-			if (monster.findStatusEffect(StatusEffects.Shell) >= 0) {
-				output.text("As soon as your magic touches the multicolored shell around " + monster.a + monster.short + ", it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
+			if (monster is TentacleBeast) {
+				output.text("You try to find the beast's eyes to stare at them, but you soon realize, that it has none at all!\n\n");
+				player.changeFatigue(1);
 				monster.doAI();
 				return;
 			}
-			var theMonster:String = monster.a + monster.short;
+			if (monster.findPerk(PerkLib.BasiliskResistance) >= 0) {
+				output.text("You attempt to apply your paralyzing stare at " + theMonster + ", but you soon realize, that " + monster.pronoun1
+				           +" is immune to your eyes, so you quickly back up.\n\n");
+				player.changeFatigue(10, 1);
+				monster.doAI();
+				return;
+			}
+			player.changeFatigue(20, 1);
+			if (monster.findStatusEffect(StatusEffects.Shell) >= 0) {
+				output.text("As soon as your magic touches the multicolored shell around " + theMonster + ", it sizzles and fades to nothing."
+				           +"  Whatever that thing is, it completely blocks your magic!\n\n");
+				monster.doAI();
+				return;
+			}
+
 			output.text("You open your mouth and, staring at " + theMonster + ", uttering calming words to soothe " + monster.pronoun3 + " mind."
 			           +"  The sounds bore into " + theMonster + "'s mind, working and buzzing at the edges of " + monster.pronoun3 + " resolve,"
 			           +" suggesting, compelling, then demanding " + monster.pronoun2 + " to look into your eyes.  ");
 
-			if (flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] > 100)
-				flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] = 100;
-
-			var stareTraining:Number = flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] / 100;
-			var slowEffect:Number = monster.statusEffectv1(StatusEffects.BasiliskSlow);
-			var oldSpeed:Number = monster.spe;
-			var speedDiff:int = 0;
-			var message:String = "";
 			if (slowEffect < 3 && (monster.inte + 110 - stareTraining * 30 + slowEffect * 10 - player.inte < rand(100))) {
 			//Reduce speed down to -24 (no training) or -36 (full training).
-				message = monster.Pronoun1 + " can't help " + monster.pronoun2 + "self... " + monster.pronoun1 + " glimpses your eyes. "
-				        + monster.Pronoun1 + " looks away quickly, but " + monster.pronoun1 + " can picture them in " + monster.pronoun3
-				        + " mind's eye, staring in at " + monster.pronoun3 + " thoughts, making " + monster.pronoun2 + " feel sluggish and unable to"
-				        + " coordinate. Something about the helplessness of it feels so good... " + monster.pronoun1 + " can't banish the feeling"
-				        + " that really, " + monster.pronoun1 + " wants to look into your eyes forever, for you to have total control over "
-				        + monster.pronoun2 + ". ";
+				message = TheMonster + " can't help " + monster.pronoun2 + "self... " + monster.pronoun1 + " glimpses your eyes. " + monster.Pronoun1
+				        + " looks away quickly, but " + monster.pronoun1 + " can picture them in " + monster.pronoun3 + " mind's eye, staring in at "
+				        + monster.pronoun3 + " thoughts, making " + monster.pronoun2 + " feel sluggish and unable to coordinate. Something about the"
+				        + " helplessness of it feels so good... " + monster.pronoun1 + " can't banish the feeling that really, " + monster.pronoun1
+				        + " wants to look into your eyes forever, for you to have total control over " + monster.pronoun2 + ". ";
 				if (slowEffect > 0)
 					monster.addStatusValue(StatusEffects.BasiliskSlow, 1, 1);
 				else

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -1345,9 +1345,12 @@ package classes.Scenes.Combat
 
 			var stareTraining:Number = flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] / 100;
 			var slowEffect:Number = monster.statusEffectv1(StatusEffects.BasiliskSlow);
+			var oldSpeed:Number = monster.spe;
+			var speedDiff:int = 0;
+			var message:String = "";
 			if (slowEffect < 3 && (monster.inte + 110 - stareTraining * 30 + slowEffect * 10 - player.inte < rand(100))) {
 			//Reduce speed down to -24 (no training) or -36 (full training).
-				output.text("  They stumble humorously to and fro, unable to keep pace with the shifting illusions that cloud their perceptions.\n\n");
+				message = "  They stumble humorously to and fro, unable to keep pace with the shifting illusions that cloud their perceptions. ";
 				if (slowEffect > 0)
 					monster.addStatusValue(StatusEffects.BasiliskSlow, 1, 1);
 				else
@@ -1356,6 +1359,8 @@ package classes.Scenes.Combat
 				if (monster.spe > 1) monster.spe -= 16 + stareTraining * 8 - slowEffect * (4 + stareTraining * 2);
 				if (monster.spe < 1) monster.spe = 1;
 				flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] += 4;
+				speedDiff = Math.round(oldSpeed - monster.spe);
+				output.text(message + combat.getDamageText(speedDiff) + "\n\n");
 			} else {
 				output.text("  Like the snapping of a rubber band, reality falls back into its rightful place as " + monster.a + monster.short + " resists your compulsion.\n\n");
 				flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] += 2;

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -1345,7 +1345,7 @@ package classes.Scenes.Combat
 
 			var stareTraining:Number = flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] / 100;
 			var slowEffect:Number = monster.statusEffectv1(StatusEffects.BasiliskSlow);
-			if (slowEffect < 3 && (monster.inte / 2 + 55 - stareTraining * 20 + monster.statusEffectv1(StatusEffects.BasiliskSlow) * 10 - player.inte / 2 < rand(100))) {
+			if (slowEffect < 3 && (monster.inte + 110 - stareTraining * 30 + slowEffect * 10 - player.inte < rand(100))) {
 			//Reduce speed down to -24 (no training) or -36 (full training).
 				output.text("  They stumble humorously to and fro, unable to keep pace with the shifting illusions that cloud their perceptions.\n\n");
 				if (slowEffect > 0)

--- a/classes/classes/Scenes/Dungeons/D3/JeanClaude.as
+++ b/classes/classes/Scenes/Dungeons/D3/JeanClaude.as
@@ -98,11 +98,14 @@ package classes.Scenes.Dungeons.D3
 			hipRating = HIP_RATING_AVERAGE;
 			buttRating = BUTT_RATING_AVERAGE;
 			lowerBody = LOWER_BODY_TYPE_LIZARD;
+			tailType = TAIL_TYPE_LIZARD;
 			skinDesc = "green-purple mottled hide";
 			initStrTouSpeInte(80, 100, 80, 60);
 			initLibSensCor(40, 40, 80);
 			faceType = FACE_LIZARD;
-			
+			earType = EARS_LIZARD;
+			eyeType = EYES_BASILISK;
+
 			weaponName = "cutlass";
 			weaponVerb = "slash";
 			weaponAttack = 20;
@@ -117,7 +120,9 @@ package classes.Scenes.Dungeons.D3
 			gems = 300 + rand(55);
 			
 			this.drop = NO_DROP;
-			
+
+			this.createPerk(PerkLib.BasiliskResistance, 0, 0, 0, 0);
+
 			checkMonster();
 		}
 		


### PR DESCRIPTION
### Gameplay changes
- If you have the combat ability '**Stare**' you're naturally immune to the basilisks stare.
- Basilisks and Dracolisks now gain additional +5 toughness and +5 int.
  - Needs more balancing, especially other races since dracolisks are quite OP right now.
- Basilisks and Jean Claude are immune to Stare
- With eyes enabling the stare combat ability (bassy eyes only for now) you won't get the speed malus from '**Basilisk Resistance**'
- On success, the speed 'damage' dealt will be shown to the player
- Tentacle beasts have no eyes, so you're not able to stare at them.
- I forgot to handle monsters that have the basilisk resistance perk. Should work now.

### Internal changes
- Added `canUseStare()` to Creature.as as yet another method to check for basilisk immunity.
- Added `HAIR_BASILISK_SPINES` and `HAIR_BASILISK_PLUME` to the `DEFAULT_HAIR_NAMES` (Forgot that in phase 2).
- Added more details to Jean Claude and especially Basilisks:
  - lizard face
  - lizard ears
  - basilisk eyes
  - hair = 2 inch grey-green basilisk spines
  - skinTone: "gray" → "grey-green"
  - **[Fixed]** tailType: cow → lizard
- Added the method `public function getDamageText(damage:Number):String` to `Combat.as` to get the color-formatted damage. This is used in:
  - `CombatAbilities.petrifyingStare()`
  - `Player.takeDamage()` and
  - `Combat.doDamage()`
- instead of checking for `if (monster.short == "pod")` I'm now checking for `if (monster is EncapsulationPod)` ... makes more sense to me.

### Notes
- Especially dracolisks have high stats as of now. I could probably revert this, but I guess, its better to balance other races later. Your opinion to that @Kitteh6660?
- Basic mechanics are done. See [the gdoc](https://docs.google.com/document/d/1KgaLS5xm51yesCyI_WuGf6j69diwnOjbKHEkWue99Ac/edit#heading=h.1xkbtcd68cs4) for the details.
- When dealing with (Corrupted) Fox Fire displaying the wrong damage I always wanted to write a generic method for this. Well, BTDT now 😉
