### PR TITLE
Eating Echidna Cake should not remove the Oviposition Perk

### DIFF
--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -380,7 +380,7 @@ package classes.Items
 
 			if (changes >= changeLimit) return 0;
 
-			// Note, that we don't do the score checks anymore. That was just an unly workaround and we don't want to do that again!
+			// Note, that we don't do the score checks anymore. That was just an ugly workaround and we don't want to do that again!
 			switch(tfSource) {
 				case "EmberTFs":
 				case "snakeOil":
@@ -392,6 +392,7 @@ package classes.Items
 					return 0; // Don't change it. So we're done, yay!
 
 				case "reptilum":
+				case "echidnaTFs":
 					if (player.findPerk(PerkLib.Oviposition) >= 0) return 0;
 					outputText("\n\nDeep inside yourself there is a change.  It makes you feel a little woozy, but passes quickly."
 					          +"  Beyond that, you aren't sure exactly what just happened, but you are sure it originated from your womb.\n");

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -1850,8 +1850,6 @@ package classes.Scenes.Places.Bazaar
 			
 			// Normal TFs
 			//------------
-			if (rand(5) == 0) mutations.updateOvipositionPerk(tfSource);
-
 			if (rand(4) == 0 && changes < changeLimit && player.hairType != HAIR_NORMAL && player.hairType != HAIR_QUILL) {
 				outputText("\n\nYour scalp feels really strange, but the sensation is brief. You feel your hair, and you immediately notice the change. <b>It would seem that your hair is normal again!</b>");
 				player.hairType = HAIR_NORMAL;
@@ -2064,10 +2062,7 @@ package classes.Scenes.Places.Bazaar
 				changes++;
 			}
 			if (rand(4) == 0 && changes < changeLimit && player.echidnaScore() >= 3 && player.hasVagina() && player.findPerk(PerkLib.Oviposition) < 0) {
-				outputText("\n\nDeep inside yourself there is a change.  It makes you feel a little woozy, but passes quickly.  Beyond that, you aren't sure exactly what just happened, but you are sure it originated from your womb.\n");
-				outputText("(<b>Perk Gained: Oviposition</b>)");
-				player.createPerk(PerkLib.Oviposition, 0, 0, 0, 0);
-				changes++;
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			if (rand(3) == 0 && (rand(2) == 0 || !player.inHeat) && player.hasVagina() && player.statusEffectv2(StatusEffects.Heat) < 30) {
 				player.goIntoHeat(true);


### PR DESCRIPTION
Didn't realize, that female Echidnas may gain an Oviposition perk. Well, that should be fixed now.

Fun fact: With the old raceScore checks in `PlayerEvents.as`, players were likely to lose that perk the moment they leave the bazaar.