### PR TITLE
Bimbofication part 4

### DIFF
--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -840,6 +840,32 @@ package classes {
 			if (flags[kFLAGS.TIME_SINCE_VALA_ATTEMPTED_RAPE_PC] > 0) flags[kFLAGS.TIME_SINCE_VALA_ATTEMPTED_RAPE_PC]--; //Vala post-rape countdown
 			if (flags[kFLAGS.GATS_ANGEL_TIME_TO_FIND_KEY] > 0 && flags[kFLAGS.GATS_ANGEL_TIME_TO_FIND_KEY] < 500) flags[kFLAGS.GATS_ANGEL_TIME_TO_FIND_KEY]++;
 			
+			if (player.armorName == "bimbo skirt") {
+			
+				var wornUpper:Boolean = (player.upperGarment != UndergarmentLib.NOTHING);
+				var wornLower:Boolean = (player.lowerGarment != UndergarmentLib.NOTHING);
+			
+				// If player wears underwear with bimbo skirt, slutty seduction perks are severely reduced
+				if (player.findPerk(PerkLib.SluttySeduction) >= 0) {
+					if (wornLower) {
+						if (wornUpper) player.setPerkValue(PerkLib.SluttySeduction, 1, 0);
+						else 		   player.setPerkValue(PerkLib.SluttySeduction, 1, 1);
+					}
+					else {
+						if (wornUpper) player.setPerkValue(PerkLib.SluttySeduction, 1, 3);
+						else  	       player.setPerkValue(PerkLib.SluttySeduction, 1, 10);
+					}
+				}
+				
+				// Normal tits growth if not wearing bra
+				if (getGame().model.time.hours == 6 && rand(10) == 0 && player.biggestTitSize() < 12 && !wornUpper && !getGame().bimboProgress.ableToProgress()) {
+					outputText("\n<b>As you wake up, you feel a strange tingling starting in your nipples that extends down into your breasts.  After a minute, the tingling dissipates in a soothing wave.  As you cup your tits, you realize they've gotten larger!</b>");
+					player.growTits(1, player.bRows(), false, 2);
+					getGame().dynStats("lus", 10);
+					needNext = true;
+				}
+			}
+			
 			if (getGame().model.time.hours > 23) { //Once per day
 				flags[kFLAGS.BROOKE_MET_TODAY] = 0;
 				if (getGame().model.time.days % 2 == 0 && flags[kFLAGS.KAIJU_BAD_END_COUNTER] > 0) {

--- a/classes/classes/Scenes/Areas/Desert/NagaScene.as
+++ b/classes/classes/Scenes/Areas/Desert/NagaScene.as
@@ -160,7 +160,6 @@ public function nagaEncounter():void {
 
 private function gooNagaRape():void {
 	clearOutput();
-	player.orgasm();
 	outputText("You look over at the prone form of the naga lying in the sand, her ", false);
 	if (monster.HP < 0) outputText("weak ", false);
 	else outputText("flushed ", false);
@@ -249,13 +248,13 @@ private function gooNagaRape():void {
 		outputText("You cry out and shudder as you feel wave after wave of the naga's orgasm rushing over your body, bringing you to a strange orgasmic bliss of your own.", false);
 	} 
 	outputText("  For a moment you just sit there in post orgasmic bliss, the walls of the naga convulsing around your gooey half. You decide that the snake woman has had enough and slowly withdraw yourself from her abused love canal. You gather up your things and head back to your camp, leaving the naga lying in the sands.", false);
+	player.orgasm();
 	combat.cleanupAfterCombat();
 }
 
 //3) Victory male
 private function nagaVictoryMale():void {
 	clearOutput();
-	player.orgasm();
 	//Male or 50% herms
 	if (player.totalCocks() > 0) {
 		//Centaur
@@ -335,7 +334,7 @@ private function nagaVictoryMale():void {
 		}
 	}
 	outputText("You think it would be a very good idea to come to the desert more often.", false);
-	player.orgasm();
+	player.orgasm('Dick');
 	combat.cleanupAfterCombat();
 	return;
 }
@@ -483,6 +482,7 @@ internal function nagaFUCKSJOOOOOO():void {
 		outputText("As the tip of her tail finally comes to rest against your cervix, you find yourself succumbing to another orgasm, your slutty wails of pleasure encouraging the naga to continue. As you begin to calm down again, you believe that this is the deepest the naga will go, although your brain works really hard and comes up with a desire for MORE depth...", false);
 		//PROPER stretched.
 		player.cuntChange((player.vaginalCapacity() + 5),true,true,false);
+		player.orgasm('Vaginal');
 		outputText("\n\n", false);
 		
 		outputText("Then, like, your wish totally comes true! The naga's tail begins to bash itself against your cervix, searching for the weak point. Her hands hold you steady as her thrusts begin to increase in intensity. It's not long into this rough tail-fucking that you find yourself on the verge of orgasm again, totally turned on by the sight of your own " + player.allBreastsDescript() + " bouncing as she fucks you. The naga grits her teeth, and, with one last, powerful thrust, forces her tail inside of your womb, pushing through your well-pounded, well-used cervix. She manages to stuff enough tail inside you to cause a visible bulge in your stomach. This combination of sensations is too much for your tiny brain, and sends your head spinning as your climax reaches its peak. Your already weak mind slips even further, your vision fading. The last thing you see is the naga's smiling face, her cheeks flushed and her eyes full of passion.", false);
@@ -560,6 +560,7 @@ internal function nagaFUCKSJOOOOOO():void {
 			else 
 				outputText("You end up enjoying the whole thing. She then gets back up and leave you there, not without looking back. You stay there, lying on the sand for a few moments before you doze off in a nap.  After you wake, you finally decide to head back to your camp.", false);
 		}
+		player.orgasm('Dick');
 	}
 	//b) female //http://nekomimichan.org/mg/src/12844585127.jpg
 	else if (player.hasVagina()) {
@@ -667,6 +668,7 @@ internal function nagaFUCKSJOOOOOO():void {
 		}
 		outputText("  ", false);
 		player.cuntChange(40,true);
+		player.orgasm('Vaginal');
 	}
 	//d) genderless
 	else {
@@ -686,8 +688,8 @@ internal function nagaFUCKSJOOOOOO():void {
 		outputText("Her tail starts to squeeze you even tighter and you start having trouble breathing, causing you to pull your head back. The naga looks down at you, begging you to continue until she realizes what she was doing all along. Slowly, she unwraps you, giving you some time to catch your breath before finishing the job.\n\n", false);
 		
 		outputText("You bring your mouth back to her awaiting hole and redouble your efforts. You can feel that she is nearing her peak as you continue to lick at her pussy. With a final shudder the naga climaxes, squeezing you firmly against her, coating your chin and nose with her thick honey.  As the naga relaxes her grip you slide out from her loosened tail coils.  Exhausted, you lose consciousness, but when you awake, you grab your things and leave the moistened sands behind.", false);
+		player.orgasm('Lips');
 	}
-	player.orgasm();
 	combat.cleanupAfterCombat();
 }
 

--- a/classes/classes/Scenes/Areas/Forest/AkbalScene.as
+++ b/classes/classes/Scenes/Areas/Forest/AkbalScene.as
@@ -1362,6 +1362,7 @@ package classes.Scenes.Areas.Forest
 
 		private function topAkbitchFromBottomDuex():void
 		{
+			var analOrgasm:Boolean = false;
 			clearOutput();
 			outputText(images.showImage("akbal-deepwoods-male-akbalonback2"));
 			//-page turn-
@@ -1391,13 +1392,14 @@ package classes.Scenes.Areas.Forest
 				else
 					outputText(" climaxes");
 				outputText(".  Your [vagOrAss] spasms around the demon’s embedded cock as [eachCock] paints his chest and face with a generous coating of baby batter.  Your orgasm rages on, covering the demon cat in your sex fluids, matting his fur and darkening it with more seed than you ever thought possible.");
+				analOrgasm = true;
 			}
 			//[if (hasCock = false)
 			else
 				outputText("\n\nEvery nerve ending in your body explodes as you convulse atop the jaguar.  With a hoarse groan, your [vagOrAss] begins to spasm around the embedded pleasure rod as it gushes more fluid than you thought possible.  Soon the Jaguar is soaked from waist to thigh.");
 
 			outputText("\n\nYou look back at your new bitch with a grin while he regains his senses.  As you leave the forest, you hear a promise from Akbal’s chorus of voices, \"<i>You will regret this... Champion.</i>\"");
-			player.orgasm();
+			player.orgasm(analOrgasm ? 'Anal' : 'Vaginal');
 			dynStats("cor", 3);
 			if (player.hasVagina())
 				player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);

--- a/classes/classes/Scenes/Areas/HighMountains/IzumiScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/IzumiScene.as
@@ -964,6 +964,7 @@ package classes.Scenes.Areas.HighMountains
 		protected function surrenderFemaleNonExhibitionVariant():void
 		{
 			clearOutput();
+			var titsOrgasm:Boolean = false;
 
 			outputText("You squirm desperately, the feeling of a dozen pairs of eyes leering at you making you feel decidedly uncomfortable.  Izumi apparently notices your distress, however, as a few seconds later you hear a thunderous crack as she reaches out to a nearby outcropping of jagged rock, snapping it off with one massive hand.\n\n");
 
@@ -1061,9 +1062,10 @@ package classes.Scenes.Areas.HighMountains
 				outputText("You open your mouth to gasp for air, Izumi’s head darts forwards and she locks her lips to yours, pulling you into a sudden french kiss.  Her tongue wraps around your own, bizarrely flexible as it invades your mouth, forcing you to surrender to her embrace.  She runs her hands over your body and you can only moan feebly into her mouth as your orgasm begins to rise within you, suffusing your entire being as you flex and strain inside Izumi’s iron grip.  You squirm and buck your hips desperately and Izumi pins you down, riding out your orgasm as she strums away at your desperate nethers, your juices splattering wetly across the cave floor.\n\n");
 
 				outputText("Izumi releases you, a trail of saliva hanging between your exhausted mouths for a moment before she gives you an indulgent pat on the behind and rises to her feet, licking suggestively at her fingers.  You shakily pull your clothes towards you and redress, while Izumi settles back down to take a long drag from her pipe, eyeing you with clear amusement as you attempt to cover yourself.  You decide to make your escape before the big woman decides to rope you into another, more strenuous round of sexual wrestling...\n\n");
+				titsOrgasm = true;
 			}
 
-			player.orgasm();
+			player.orgasm(titsOrgasm ? 'Tits' : 'Vaginal');
 
 			menu();
 			doNext(camp.returnToCampUseOneHour);

--- a/classes/classes/Scenes/Areas/Lake/GooGirlScene.as
+++ b/classes/classes/Scenes/Areas/Lake/GooGirlScene.as
@@ -218,6 +218,7 @@ package classes.Scenes.Areas.Lake
 		{
 			clearOutput();
 			outputText("You sway, finding it difficult to maintain your balance. When you fall, your " + player.buttDescript() + " splashes wetly in the enveloping folds of the goo-girl's eager slime. You weakly hold your hand up to keep her back, but the wide-eyed victor disregards the gesture with playful disdain. She slithers against you, moist muck slurping at your flesh with a hungry heat. Her semi-solid hands take yours, pulling your arms apart to bare your chest. She cranes her dripping head around your shoulders, skillfully removing your " + player.armorName + " with only her mouth. Your " + player.chestDesc() + " heave as the irrepressible heat of the slime sears your " + player.nippleDescript(0) + "s until beads of sweat well up on your " + player.skin() + " and trickle down your curves, leaving a wet sheen over your body.\n\n", false);
+			var titsOrgasm:Boolean = false;
 
 			//[If the player is pregnant]
 			if (player.pregnancyIncubation <= 280 && player.pregnancyIncubation >= 1) {
@@ -232,6 +233,7 @@ package classes.Scenes.Areas.Lake
 				//[player breast size increase, lactation activated/ amount increases]
 				player.breastRows[0].breastRating++;
 				player.boostLactation(1);
+				titsOrgasm = true;
 			}
 			//[Pregnancy continued]
 			if (player.pregnancyIncubation <= 280 && player.pregnancyIncubation >= 1) {
@@ -243,6 +245,7 @@ package classes.Scenes.Areas.Lake
 				else if (player.lactationQ() <= 2000) outputText("  She drinks gratefully, nursing you with her permeable body until the pout of her belly sloshes heavily with the pale ivory of your motherly bounty.", false);
 				else outputText("  You bite your lip and let go, torrents of rich, pearl fluid rushing through her arms and inflating the surprised girl before your eyes. The milk gushing into her fills the goo from base to breast, giving the once-" + gooColor5() + " girl an opalescent shine, her over-filled body bloated as if she were carrying triplets.", false);
 				outputText("  She gives you a fond bop on the chin and a loving stroke on your belly before sloshing back into the lake, her seething heat still clinging to your body like a lingering hug.", false);
+				titsOrgasm = true;
 			}
 			//[If the player isn't pregnant]
 			else {
@@ -262,7 +265,7 @@ package classes.Scenes.Areas.Lake
 					player.knockUp(PregnancyStore.PREGNANCY_GOO_GIRL, PregnancyStore.INCUBATION_GOO_GIRL, 1, 1);
 				}
 			}
-			player.orgasm();
+			player.orgasm(titsOrgasm ? 'Tits' : 'Vaginal');
 			dynStats("sen", 4);
 			player.slimeFeed();
 			combat.cleanupAfterCombat();

--- a/classes/classes/Scenes/BimboProgression.as
+++ b/classes/classes/Scenes/BimboProgression.as
@@ -69,7 +69,7 @@ package classes.Scenes
 		}
 		
 		public function toggleProgress():void {
-			flags[kFLAGS.USE_OLD_INTERFACE] ^= 1;
+			flags[kFLAGS.BIMBO_MINISKIRT_PROGRESS_DISABLED] ^= 1;
 			getGame().inventory.inventoryMenu();
 		}
 		

--- a/classes/classes/Scenes/Combat/CombatTeases.as
+++ b/classes/classes/Scenes/Combat/CombatTeases.as
@@ -76,7 +76,7 @@ package classes.Scenes.Combat
 			//10% for seduction perk
 			if (player.findPerk(PerkLib.Seduction) >= 0) chance += 10;
 			//10% for sexy armor types
-			if (player.findPerk(PerkLib.SluttySeduction) >= 0) chance += 10;
+			if (player.findPerk(PerkLib.SluttySeduction) >= 0) chance += player.perkv1(PerkLib.SluttySeduction);
 			//10% for bimbo shits
 			if (player.findPerk(PerkLib.BimboBody) >= 0) {
 				chance += 10;
@@ -95,6 +95,7 @@ package classes.Scenes.Combat
 				chance += 2;
 			}
 			if (player.findPerk(PerkLib.ChiReflowLust) >= 0) chance += UmasShop.NEEDLEWORK_LUST_TEASE_MULTI;
+			if (getGame().bimboProgress.ableToProgress()) chance += player.bimboScore() / 2; // up to maximum value of 10 for pure bimbos 
 			//==============================
 			//Determine basic damage.
 			//==============================
@@ -110,6 +111,7 @@ package classes.Scenes.Combat
 				damage += 5;
 				bimbo = true;
 			}
+			if (getGame().bimboProgress.ableToProgress()) damage += player.bimboScore() / 4; // up to maximum value of 5 for pure bimbos
 			if (player.level < 30) damage += player.level;
 			else if (player.level < 60) damage += 30 + ((player.level - 30) / 2);
 			else damage += 45 + ((player.level - 60) / 5);

--- a/classes/classes/Scenes/NPCs/CeraphScene.as
+++ b/classes/classes/Scenes/NPCs/CeraphScene.as
@@ -1298,6 +1298,7 @@ package classes.Scenes.NPCs
 					outputText("\n\nIn a panic, you wriggle your tit-tail, propelling yourself around the confines of your small chamber.  The door is locked, as always, but you press your tight, hard nipples against it anyhow.  Mistress has kept you pent up for so long, trapped away in this little box.  You regret everything!  You'll never doubt her again!  She was so right... nipples can feel so wonderfully, exquisitely pleasureable, but you can't take it any longer.  Every movement, every sinuous slide, they feel so good.  You can cum just from pacing about, but you know you'll just wind up a twisted, curling mass of squirming nipple-flesh, your tail half-tied in knots as it tries to rub each pair of breasts against another. You know because you've done it countless times already.");
 					outputText("\n\nA spiral of pain twists through your pleasure-wounded psyche, and you remember yourself, not the demon-enslaved naga.  Still, conjoined as your minds are, you're able to recognize that one of those many breasts used to be yours.  Ceraph has put it to good use.  The realization jars you to wakefulness, and you're forced to try and go to sleep with the knowledge that somewhere, your breasts are being used to break a naga.  Sleep does not return easily.");
 					dynStats("lus", 5 + player.lib / 5);
+					player.orgasm('Tits',false);
 				}
 				//Milk Dispenser
 				else if (subChoice == 1) {
@@ -1305,6 +1306,7 @@ package classes.Scenes.NPCs
 					outputText("\n\nSuddenly, from out of nowhere, you hear a voice in the silence, \"<i>Well, I can't thank [name] enough for these.  No shortage of milk here!</i>\"  Then, there is brightness.  The appearance of light reveals a strange, disembodied view of a demon standing next to a tank. It's Ceraph!  She holds a cup of coffee, and as she pulls a lever, creamy breast milk flows into the mocha-colored beverage, lightening it significantly. Your tits, hooked up to some kind of odd machinery, tremble and shake as fluids are fed into them by transparent cables.  The speed of the milking increases, gallons gushing from your tender teats in mere seconds.  Faster and faster the liquids flow, a veritable waterfall of lactic cream.");
 					outputText("\n\nErotic energy sizzles through your nipples as the milking goes faster and faster, the pleasure unbearable.  Sadly, just when you feel on the cusp of orgasm, the machine shuts down, and the vision fades.  There will be no relief for you tonight.");
 					dynStats("lus", 5 + player.lib / 5);
+					player.orgasm('Tits',false);
 				}
 				//Tit Volleyball
 				else {
@@ -1324,6 +1326,7 @@ package classes.Scenes.NPCs
 					if (silly()) outputText(" and what possible ramifications it has for your mental health");
 					outputText(", until you dismiss it as corruption and toss over, entering a peaceful, dreamless sleep.");
 					dynStats("lus", 5 + player.lib / 5);
+					player.orgasm('Tits',false);
 				}
 			}
 			//COCKUUUU

--- a/classes/classes/Scenes/NPCs/Exgartuan.as
+++ b/classes/classes/Scenes/NPCs/Exgartuan.as
@@ -392,6 +392,7 @@ public function exgartuanMasturbation():void {
 		dynStats("sen", .25, "lus", 15, "cor", 1);
 		if (player.biggestLactation() > 1) outputText("As you calm down you realize your " + player.nippleDescript(0) + "s are dribbling streams of milk, and judging from the pools of whiteness in the soil, you turned into quite the little milk-sprinkler.  ", false);
 		outputText("You blush and redress, noting that Exgartuan seems to be silent and sleeping...  maybe you'll get a little peace now?", false);
+		player.orgasm('Tits',false);
 	}
 	player.changeStatusValue(StatusEffects.Exgartuan,2,(12+rand(7)));
 	doNext(camp.returnToCampUseOneHour);
@@ -1331,6 +1332,7 @@ private function boobgartuanSurprise3():void {
 	else outputText("  Your fingertips continue to sweep across your " + player.skin() + ", seemingly in denial that the exciting night has drawn to a close.  You peer up at the ever-present moon, its crimson hue as foreboding as the day you first arrived in Mareth.  You stew on the prospect of apologizing to the demoness for your forgetfulness.  Though, be it for your pride or hers, you decide it better to just shelf the idea.  All Exgartuan cares about is attention and fucking, better to not go and try to turn her into a conversationalist.  Best to just tend to her every so often if you actually do care.  Once you've taken care of your own lust anyway.  You shake some sense back into your head, sending some dirt flying.  The \"<i>breast show on earth</i>\" left you soaked, your milk turning the dirt to mud around you.  You figure it best to worry about it once you're at camp.  You begin the trek back, a little smile growing on your face once you see the trail of milk you're leaving behind in your wake.", false);
 	//[corruption +2, lust +5] 
 	dynStats("lus", 5, "cor", 2);
+	player.orgasm('Tits',false);
 	flags[kFLAGS.BOOBGARTUAN_SURPRISE_COUNT]++;
 	player.changeStatusValue(StatusEffects.Exgartuan,2,25);
 	doNext(playerMenu);

--- a/classes/classes/Scenes/NPCs/HelFollower.as
+++ b/classes/classes/Scenes/NPCs/HelFollower.as
@@ -1746,6 +1746,7 @@ private function girlsThreesomeHelAndKiha():void {
 	
 	outputText("\n\nWith the two lizard-girls distracted, you languidly pull their limp tails out of your holes, relishing the blessedly empty feeling left before you collapse into a pool of your own juices... just to catch your breath, you insist.");
 	player.orgasm();
+	player.orgasm('Anal',false);
 	dynStats("sen", -2);
 	doNext(camp.returnToCampUseOneHour);
 }

--- a/classes/classes/Scenes/NPCs/HelScene.as
+++ b/classes/classes/Scenes/NPCs/HelScene.as
@@ -223,6 +223,7 @@ internal function loseToSalamander():void {
 		outputText(".  She gasps at the sensation and grabs your hips as another shot goes off inside her.  Panting, she gives you one massive, final thrust and cums herself, squeezing your " + player.cockDescript(x) + " hard inside her and screaming as brutal a scream as any warcry to the heavens.", false);
 
 		outputText("She collapses atop you, panting heavily.  \"<i>That.  Was.  Awesome,</i>\" she laughs, reaching up to give your nipple a pinch as she nestles her head on you.  Your cock begins to deflate inside her as trickles of spooge spill out around your girth, but she doesn't seem intent on leaving any time soon, and you have to admit, the warmth of her against you is more than nice.  The salamander gives you one last grin and withdraws her tail from your lips.  A moment later, she slides it under your head like a pillow, and closes her eyes, exhausted.  Soon, you, too, fall into a peaceful sleep.\n\n", false);
+		player.orgasm('Dick');
 	}
 	//Player Loss – Rape – Female
 	else if (player.hasVagina()) {
@@ -245,6 +246,7 @@ internal function loseToSalamander():void {
 		outputText(".\n\n", false);
 
 		outputText("Before your mind has settled, your new friend has collapsed on top of you, resting her cheek on your " + player.chestDesc() + ".  Her breath is ragged, not unlike yours, and her eyelids seem suddenly heavy.  Smiling, she slowly withdraws her cum-soaked tail from your " + player.vaginaDescript(0) + " and slips it under your head like a pillow, soft and warm, if not a little moist.  Seeing as she doesn't seem intent on going anywhere, you, too, close your eyes and drift off to a peaceful sleep.", false);
+		player.orgasm('Vaginal');
 	}
 	//Player Loss – Rape – Genderless & Male >85 cockarea
 	else {
@@ -268,8 +270,10 @@ internal function loseToSalamander():void {
 		outputText("All good things must come to an end, however, and soon the salamander's hot cunt contracts around your tongue as she cums, squirting girl-juice all over your face and neck.  You give her a last good tongue-fucking, picking up the pace and bringing her to a screaming, shuddering climax.  The power of her orgasm has a welcome side effect, as her tail begins to thrash wildly within you, battering your ass and bringing you, too, to a massive, mind-numbing climax.\n\n", false);
 
 		outputText("Before your mind has settled, your new friend has collapsed on top of you, resting her cheek on your " + player.chestDesc() + ".  Her breath is ragged, not unlike yours, and her eyelids seem suddenly heavy.  Smiling, she slowly withdraws her tail from your " + player.assholeDescript() + " and slips it under your head like a pillow, soft and warm, if not a little moist.  Seeing as she doesn't seem intent on going anywhere, you, too, close your eyes and drift off to a peaceful sleep.", false);
+		
+		player.orgasm('Anal');
+		
 	}
-	player.orgasm();
 	dynStats("sen", 1);
 	flags[kFLAGS.HEL_FUCK_COUNTER]++;
 	flags[kFLAGS.HEL_AFFECTION]++;

--- a/classes/classes/Scenes/NPCs/JojoScene.as
+++ b/classes/classes/Scenes/NPCs/JojoScene.as
@@ -587,6 +587,7 @@ public function useTentacleJojo():void {
 		else outputText("  Somehow you know they won't get any bigger from his rough treatment.", false);
 		outputText("  Your " + player.allBreastsDescript() + " finally feel emptied; it's a relief.\n\n", false);
 		milkPuddle = true;
+		player.orgasm('Tits',false);
 	}
 	//Titfucking breastgasm
 	if (titFucking) {
@@ -618,6 +619,7 @@ public function useTentacleJojo():void {
 	player.buttChange(40, true);
 	player.cuntChange(40, true);
 	player.orgasm();
+	player.orgasm('Anal',false);
 	dynStats("cor", .5);
 	doNext(camp.returnToCampUseOneHour);
 }

--- a/classes/classes/Scenes/NPCs/ShouldraScene.as
+++ b/classes/classes/Scenes/NPCs/ShouldraScene.as
@@ -1103,7 +1103,8 @@ private function genderlessShouldrasLossRapes():void {
 	outputText(".  With a happy sigh, you heave yourself upright, slipping back into your " + player.armorName + " and moving out into the ruins once more.\n\n", false);
 	outputText("A strange sensation begins in your midsection, and you press a hand against the flesh curiously. You remove it swiftly as a familiar head suddenly pushes out, wiggling about until it faces you. She smiles, then draws her arms out of her torso and uses them as leverage (with a whispered spell to make her hands tangible) to remove herself from you completely. Muttering an incantation and solidifying her again-unremarkable form, she winks at you and gathers her tunic, slipping it over her frame. As you watch, she slips her thumb and forefinger into her satisfied snatch, producing a healthy helping of a spooky gooey substance. Reaching into a pocket inside her tunic, she draws out a small bottle, which she promptly squishes the ectoplasm into. She offers you the bottle, explaining, \"<i>The product of a... ghost climax, if you will. Keep it, it's good for you.</i>\"  With a happy goodbye, she wanders into an alley, grabbing her ruined leggings and discarded shoes as she goes, and disappears into the shadows. You move to leave, but find your " + player.legs() + " growing heavy, fatigue washing over you in the aftermath of the possession. Before you know it, you're on your knees, and you have to struggle to keep your eyelids from drooping. You succumb to the exhaustion, slumping to the ground and soon snoring contentedly.", false);
 	flags[kFLAGS.SHOULDRA_GENDERLESS_FUCK_COUNT]++;
-	player.orgasm();
+	player.orgasm('Tits');
+	player.orgasm('Anal',false);
 	dynStats("sen", 1);
 	if (getGame().inCombat) {
 		flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID] = consumables.ECTOPLS.id;

--- a/classes/classes/Scenes/NPCs/Valeria.as
+++ b/classes/classes/Scenes/NPCs/Valeria.as
@@ -660,6 +660,7 @@ private function valeriaGooRapeII():void {
 			player.breastRows[x].breastRating += 3 + rand(3);
 		}
 		outputText(" Your tits have grown much larger, " + player.breastCup(0) + "-cups at least.");
+		player.orgasm('Tits',false);
 	}
 	if (player.hasCock() && player.balls > 0) {
 		player.ballSize += 3 + rand(2);

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -438,6 +438,28 @@ public function goNext(time:Number, needNext:Boolean):Boolean  {
 			return true;
 		}
 	}
+	//Unequip undergarment if bimbo skirt & corruption
+	if (player.armorName == "bimbo skirt" && player.cor >= 10 && player.upperGarment != UndergarmentLib.NOTHING) {
+		outputText("\nYou are feeling strange heat in your [breasts]. The thought of how much more pleasure you'll have without the embarassing strain from your " + player.upperGarmentName + " drives you into the frenzy. You take of the top of your dress, put off the garment and start teasing your [nipples], feeling lost in the waves warmth radiating through you body. Eventually, the pleasure subsides, but you decide to stay without your " + player.upperGarmentName + " for a while.\n\n");
+		kGAMECLASS.dynStats("lus", 10);
+		inventory.takeItem(player.setUndergarment(UndergarmentLib.NOTHING, 0), playerMenu);
+		return true;
+	}
+	if (player.armorName == "bimbo skirt" && player.cor >= 10 && player.lowerGarment != UndergarmentLib.NOTHING) {
+		outputText("\nLost in strange thought, you reach with your hand under the skirt. You take of you " + player.lowerGarmentName + " and immediately feel the increased sensitivity of your skin. You think how irresistible seductive you'll become without that embarassing underwear, and decide to stay that way.\n\n");
+		kGAMECLASS.dynStats("lus", 10);
+		inventory.takeItem(player.setUndergarment(UndergarmentLib.NOTHING, 1), playerMenu);
+		return true;
+	}
+	if (player.armorName == "bimbo skirt" && player.upperGarment != UndergarmentLib.NOTHING && flags[kFLAGS.TIMES_ORGASM_TITS] > 10) {
+		outputText("\nThe pressure building in your [breasts] becomes unbearable. Hastily, you take off your " + player.upperGarmentName + " and start teasing your nipples. ");
+		if (kGAMECLASS.bimboProgress.ableToProgress()) {
+			kGAMECLASS.bimboProgress.titsOrgasm();
+			
+		}
+		inventory.takeItem(player.setUndergarment(UndergarmentLib.NOTHING, 0), playerMenu);
+		return true;
+	}
 	//Unequip shield if you're wielding a large weapon.
 	if (player.weaponPerk == "Large" && player.shield != ShieldLib.NOTHING) {
 		outputText("Your current weapon requires the use of two hands. As such, your shield has been unequipped automatically. ");


### PR DESCRIPTION
- Fixed bug in toggling bimbofication on/off through items menu
- Underwear protects from bimbofication, but if corruption is above 10, underwear is removed. 
- Bimbo progression adds to tease damage and tease chance proportionally to the bimbo score. The maximal efect is equal to effect of bimboBody perk
- If bimbo progression is disabled, bimbo skirt gives 10% chance of breast expansion every day (as was initially coded)

+ Customized some orgasms