### PR TITLE
Fix for improper loading of undefined flags

### DIFF
--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -2162,15 +2162,15 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			player.autoSave = saveFile.data.autoSave;
 		
 		// Fix possible old save for Plot & Exploration
-		flags[kFLAGS.TIMES_EXPLORED_LAKE]     = (flags[kFLAGS.TIMES_EXPLORED_LAKE] || saveFile.data.exploredLake);
-		flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] || saveFile.data.exploredMountain);
-		flags[kFLAGS.TIMES_EXPLORED_FOREST]   = (flags[kFLAGS.TIMES_EXPLORED_FOREST] || saveFile.data.exploredForest);
-		flags[kFLAGS.TIMES_EXPLORED_DESERT]   = (flags[kFLAGS.TIMES_EXPLORED_DESERT] || saveFile.data.exploredDesert);
-		flags[kFLAGS.TIMES_EXPLORED]          = (flags[kFLAGS.TIMES_EXPLORED] || saveFile.data.exploredDesert);
+		flags[kFLAGS.TIMES_EXPLORED_LAKE]     = (flags[kFLAGS.TIMES_EXPLORED_LAKE] || saveFile.data.exploredLake || 0);
+		flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] || saveFile.data.exploredMountain || 0);
+		flags[kFLAGS.TIMES_EXPLORED_FOREST]   = (flags[kFLAGS.TIMES_EXPLORED_FOREST] || saveFile.data.exploredForest || 0);
+		flags[kFLAGS.TIMES_EXPLORED_DESERT]   = (flags[kFLAGS.TIMES_EXPLORED_DESERT] || saveFile.data.exploredDesert || 0);
+		flags[kFLAGS.TIMES_EXPLORED]          = (flags[kFLAGS.TIMES_EXPLORED] || saveFile.data.explored || 0);
  
-		flags[kFLAGS.JOJO_STATUS]        = (flags[kFLAGS.JOJO_STATUS] || saveFile.data.monk);
-		flags[kFLAGS.SANDWITCH_SERVICED] = (flags[kFLAGS.SANDWITCH_SERVICED] || saveFile.data.sand);
-		flags[kFLAGS.GIACOMO_MET]        = (flags[kFLAGS.GIACOMO_MET] || saveFile.data.giacomo);
+		flags[kFLAGS.JOJO_STATUS]        = (flags[kFLAGS.JOJO_STATUS] || saveFile.data.monk || 0);
+		flags[kFLAGS.SANDWITCH_SERVICED] = (flags[kFLAGS.SANDWITCH_SERVICED] || saveFile.data.sand || 0);
+		flags[kFLAGS.GIACOMO_MET]        = (flags[kFLAGS.GIACOMO_MET] || saveFile.data.giacomo || 0);
 		
 		if (saveFile.data.beeProgress == 1)
 			game.forest.beeGirlScene.setTalked();

--- a/classes/classes/Scenes/Areas/Desert.as
+++ b/classes/classes/Scenes/Areas/Desert.as
@@ -24,8 +24,8 @@ package classes.Scenes.Areas
 		//Explore desert
 		public function exploreDesert():void
 		{
-			flags[kFLAGS.TIMES_EXPLORED_DESERT] = int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) + 1;
-			if ((player.level >= 4 || int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) > 45) && int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) % 15 == 0 && flags[kFLAGS.DISCOVERED_WITCH_DUNGEON] == 0) {
+			flags[kFLAGS.TIMES_EXPLORED_DESERT]++;
+			if ((player.level >= 4 || flags[kFLAGS.TIMES_EXPLORED_DESERT] > 45) && flags[kFLAGS.TIMES_EXPLORED_DESERT] % 15 == 0 && flags[kFLAGS.DISCOVERED_WITCH_DUNGEON] == 0) {
 				kGAMECLASS.dungeons.desertcave.enterDungeon();
 //				kGAMECLASS.inDungeon = true;
 //				kGAMECLASS.dungeonLoc = 23;
@@ -41,7 +41,7 @@ package classes.Scenes.Areas
 				kGAMECLASS.helScene.helSexualAmbush();
 				return;
 			}
-			if ((int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) == 20 && player.findStatusEffect(StatusEffects.TelAdre) < 0) || (rand(20) == 0 && player.statusEffectv1(StatusEffects.TelAdre) == 0)) {
+			if ((flags[kFLAGS.TIMES_EXPLORED_DESERT] == 20 && player.findStatusEffect(StatusEffects.TelAdre) < 0) || (rand(20) == 0 && player.statusEffectv1(StatusEffects.TelAdre) == 0)) {
 				kGAMECLASS.telAdre.discoverTelAdre();
 				return;
 			}
@@ -51,7 +51,7 @@ package classes.Scenes.Areas
 				return;
 			}
 			//Ant colony debug chances
-			if (player.level >= 5 && flags[kFLAGS.ANT_WAIFU] == 0 && (int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) % 8 == 0) && flags[kFLAGS.ANTS_PC_FAILED_PHYLLA] == 0 && flags[kFLAGS.ANT_COLONY_KEPT_HIDDEN] == 0) {
+			if (player.level >= 5 && flags[kFLAGS.ANT_WAIFU] == 0 && (flags[kFLAGS.TIMES_EXPLORED_DESERT] % 8 == 0) && flags[kFLAGS.ANTS_PC_FAILED_PHYLLA] == 0 && flags[kFLAGS.ANT_COLONY_KEPT_HIDDEN] == 0) {
 				antsScene.antColonyEncounter();
 				return;
 			}

--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -147,7 +147,7 @@ package classes.Scenes.Areas
 		{
 			clearOutput();
 			//Increment forest exploration counter.
-			flags[kFLAGS.TIMES_EXPLORED_FOREST] = int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) + 1;
+			flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
 
 			var choice:Array = [];
 			var select:int;
@@ -172,7 +172,7 @@ package classes.Scenes.Areas
 				return;
 			}
 			//Chance to discover deepwoods
-			if ((int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) >= 20) && player.findStatusEffect(StatusEffects.ExploredDeepwoods) < 0) {
+			if ((flags[kFLAGS.TIMES_EXPLORED_FOREST] >= 20) && player.findStatusEffect(StatusEffects.ExploredDeepwoods) < 0) {
 				player.createStatusEffect(StatusEffects.ExploredDeepwoods, 0, 0, 0, 0);
 				outputText("After exploring the forest so many times, you decide to really push it, and plunge deeper and deeper into the woods.  The further you go the darker it gets, but you courageously press on.  The plant-life changes too, and you spot more and more lichens and fungi, many of which are luminescent.  Finally, a wall of tree-trunks as wide as houses blocks your progress.  There is a knot-hole like opening in the center, and a small sign marking it as the entrance to the 'Deepwoods'.  You don't press on for now, but you could easily find your way back to explore the Deepwoods.\n\n<b>Deepwoods exploration unlocked!</b>", true);
 				doNext(camp.returnToCampUseOneHour);
@@ -191,7 +191,7 @@ package classes.Scenes.Areas
 				return;
 			}
 			//Marble randomness
-			if (int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) % 50 == 0 && int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) > 0 && player.findStatusEffect(StatusEffects.MarbleRapeAttempted) < 0 && player.findStatusEffect(StatusEffects.NoMoreMarble) < 0 && player.findStatusEffect(StatusEffects.Marble) >= 0 && flags[kFLAGS.MARBLE_WARNING] == 0) {
+			if (flags[kFLAGS.TIMES_EXPLORED_FOREST] % 50 == 0 && flags[kFLAGS.TIMES_EXPLORED_FOREST] > 0 && player.findStatusEffect(StatusEffects.MarbleRapeAttempted) < 0 && player.findStatusEffect(StatusEffects.NoMoreMarble) < 0 && player.findStatusEffect(StatusEffects.Marble) >= 0 && flags[kFLAGS.MARBLE_WARNING] == 0) {
 				//can be triggered one time after Marble has been met, but before the addiction quest starts.
 				clearOutput();
 				outputText("While you're moving through the trees, you suddenly hear yelling ahead, followed by a crash and a scream as an imp comes flying at high speed through the foliage and impacts a nearby tree.  The small demon slowly slides down the tree before landing at the base, still.  A moment later, a familiar-looking cow-girl steps through the bushes brandishing a huge two-handed hammer with an angry look on her face.");

--- a/classes/classes/Scenes/Areas/Lake.as
+++ b/classes/classes/Scenes/Areas/Lake.as
@@ -27,7 +27,7 @@ package classes.Scenes.Areas
 		public function exploreLake():void
 		{
 			//Increment exploration count
-			flags[kFLAGS.TIMES_EXPLORED_LAKE] = int(flags[kFLAGS.TIMES_EXPLORED_LAKE]) + 1;
+			flags[kFLAGS.TIMES_EXPLORED_LAKE]++;
 			if (kGAMECLASS.aprilFools.poniesYN()) return;
 
 			//Helia monogamy fucks
@@ -35,7 +35,7 @@ package classes.Scenes.Areas
 				kGAMECLASS.helScene.helSexualAmbush();
 				return;
 			}
-			if (int(flags[kFLAGS.TIMES_EXPLORED_LAKE]) % 20 == 0 || (flags[kFLAGS.HUNGER_ENABLED] > 0 && player.hunger < 10 && rand(5) == 0)) {
+			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] % 20 == 0 || (flags[kFLAGS.HUNGER_ENABLED] > 0 && player.hunger < 10 && rand(5) == 0)) {
 				calluScene.ottahGirl();
 				return;
 			}
@@ -71,7 +71,7 @@ package classes.Scenes.Areas
 			if (player.level >= 2)
 				choice[choice.length] = 4;
 			//Izma
-			if (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00230] > 0 && (int(flags[kFLAGS.TIMES_EXPLORED_LAKE]) >= 10) && (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00233] == 0 || player.findStatusEffect(StatusEffects.Infested) < 0) && flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00238] <= 0)
+			if (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00230] > 0 && (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 10) && (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00233] == 0 || player.findStatusEffect(StatusEffects.Infested) < 0) && flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00238] <= 0)
 				choice[choice.length] = 5;
 			//Rathazul
 			if (player.findStatusEffect(StatusEffects.CampRathazul) < 0)

--- a/classes/classes/Scenes/Areas/Mountain.as
+++ b/classes/classes/Scenes/Areas/Mountain.as
@@ -27,7 +27,7 @@ package classes.Scenes.Areas
 		//Explore Mountain
 		public function exploreMountain():void
 		{
-			flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) + 1;
+			flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]++;
 			var chooser:Number = rand(5);
 			if (chooser == 5 && player.level < 3 && model.time.days < 20) //Disable mimic if requirements not met (Can still be encountered in level 1 run)
 				chooser = rand(4);
@@ -37,7 +37,7 @@ package classes.Scenes.Areas
 				return;
 			}
 			//Discover 'high mountain' at level 5 or 40 explores of mountain
-			if ((player.level >= 5 || int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) >= 40) && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] == 0) {
+			if ((player.level >= 5 || flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 40) && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] == 0) {
 				outputText("While exploring the mountain, you come across a relatively safe way to get at its higher reaches.  You judge that with this route you'll be able to get about two thirds of the way up the mountain.  With your newfound discovery fresh in your mind, you return to camp.\n\n(<b>High Mountain exploration location unlocked!</b>)", true);
 				flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN]++;
 				doNext(camp.returnToCampUseOneHour);
@@ -75,12 +75,12 @@ package classes.Scenes.Areas
 			}
 			//Rarer 'nice' Ceraph encounter
 			//Overlaps half the old encounters once pierced.
-			if (!kGAMECLASS.ceraphFollowerScene.ceraphIsFollower() && player.level > 2 && (int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) % 30 == 0) && flags[kFLAGS.PC_FETISH] > 0) {
+			if (!kGAMECLASS.ceraphFollowerScene.ceraphIsFollower() && player.level > 2 && (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] % 30 == 0) && flags[kFLAGS.PC_FETISH] > 0) {
 				kGAMECLASS.ceraphScene.friendlyNeighborhoodSpiderManCeraph();
 				return;
 			}
 			//15% chance of Ceraph
-			if (!kGAMECLASS.ceraphFollowerScene.ceraphIsFollower() && player.level > 2 && (int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) % 15 == 0) && flags[kFLAGS.PC_FETISH] != 1) {
+			if (!kGAMECLASS.ceraphFollowerScene.ceraphIsFollower() && player.level > 2 && (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] % 15 == 0) && flags[kFLAGS.PC_FETISH] != 1) {
 				kGAMECLASS.ceraphScene.encounterCeraph();
 				return;
 			}
@@ -105,7 +105,7 @@ package classes.Scenes.Areas
 				chooser = 1;
 			}
 			//Every 16 explorations chance at mino bad-end!
-			if (int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) % 16 == 0 && player.findPerk(PerkLib.MinotaurCumAddict) >= 0 && rand(3) == 0) {
+			if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] % 16 == 0 && player.findPerk(PerkLib.MinotaurCumAddict) >= 0 && rand(3) == 0) {
 				spriteSelect(44);
 				minotaurScene.minoAddictionBadEndEncounter();
 				return;

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2743,15 +2743,15 @@ private function updateAchievements():void {
 	if (flags[kFLAGS.LETHICE_DEFEATED] > 0) awardAchievement("Demon Slayer", kACHIEVEMENTS.STORY_FINALBOSS);
 	
 	//Zones
-	if (int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) > 0 && int(flags[kFLAGS.TIMES_EXPLORED_LAKE]) > 0 && int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) > 0 && int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) > 0 && int(flags[kFLAGS.TIMES_EXPLORED_PLAINS]) > 0 && int(flags[kFLAGS.TIMES_EXPLORED_SWAMP]) > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
+	if (flags[kFLAGS.TIMES_EXPLORED_FOREST] > 0 && flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0 && flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0 && flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] > 0 && flags[kFLAGS.BOG_EXPLORED] > 0 && flags[kFLAGS.DISCOVERED_GLACIAL_RIFT] > 0) awardAchievement("Explorer", kACHIEVEMENTS.ZONE_EXPLORER);
 	if (placesCount() >= 10) awardAchievement("Sightseer", kACHIEVEMENTS.ZONE_SIGHTSEER);
-	if (int(flags[kFLAGS.TIMES_EXPLORED]) >= 1) awardAchievement("Where am I?", kACHIEVEMENTS.ZONE_WHERE_AM_I);
-	if (int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) >= 100) awardAchievement("Dehydrated", kACHIEVEMENTS.ZONE_DEHYDRATED);
-	if (int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) >= 100) awardAchievement("Forest Ranger", kACHIEVEMENTS.ZONE_FOREST_RANGER);
-	if (int(flags[kFLAGS.TIMES_EXPLORED_LAKE]) >= 100) awardAchievement("Vacationer", kACHIEVEMENTS.ZONE_VACATIONER);
-	if (int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) >= 100) awardAchievement("Mountaineer", kACHIEVEMENTS.ZONE_MOUNTAINEER);
-	if (int(flags[kFLAGS.TIMES_EXPLORED_PLAINS]) >= 100) awardAchievement("Rolling Hills", kACHIEVEMENTS.ZONE_ROLLING_HILLS);
-	if (int(flags[kFLAGS.TIMES_EXPLORED_SWAMP]) >= 100) awardAchievement("Wet All Over", kACHIEVEMENTS.ZONE_WET_ALL_OVER);
+	if (flags[kFLAGS.TIMES_EXPLORED] >= 1) awardAchievement("Where am I?", kACHIEVEMENTS.ZONE_WHERE_AM_I);
+	if (flags[kFLAGS.TIMES_EXPLORED_DESERT] >= 100) awardAchievement("Dehydrated", kACHIEVEMENTS.ZONE_DEHYDRATED);
+	if (flags[kFLAGS.TIMES_EXPLORED_FOREST] >= 100) awardAchievement("Forest Ranger", kACHIEVEMENTS.ZONE_FOREST_RANGER);
+	if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 100) awardAchievement("Vacationer", kACHIEVEMENTS.ZONE_VACATIONER);
+	if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 100) awardAchievement("Mountaineer", kACHIEVEMENTS.ZONE_MOUNTAINEER);
+	if (flags[kFLAGS.TIMES_EXPLORED_PLAINS] >= 100) awardAchievement("Rolling Hills", kACHIEVEMENTS.ZONE_ROLLING_HILLS);
+	if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] >= 100) awardAchievement("Wet All Over", kACHIEVEMENTS.ZONE_WET_ALL_OVER);
 	if (player.statusEffectv1(StatusEffects.ExploredDeepwoods) >= 100) awardAchievement("We Need to Go Deeper", kACHIEVEMENTS.ZONE_WE_NEED_TO_GO_DEEPER);
 	if (flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN] >= 100) awardAchievement("Light-headed", kACHIEVEMENTS.ZONE_LIGHT_HEADED);
 	if (flags[kFLAGS.BOG_EXPLORED] >= 100) awardAchievement("All murky", kACHIEVEMENTS.ZONE_ALL_MURKY);

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -25,16 +25,16 @@ package classes.Scenes
 			// Clear 
 			clearOutput();
 	
-			// Introductions to exploration //			
-			if (int(flags[kFLAGS.TIMES_EXPLORED]) <= 0) {
+			// Introductions to exploration //
+			if (flags[kFLAGS.TIMES_EXPLORED] <= 0) {
 				outputText("You tentatively step away from your campsite, alert and scanning the ground and sky for danger.  You walk for the better part of an hour, marking the rocks you pass for a return trip to your camp.  It worries you that the portal has an opening on this side, and it was totally unguarded...\n\n...Wait a second, why is your campsite in front of you? The portal's glow is clearly visible from inside the tall rock formation.   Looking carefully you see your footprints leaving the opposite side of your camp, then disappearing.  You look back the way you came and see your markings vanish before your eyes.  The implications boggle your mind as you do your best to mull over them.  Distance, direction, and geography seem to have little meaning here, yet your campsite remains exactly as you left it.  A few things click into place as you realize you found your way back just as you were mentally picturing the portal!  Perhaps memory influences travel here, just like time, distance, and speed would in the real world!\n\nThis won't help at all with finding new places, but at least you can get back to camp quickly.  You are determined to stay focused the next time you explore and learn how to traverse this gods-forsaken realm.", true);
-				flags[kFLAGS.TIMES_EXPLORED] = int(flags[kFLAGS.TIMES_EXPLORED]) + 1; // just trust me on this one
+				flags[kFLAGS.TIMES_EXPLORED]++;
 				doNext(camp.returnToCampUseOneHour);
 				return;
-			} else if (int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) <= 0) {
+			} else if (flags[kFLAGS.TIMES_EXPLORED_FOREST] <= 0) {
 				outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You have discovered the Forest!</b>", true);
-				flags[kFLAGS.TIMES_EXPLORED] = int(flags[kFLAGS.TIMES_EXPLORED]) + 1;
-				flags[kFLAGS.TIMES_EXPLORED_FOREST] = int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) + 1;
+				flags[kFLAGS.TIMES_EXPLORED]++;
+				flags[kFLAGS.TIMES_EXPLORED_FOREST]++;
 				doNext(camp.returnToCampUseOneHour);
 				return;
 			}
@@ -49,11 +49,11 @@ package classes.Scenes
 			hideMenus();
 			menu();
 			addButton(0, "Explore", tryDiscover, null, null, null, "Explore to find new regions and visit any discovered regions.");
-			if (int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) > 0) addButton(1, "Forest", kGAMECLASS.forest.exploreForest, null, null, null, "Visit the lush forest. \n\nRecommended level: 1" + (player.level < 6 ? "\n\nBeware of Tentacle Beasts!" : "") + (debug ? "\n\nTimes explored: " + int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) : ""));
-			if (int(flags[kFLAGS.TIMES_EXPLORED_LAKE]) > 0) addButton(2, "Lake", kGAMECLASS.lake.exploreLake, null, null, null, "Visit the lake and explore the beach. \n\nRecommended level: 1" + (debug ? "\n\nTimes explored: " + int(flags[kFLAGS.TIMES_EXPLORED_LAKE]) : ""));
-			if (int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) > 0) addButton(3, "Desert", kGAMECLASS.desert.exploreDesert, null, null, null, "Visit the dry desert. \n\nRecommended level: 2" + (debug ? "\n\nTimes explored: " + int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) : ""));
+			if (flags[kFLAGS.TIMES_EXPLORED_FOREST] > 0) addButton(1, "Forest", kGAMECLASS.forest.exploreForest, null, null, null, "Visit the lush forest. \n\nRecommended level: 1" + (player.level < 6 ? "\n\nBeware of Tentacle Beasts!" : "") + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_FOREST] : ""));
+			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] > 0) addButton(2, "Lake", kGAMECLASS.lake.exploreLake, null, null, null, "Visit the lake and explore the beach. \n\nRecommended level: 1" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_LAKE] : ""));
+			if (flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0) addButton(3, "Desert", kGAMECLASS.desert.exploreDesert, null, null, null, "Visit the dry desert. \n\nRecommended level: 2" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_DESERT] : ""));
 
-			if (int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) > 0) addButton(5, "Mountain", kGAMECLASS.mountain.exploreMountain, null, null, null, "Visit the mountain. \n\nRecommended level: 5" + (debug ? "\n\nTimes explored: " + int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) : ""));
+			if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] > 0) addButton(5, "Mountain", kGAMECLASS.mountain.exploreMountain, null, null, null, "Visit the mountain. \n\nRecommended level: 5" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] : ""));
 			if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0) addButton(6, "Swamp", kGAMECLASS.swamp.exploreSwamp, null, null, null, "Visit the wet swamplands. \n\nRecommended level: 12" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_SWAMP] : ""));
 			if (flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0) addButton(7, "Plains", kGAMECLASS.plains.explorePlains, null, null, null, "Visit the plains. \n\nRecommended level: 10" + (debug ? "\n\nTimes explored: " + flags[kFLAGS.TIMES_EXPLORED_PLAINS] : ""));
 			if (player.findStatusEffect(StatusEffects.ExploredDeepwoods) >= 0) addButton(8, "Deepwoods", kGAMECLASS.forest.exploreDeepwoods, null, null, null, "Visit the dark, bioluminescent deepwoods. \n\nRecommended level: 5" + (debug ? "\n\nTimes explored: " + player.statusEffectv1(StatusEffects.ExploredDeepwoods) : ""));
@@ -224,13 +224,13 @@ package classes.Scenes
 				return;
 			}
 			clearOutput();
-			flags[kFLAGS.TIMES_EXPLORED] = int(flags[kFLAGS.TIMES_EXPLORED]) + 1;
-			if (int(flags[kFLAGS.TIMES_EXPLORED_LAKE]) <= 0) {
+			flags[kFLAGS.TIMES_EXPLORED]++;
+			if (flags[kFLAGS.TIMES_EXPLORED_LAKE] <= 0) {
 				// Discover Lake
 				flags[kFLAGS.TIMES_EXPLORED_LAKE] = 1;
 				outputText("Your wanderings take you far and wide across the barren wasteland that surrounds the portal, until the smell of humidity and fresh water alerts you to the nearby lake.  With a few quick strides you find a lake so massive the distant shore cannot be seen.  Grass and a few sparse trees grow all around it.\n\n<b>You've discovered the Lake!</b>");
 				doNext(camp.returnToCampUseOneHour);
-			} else if (int(flags[kFLAGS.TIMES_EXPLORED_LAKE]) >= 1 && rand(3) == 0 && int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) <= 0) {
+			} else if (flags[kFLAGS.TIMES_EXPLORED_LAKE] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_DESERT] <= 0) {
 				// Discover Desert
 				flags[kFLAGS.TIMES_EXPLORED_DESERT] = 1;
 				outputText("You stumble as the ground shifts a bit underneath you.  Groaning in frustration, you straighten up and discover the rough feeling of sand ");
@@ -240,12 +240,12 @@ package classes.Scenes
 				else if (player.lowerBody == LOWER_BODY_TYPE_NAGA)    outputText("in your scales");
 				outputText(".\n\n<b>You've discovered the Desert!</b>");
 				doNext(camp.returnToCampUseOneHour);
-			} else if (int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) >= 1 && rand(3) == 0 && int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) <= 0) {
+			} else if (flags[kFLAGS.TIMES_EXPLORED_DESERT] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] <= 0) {
 				// Discover Mountain
 				flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] = 1;
 				outputText("Thunder booms overhead, shaking you out of your thoughts.  High above, dark clouds encircle a distant mountain peak.  You get an ominous feeling in your gut as you gaze up at it.\n\n<b>You've discovered the Mountain!</b>");
 				doNext(camp.returnToCampUseOneHour);
-			} else if (int(flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN]) >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] <= 0) {
+			} else if (flags[kFLAGS.TIMES_EXPLORED_MOUNTAIN] >= 1 && rand(3) == 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] <= 0) {
 				// Discover Plains
 				flags[kFLAGS.TIMES_EXPLORED_PLAINS] = 1;
 				outputText("You find yourself standing in knee-high grass, surrounded by flat plains on all sides.  Though the mountain, forest, and lake are all visible from here, they seem quite distant.\n\n<b>You've discovered the plains!</b>");

--- a/classes/classes/Scenes/Explore/Gargoyle.as
+++ b/classes/classes/Scenes/Explore/Gargoyle.as
@@ -32,7 +32,7 @@ public function gargoylesTheShowNowOnWBNetwork():void {
 	//(When using the “Explore” option; perhaps a 15-25% chance of discovery per go)
 	outputText("You set off in search of new horizons, setting off from camp in a completely new direction than you've ever tried before.  Away from the parts of Mareth you have thus far discovered, much of the world seems to be a barren wasteland");
 	//if Desert is discovered:
-	if (int(flags[kFLAGS.TIMES_EXPLORED_DESERT]) > 0) outputText(", making even the desert seem healthy and full of life");
+	if (flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0) outputText(", making even the desert seem healthy and full of life");
 	outputText(".  Your trip soon begins to seem unproductive, having found no new areas of Mareth or any contact with its inhabitants.  You sigh and turn back towards camp.");
 	
 	outputText("\n\nHowever, soon you catch the faintest glimpse of <b>something</b> in the distance!  Squinting, you shield your eyes from the sun and try to discern the strange glint on the horizon, but it's simply too far away.  Well, whatever it is, it certainly merits a check – it could be anything, perhaps a city, ");

--- a/classes/classes/Scenes/NPCs/SheilaScene.as
+++ b/classes/classes/Scenes/NPCs/SheilaScene.as
@@ -2742,7 +2742,7 @@ private function forcedSheilaOral(dick:Boolean = true):void {
 		//[(no horse)
 		if (!player.isTaur()) outputText("pinch her nipple for emphasis, then grind your hips across her face, mauling her nose with your ass.  \"<i>I could fuck a tree and it wouldn't be as wooden as you in the sack");
 		//[(PC has found corrupt glade)
-		if (int(flags[kFLAGS.TIMES_EXPLORED_FOREST]) >= 40) outputText(" - in fact, there are quite a few I've seen who look like better lovers than you.  Maybe I should carry you to the forest and tie you to a nice pussy-shaped giant flower to give you lessons");
+		if (flags[kFLAGS.TIMES_EXPLORED_FOREST] >= 40) outputText(" - in fact, there are quite a few I've seen who look like better lovers than you.  Maybe I should carry you to the forest and tie you to a nice pussy-shaped giant flower to give you lessons");
 		outputText(".  ");
 		//[(minotaur addiction score =/= 0%)
 		if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] > 0 || player.findPerk(PerkLib.MinotaurCumAddict) >= 0) {


### PR DESCRIPTION
Moving some vars, like the exploration vars to flags was incomplete and sometimes led to set those flags to undefined upon loading a saveGame.

This reverts the workaround from PR #361 and fixes the issue at its cause.

Kudos goes to @Modenn to find and workaround the bug in first place. :)