### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-language: actionscript
+language: java
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - Xvnc :1 &
  
 script:
+    # this is where the build happens. A separate build is started for every entry in the matrix element
   - ant test-$BUILD
 
 env:
@@ -26,5 +27,6 @@ env:
     # this is to trick the flash player into thinking it is running on a desktop
     - DISPLAY=":1"
   matrix:
+    # different configurations that should be built
     - BUILD="release"
     - BUILD="debug"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: required
+
+# travis-ci does not support actionscript.
+# However the build uses ant, which is usually used to build java projects.
+# The ant task (mxmlc) provided by the flex SDK (ant/lib/flexTasks.jar) is used to build the project.
 language: java
 
 before_install:


### PR DESCRIPTION
The language setting seemed obvious, so documenting it never occurred to me.
This will hopefully make it more clear why `language: java` is used.

- Documented `language` element
- Documented `script` step