### PR TITLE
Implemented lizard tongue

### DIFF
--- a/classes/classes/Appearance.as
+++ b/classes/classes/Appearance.as
@@ -175,10 +175,11 @@
 		 */
 		public static function tongueDescription(i_character:Character):String
 		{
-			if (i_character.tongueType == 1) return "serpentine tongue";
-			else if (i_character.tongueType == 2) return "demonic tongue";
-			else if (i_character.tongueType == 3) return "draconic tongue";
-			else return "tongue";
+			// fallback for tongueTypes not fully implemented yet
+			if (i_character.tongueType == TONGUE_HUMAN || !DEFAULT_TONGUE_NAMES.hasOwnProperty(i_character.tongueType))
+				return "tongue";
+
+			return DEFAULT_TONGUE_NAMES[i_character.tongueType] + " tongue";
 		}
 
 		public static function nippleDescription(i_creature:Creature, i_rowNum:Number):String
@@ -2262,10 +2263,11 @@
 		public static const DEFAULT_TONGUE_NAMES:Object = createMapFromPairs(
 				[
 					[TONGUE_HUMAN, "human"],
-					[TONGUE_SNAKE, "snake"],
+					[TONGUE_SNAKE, "serpentine"],
 					[TONGUE_DEMONIC, "demonic"],
 					[TONGUE_DRACONIC, "draconic"],
-					[TONGUE_ECHIDNA, "echidna"]
+					[TONGUE_ECHIDNA, "echidna"],
+					[TONGUE_LIZARD, "lizard"],
 				]
 		);
 		public static const DEFAULT_EYES_NAMES:Object = createMapFromPairs(

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -5301,8 +5301,12 @@
 				outputText("\n\nTerrible agony wracks your " + player.face() + " as bones crack and shift.  Your jawbone rearranges while your cranium shortens.  The changes seem to last forever; once they've finished, no time seems to have passed.  Your fingers brush against your toothy snout as you get used to your new face.  It seems <b>you have a toothy, reptilian visage now.</b>", false);
 				player.faceType = FACE_LIZARD;
 			}
-			//-Snake tongue
-			if (player.hasReptileFace() && rand(3) == 0) gainSnakeTongue();
+			//-Lizard tongue
+			if (player.tongueType == TONGUE_SNAKE && changes < changeLimit && rand(10) < 6) // Higher (60%) chance to be 'fixed' if old variant
+				gainLizardTongue();
+
+			if ([TONGUE_LIZARD, TONGUE_SNAKE].indexOf(player.tongueType) == -1 && player.hasReptileFace() && changes < changeLimit && rand(3) == 0)
+				gainLizardTongue();
 			//-Remove Gills
 			if (rand(4) == 0 && player.hasGills() && changes < changeLimit) updateGills();
 			//<mod name="Reptile eyes" author="Stadler76">

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -537,6 +537,56 @@ package classes.Items
 			return false;
 		}
 
+		public function gainLizardTongue():Boolean
+		{
+			if (player.tongueType != TONGUE_LIZARD) {
+				outputText("\n\nYour tongue goes numb, making your surprised noise little more than a gurgle as your tongue flops comically. ");
+				switch (player.tongueType) {
+					case TONGUE_SNAKE:
+						outputText("\nSlowly your tongue swells, thickening up until it's about as thick as your thumb, while staying quite "
+					              +" flexible. You drool, your tongue lolling out of your mouth as you slowly begin to regain control of your forked"
+					              +" organ. When you retract your tongue however, you are shocked to find it is much longer than it used to be,"
+					              +" now a foot long. As you cram your newly shifted appendage back in your mouth, you feel a sudden SNAP,"
+					              +" and on inspection, find you've snapped off your fangs! Well, you suppose you needed the room anyway.");
+						break;
+
+					case TONGUE_DEMONIC:
+						outputText("\nYour tongue gently shrinks down, the thick appendage remaining flexible but getting much smaller. There's"
+					              +" little you can do but endure the weird pinching feeling as your tongue eventually settles at being a foot long."
+					              +" The pinching sensation continues as the tip of your tongue morphs, becoming a distinctly forked shape."
+					              +" As you inspect your tongue you slowly regain control, retracting it into your mouth, the forked tips picking up"
+					              +" on things you couldn't taste before.");
+						break;
+
+					case TONGUE_DRACONIC:
+						outputText("\nYour tongue rapidly shrinks down, the thick appendage remaining flexible but getting much smaller. There's"
+					              +" little you can do but endure the weird pinching feeling as your tongue eventually settles at being a foot long."
+					              +" The pinching sensation continues as the tip of your tongue morphs, becoming a distinctly forked shape."
+					              +" As you inspect your tongue you slowly regain control, retracting it into your mouth, the forked tips picking up"
+					              +" on things you couldn't taste before.");
+						break;
+
+					case TONGUE_ECHIDNA:
+						outputText("\nSlowly your tongue swells, thickening up until it’s about as thick as your thumb, while staying long."
+					              +" The tip pinches making you wince, morphing into a distinctly forked shape. As you inspect your tongue you slowly"
+					              +" regain control, retracting it into your mouth, the forked tips picking up on things you couldn't taste before.");
+						break;
+
+					default:
+						outputText("\nSlowly your tongue swells, thickening up until it’s about as thick as your thumb, filling your mouth as you"
+					              +" splutter. It begins lengthening afterwards, continuing until it hangs out your mouth, settling at 1 foot long."
+					              +" The tip pinches making you wince, morphing into a distinctly forked shape. As you inspect your tongue you slowly"
+					              +" regain control, retracting it into your mouth, the forked tips picking up on things you couldn't taste before.");
+				}
+				outputText("\n\n<b>You now have a lizard tongue!</b>");
+				player.tongueType = TONGUE_LIZARD;
+				dynStats("sen", 5); // Sensitivy gain since its forked
+				changes++;
+			}
+
+			return false;
+		}
+
 		public function gainDraconicHorns(tfSource:String):void
 		{
 			trace('called gainDraconicHorns("' + tfSource + '")');

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1265,7 +1265,7 @@ use namespace kGAMECLASS;
 				lizardCounter++;
 			if (tailType == TAIL_TYPE_LIZARD)
 				lizardCounter++;
-			if (tongueType == TONGUE_SNAKE)
+			if ([TONGUE_LIZARD, TONGUE_SNAKE].indexOf(tongueType) != -1)
 				lizardCounter++;
 			if (lowerBody == LOWER_BODY_TYPE_LIZARD)
 				lizardCounter++;

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -383,6 +383,9 @@ package classes
 				outputText("  Your mouth contains a thick, fleshy tongue that, if you so desire, can telescope to a distance of about four feet.  It has sufficient manual dexterity that you can use it almost like a third arm.");
 			else if (player.tongueType == TONGUE_ECHIDNA)
 				outputText("  A thin echidna tongue, at least a foot long, occasionally flits out from between your lips.");
+			else if (player.tongueType == TONGUE_LIZARD)
+				outputText("  Your mouth contains a thick, fleshy lizard tongue, bringing to mind the tongue of large predatory reptiles."
+				          +" It can reach up to one foot, its forked tips tasting the air as they flick at the end of each movement.");
 			//Horns
 			//Demonic horns
 			if (player.hornType == HORNS_DEMON) 

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -67,6 +67,7 @@ public static const TONGUE_SNAKE:int                                            
 public static const TONGUE_DEMONIC:int                                              =   2;
 public static const TONGUE_DRACONIC:int                                             =   3;
 public static const TONGUE_ECHIDNA:int                                              =   4;
+public static const TONGUE_LIZARD:int                                               =   5;
 
 // eyeType
 public static const EYES_HUMAN:int                                                  =   0;


### PR DESCRIPTION
### Gameplay changes
Lizards now get their very own tongue. For BC both the snake and the lizard tongue add a point to your lizardScore.
If you already have a snake tongue (old variant) the chance is at 60% that its being 'fixed' to become a lizard tongue (no reptile face required in that case).

### Credits
TF blurbs and appearance blurb written by **MissBlackthorne**