### PR TITLE
Reptilum TF improvements

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -520,6 +520,22 @@ package classes
 			}
 		}
 
+		public function newGamePlusMod():int
+		{
+			//Constrains value between 0 and 4.
+			return Math.max(0, Math.min(4, flags[kFLAGS.NEW_GAME_PLUS_LEVEL]));
+		}
+
+		public function ascensionFactor(multiplier:Number = 25):Number
+		{
+			return newGamePlusMod() * multiplier;
+		}
+
+		public function ngPlus(value:Number, multiplier:Number = 25):Number
+		{
+			return value + ascensionFactor(multiplier);
+		}
+
 		//Create a perk
 		public function createPerk(ptype:PerkType, value1:Number, value2:Number, value3:Number, value4:Number):void
 		{

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -5001,6 +5001,7 @@
 			//Randomly choose affects limit
 			if (rand(2) == 0) changeLimit++;
 			if (rand(2) == 0) changeLimit++;
+			if (rand(3) == 0) changeLimit++;
 			if (rand(4) == 0) changeLimit++;
 			if (player.findPerk(PerkLib.HistoryAlchemist) >= 0) changeLimit++;
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
@@ -5010,7 +5011,7 @@
 
 			//Statistical changes:
 			//-Reduces speed down to 50.
-			if (player.spe > 50 && changes < changeLimit && rand(4) == 0) {
+			if (player.spe > player.ngPlus(50) && changes < changeLimit && rand(4) == 0) {
 				outputText("\n\nYou start to feel sluggish and cold.  Lying down to bask in the sun might make you feel better.", false);
 				dynStats("spe", -1);
 				changes++;
@@ -5044,14 +5045,14 @@
 			}
 			//-Raises toughness to 70
 			//(+3 to 40, +2 to 55, +1 to 70)
-			if (player.tou < 70 && changes < changeLimit && rand(3) == 0) {
+			if (player.tou < player.ngPlus(70) && changes < changeLimit && rand(3) == 0) {
 				//(+3)
-				if (player.tou < 40) {
+				if (player.tou < player.ngPlus(40)) {
 					outputText("\n\nYour body and skin both thicken noticeably.  You pinch your " + player.skinDesc + " experimentally and marvel at how much tougher your hide has gotten.", false);
 					dynStats("tou", 3);
 				}
 				//(+2)
-				else if (player.tou < 55) {
+				else if (player.tou < player.ngPlus(55)) {
 					outputText("\n\nYou grin as you feel your form getting a little more solid.  It seems like your whole body is toughening up quite nicely, and by the time the sensation goes away, you feel ready to take a hit.", false);
 					dynStats("tou", 2);
 				}

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -551,13 +551,13 @@ package classes.Items
 			else {
 				if (player.hornType == HORNS_DRACONIC_X2) {
 					if (player.horns < 12) {
-						if (rand(2) == 0) {
+						if (rand(3) == 0) {
 							outputText("\n\nYou get a headache as an inch of fresh horn escapes from your pounding skull.");
 							player.horns += 1;
 						}
 						else {
 							outputText("\n\nYour head aches as your horns grow a few inches longer.  They get even thicker about the base, giving you a menacing appearance.");
-							player.horns += 2 + rand(4);
+							player.horns += 3 + rand(3);
 						}
 						if (player.horns >= 12) outputText("  <b>Your horns settle down quickly, as if they're reached their full size.</b>");
 						changes++;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1890,15 +1890,7 @@ use namespace kGAMECLASS;
 			if (flags[kFLAGS.MEANINGLESS_CORRUPTION] > 0) temp += 100;
 			return temp;
 		}
-		
-		public function newGamePlusMod():int {
-			var temp:int = flags[kFLAGS.NEW_GAME_PLUS_LEVEL];
-			//Constrains value between 0 and 4.
-			if (temp < 0) temp = 0;
-			if (temp > 4) temp = 4;
-			return temp;
-		}
-		
+
 		public function buttChangeDisplay():void
 		{	//Allows the test for stretching and the text output to be separated
 			if (ass.analLooseness == 5) outputText("<b>Your " + Appearance.assholeDescript(this) + " is stretched even wider, capable of taking even the largest of demons and beasts.</b>");
@@ -2575,10 +2567,10 @@ use namespace kGAMECLASS;
 			if (isNaga()) maxSpe += 10;
 			if (isTaur() || isDrider()) maxSpe += 20;
 			//Apply New Game+
-			maxStr += 25 * newGamePlusMod();
-			maxTou += 25 * newGamePlusMod();
-			maxSpe += 25 * newGamePlusMod();
-			maxInt += 25 * newGamePlusMod();
+			maxStr += ascensionFactor();
+			maxTou += ascensionFactor();
+			maxSpe += ascensionFactor();
+			maxInt += ascensionFactor();
 			//Might
 			if (findStatusEffect(StatusEffects.Might) >= 0) {
 				maxStr += statusEffectv1(StatusEffects.Might);


### PR DESCRIPTION
### Gameplay changes
- Slightly higher chance for more changes with one reptilum
- speed reduction is now capped at 50 + new-game-plus-level * 25 instead of always going down to 50
- toughness gain caps are modified by new-game-plus-level the same way:

  | New Game+ Level | Toughness cap |
  |-----------------|---------------|
  | 0               |            70 |
  | 1               |            95 |
  | 2               |           120 |
  | 3               |           145 |
  | 4+              |           170 |

- horns grow faster now:
  - **before:** 1/2 chance: +1 inch, 1/2 chance: +2-5 inches
  - **after:** 1/3 chance: +1 inch, 2/3 chance: +3-5 inches

### Internal changes
- `public function newGamePlusMod():int` moved to `Creature.as`
- Added `public function ascensionFactor(multiplier:Number = 25):Number`
- Added `public function ngPlus(value:Number, multiplier:Number = 25):Number`

### Notes
I've tested it a few times, watching the `lizardScore()` going up from 0 to 11 (The maximum atm).
Speed and toughness were maxed out, libido at its minimum of 15 and I had the perk History: Alchemist.
In most of the times I had to eat 20-25 reptilum to go from a lizard score of 0 to 11. I've been unlucky once, where I needed 47 reptilum's to max out the score, but this is quite rare.
I assume, its fine now and more finetunings can always be done later, if need be.