### PR TITLE
More minor tweaks and fixes

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -407,7 +407,7 @@
 				return;
 			}
 			clearOutput();
-			boxNames.visible = false;
+			if (boxNames != null) boxNames.visible = false;
 			mainView.nameBox.visible = false;
 			player.short = mainView.nameBox.text;
 			if (flags[kFLAGS.LETHICE_DEFEATED] > 0) { //Dirty checking as the NG+ flag is incremented after reincarnating.

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -282,6 +282,7 @@ public function saveScreen():void
 	mainView.nameBox.y = 620;
 	mainView.nameBox.width = 550;
 	mainView.nameBox.text = "";
+	mainView.nameBox.maxChars = 54;
 	mainView.nameBox.visible = true;
 	
 	// var test; // Disabling this variable because it seems to be unused.


### PR DESCRIPTION
- Fix for `Error #1009: Cannot access a property or method of a null object reference` when trying to rename you character upon ascension
- When saving the game, the note box was sometimes limited to 16 chars. Not intensively tested, but that should be hopefully fixed now.