### PR TITLE
Isabella appearance tests

### DIFF
--- a/classes/classes/Scenes/NPCs/IsabellaFollowerScene.as
+++ b/classes/classes/Scenes/NPCs/IsabellaFollowerScene.as
@@ -258,8 +258,11 @@ private function backToCamp():void
 	doNext(kGAMECLASS.farm.farmCorruption.rootScene);
 }
 
-private function isabellasAppearance():void {
+protected function isabellasAppearance():void {
 	clearOutput();
+	
+	//TODO use a Stringbuffer to construct the text, then return it to the function that does the output
+	//TODO move text into public static constant so we can use it for tests
 	
 	if (isabellaScene.pregnancy.isPregnant) {
 		switch(isabellaScene.pregnancy.event) {

--- a/classes/classes/Scenes/NPCs/IsabellaFollowerScene.as
+++ b/classes/classes/Scenes/NPCs/IsabellaFollowerScene.as
@@ -258,23 +258,50 @@ private function backToCamp():void
 	doNext(kGAMECLASS.farm.farmCorruption.rootScene);
 }
 
+/*
+ * Using const variables so text changes also affect the tests, otherwise fixing simple spelling errors will break the tests.
+ * If anyone has a better idea, let me know @brrritssocold
+ */
+
+/**
+ * This scene is used if there are no pregnancy events stored for the given pregnancy.
+ */
+public static const DESC_APPEAR_NO_EVENTS_FOR_PREG_TYPE:String = "you cannot help but question as to whether or not your seed was \"planted\" in the Bovine Braud's womb.";
+/**
+ * Display addition information if the player has a high amount of cum.
+ */
+public static const DESC_APPEAR_PLAYER_HIGH_CUMQ:String = "and your potent babymaking skills, ";
+/**
+ * Display addition information if the player has a high amount of libido.
+ */
+public static const DESC_APPEAR_PLAYER_HIGH_LIBIDO:String = "Every once in a while when the wind blows just right you get a pleasing view of her well lubricated womanhood between her legs. ";
+/**
+ * Description of isabella if not pregnant
+ */
+public static const DESC_APPEAR_EVENT_NOT_PREGNANT:String = "The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Isabella's top is sheer, white silk that barely hides anything from you, least of all her exotic, quad-tipped nipples. Unlike most of the rest of her, her face is not spotted with dark and white patches. Instead it is pure, unbroken chocolate in color. Two small, bovine horns sprout from her head, emerging from the tangle of her unruly, red curls. She even has a pair of cow ears that flick back and forth from time to time.";
+/**
+ * Description of isabella if she is in the first event stage of pregnancy
+ */
+public static const DESC_APPEAR_EVENT_FIRST_STAGE_PREGNANT:String = "The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Since you did the deed you often find her on her plump, toned, derriere. ";
+/**
+ * Description of isabella if she is in the last event stage of pregnancy
+ */
+public static const DESC_APPEAR_EVENT_LAST_STAGE_PREGNANT:String = "The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. The large woman knees shake slightly when she stands. You find yourself staring at the Bovine's large, exposed bust as it shifts with every breath, her poor exotic nipples slowly leaking out milk in a constant trickle that leaves her melon-like belly glazed and slick, already prepared to feed your offspring. Every once in awhile, you hear a giggle escape the braud as she rubs her large swollen belly. Upon further questioning she simply responds that \"it kicked.\" Unlike most of the rest of her, her face is not spotted with dark and white patches. Instead it is pure, unbroken chocolate in color. Two small, bovine horns sprout from her head, emerging from the tangle of her unruly, red curls. She even has a pair of cow ears that flick back and forth from time to time. Isabella seems to be suffering chronic bouts of pain (mock contractions, perhaps?), but still manages to smile when she sees you look her way. You don't think it'll be long now.";
+
 protected function isabellasAppearance():void {
 	clearOutput();
-	
-	//TODO use a Stringbuffer to construct the text, then return it to the function that does the output
-	//TODO move text into public static constant so we can use it for tests
-	
+
 	if (isabellaScene.pregnancy.isPregnant) {
 		switch(isabellaScene.pregnancy.event) {
 			case 0: //Just in case
 			case 1:
 				outputText("The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Isabella's top is sheer, white silk that barely hides anything from you, least of all her exotic, quad-tipped nipples. Unlike most of the rest of her, her face is not spotted with dark and white patches. Instead it is pure, unbroken chocolate in color. Two small, bovine horns sprout from her head, emerging from the tangle of her unruly, red curls. She even has a pair of cow ears that flick back and forth from time to time. Very little has changed since you two decided to have a child. Despite the fact that Isabella is off her birth controlling herbs, "); 
-				if (player.cumQ() >= 500) outputText("and your potent babymaking skills, "); 
-				outputText("you cannot help but question as to whether or not your seed was \"planted\" in the Bovine Braud's womb.");
+				if (player.cumQ() >= 500) outputText(DESC_APPEAR_PLAYER_HIGH_CUMQ); 
+				outputText(DESC_APPEAR_NO_EVENTS_FOR_PREG_TYPE);
 				break;
 			case 2:
-				outputText("The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Since you did the deed you often find her on her plump, toned, derriere. ");
-				if (player.lib >= 60) outputText("Every once in a while when the wind blows just right you get a pleasing view of her well lubricated womanhood between her legs. "); 
+				outputText(DESC_APPEAR_EVENT_FIRST_STAGE_PREGNANT);
+				if (player.lib >= 60) outputText(DESC_APPEAR_PLAYER_HIGH_LIBIDO); 
 				outputText("Several times you've asked her if she is okay but she assures you it is just swollen ankles. Isabella's top is sheer, white silk that barely hides anything from you, least of all her exotic, quad-tipped nipples, and what you hope is a new slightly protruding baby bump. Unlike most of the rest of her, her face is not spotted with dark and white patches. Instead it is pure, unbroken chocolate in color. Two small, bovine horns sprout from her head, emerging from the tangle of her unruly, red curls. She even has a pair of cow ears that flick back and forth from time to time.");
 				break;
 			case 3:
@@ -297,14 +324,14 @@ protected function isabellasAppearance():void {
 				break;
 			case 9:
 			case 10:
-				outputText("The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. The large woman knees shake slightly when she stands. You find yourself staring at the Bovine's large, exposed bust as it shifts with every breath, her poor exotic nipples slowly leaking out milk in a constant trickle that leaves her melon-like belly glazed and slick, already prepared to feed your offspring. Every once in awhile, you hear a giggle escape the braud as she rubs her large swollen belly. Upon further questioning she simply responds that \"it kicked.\" Unlike most of the rest of her, her face is not spotted with dark and white patches. Instead it is pure, unbroken chocolate in color. Two small, bovine horns sprout from her head, emerging from the tangle of her unruly, red curls. She even has a pair of cow ears that flick back and forth from time to time. Isabella seems to be suffering chronic bouts of pain (mock contractions, perhaps?), but still manages to smile when she sees you look her way. You don't think it'll be long now.");
+				outputText(DESC_APPEAR_EVENT_LAST_STAGE_PREGNANT);
 				break;
 			default: //Failsafe
 				outputText("The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Isabella's top is sheer, white silk that barely hides anything from you, least of all her exotic, quad-tipped nipples. Unlike most of the rest of her, her face is not spotted with dark and white patches. Instead it is pure, unbroken chocolate in color. Two small, bovine horns sprout from her head, emerging from the tangle of her unruly, red curls. She even has a pair of cow ears that flick back and forth from time to time.");
 		}
 	}
 	else {
-		outputText("The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Isabella's top is sheer, white silk that barely hides anything from you, least of all her exotic, quad-tipped nipples. Unlike most of the rest of her, her face is not spotted with dark and white patches. Instead it is pure, unbroken chocolate in color. Two small, bovine horns sprout from her head, emerging from the tangle of her unruly, red curls. She even has a pair of cow ears that flick back and forth from time to time.");
+		outputText(DESC_APPEAR_EVENT_NOT_PREGNANT);
 	}
 	doNext(callForFollowerIsabella);
 }

--- a/classes/classes/Scenes/NPCs/IsabellaScene.as
+++ b/classes/classes/Scenes/NPCs/IsabellaScene.as
@@ -16,7 +16,7 @@
 		public function IsabellaScene()
 		{
 			pregnancy = new PregnancyStore(kFLAGS.ISABELLA_PREGNANCY_TYPE, kFLAGS.ISABELLA_PREGNANCY_INCUBATION, 0, 0);
-			pregnancy.addPregnancyEventSet(PregnancyStore.PREGNANCY_PLAYER, 2160, 1920, 1680, 1440, 1200, 960, 720, 480, 240);
+			pregnancy.addPregnancyEventSet(PregnancyStore.PREGNANCY_PLAYER, 2160, 1920, 1680, 1440, 1200, 960, 720, 480, ISABELLA_PREGNANCY_LAST_STAGE);
 			CoC.timeAwareClassAdd(this);
 		}
 		
@@ -30,6 +30,8 @@
 		public static const OFFSPRING_HUMAN_HERMS:int = 3;
 		public static const OFFSPRING_COWGIRLS:int = 4;
 		public static const OFFSPRING_COWFUTAS:int = 5;
+		
+		public static const ISABELLA_PREGNANCY_LAST_STAGE:int = 240;
 		
 		//Implementation of TimeAwareInterface
 		public function timeChange():Boolean

--- a/test/classes/Scenes/NPCs/IsabellaFollowerSceneTest.as
+++ b/test/classes/Scenes/NPCs/IsabellaFollowerSceneTest.as
@@ -1,0 +1,176 @@
+package classes.Scenes.NPCs
+{
+	import classes.DefaultDict;
+    import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import classes.helper.StageLocator;
+	
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.CoC;
+	import classes.PregnancyStore;
+	import classes.Scenes.NPCs.IsabellaFollowerScene;
+	import classes.PerkLib;
+	import classes.CockTypesEnum;
+	
+	public class IsabellaFollowerSceneTest 
+	{
+		private var isabellaScene : IsabellaScene;
+		private var cut:IsabellaFollowerSceneForTest;
+		private var player:Player;
+		
+		private static const INCUBATION_DELTA : int = 10;
+		/**
+		 * This is used to skip time to the last pregnancy stage
+		 */
+		private static const ADVANCE_PREGNANCY : int = PregnancyStore.INCUBATION_ISABELLA - (IsabellaScene.ISABELLA_PREGNANCY_LAST_STAGE - INCUBATION_DELTA);
+		
+		public function IsabellaFollowerSceneTest() 
+		{
+		}
+		
+		[BeforeClass]
+		public static function setUpClass():void {
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+		
+		private function setUpIsabella() : void {
+			isabellaScene = new IsabellaScene();
+			cut = new IsabellaFollowerSceneForTest();
+		}
+		
+		[Before]
+        public function setUp():void {
+			setUpIsabella();
+			
+			isabellaScene.pregnancy.knockUpForce();
+			
+			// preggers time!
+			isabellaScene.pregnancy.knockUpForce(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.INCUBATION_ISABELLA)
+			
+			player = new Player();
+			kGAMECLASS.player = player;
+        }
+		
+		//FIXME text comparison makes for brittle tests, it would drive proofreaders nuts -> replace with const
+
+		[Test]
+		public function isabellaAppearance_withUnsupportedPregnancyType() : void 
+		{
+			isabellaScene.pregnancy.knockUpForce()
+			isabellaScene.pregnancy.knockUpForce(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_ISABELLA)
+			
+			cut.isaAppearance();
+			
+			assertThat(cut.collectedOutput, hasItem(equalTo("you cannot help but question as to whether or not your seed was \"planted\" in the Bovine Braud's womb.")));
+		}
+		
+		[Test]
+		public function isabellaAppearance_playerLowCumQuantity() : void 
+		{
+			isabellaScene.pregnancy.knockUpForce()
+			isabellaScene.pregnancy.knockUpForce(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_ISABELLA)
+			
+			player.cocks = []
+			assertThat(player.cumQ(), equalTo(0)); // guard assert 
+
+			cut.isaAppearance();
+			
+			assertThat(cut.collectedOutput, not(hasItem(equalTo("and your potent babymaking skills, "))));
+		}
+		
+		[Test]
+		public function isabellaAppearance_playerHighCumQuantity() : void 
+		{
+			isabellaScene.pregnancy.knockUpForce()
+			isabellaScene.pregnancy.knockUpForce(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_ISABELLA)
+			player.createPerk(PerkLib.FerasBoonSeeder, 0, 0, 0, 0);
+			player.createCock(6, 1, CockTypesEnum.HUMAN);
+			assertThat(player.cumQ(), greaterThan(500)); // guard assert 
+			
+			cut.isaAppearance();
+			
+			assertThat(cut.collectedOutput, hasItem(equalTo("and your potent babymaking skills, ")));
+		}
+		
+		[Test]
+		public function isabellaAppearance_whenNotPregnant() : void 
+		{
+			isabellaScene.pregnancy.knockUpForce();
+			
+			cut.isaAppearance();
+			
+			assertThat(cut.collectedOutput, hasItem(equalTo("The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Isabella's top is sheer, white silk that barely hides anything from you, least of all her exotic, quad-tipped nipples. Unlike most of the rest of her, her face is not spotted with dark and white patches. Instead it is pure, unbroken chocolate in color. Two small, bovine horns sprout from her head, emerging from the tangle of her unruly, red curls. She even has a pair of cow ears that flick back and forth from time to time.")));
+		}
+		
+		[Test]
+		public function isabellaAppearance_firstStageOfPregnancy() : void 
+		{
+			cut.isaAppearance();
+			
+			assertThat(cut.collectedOutput, hasItem(equalTo("The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Since you did the deed you often find her on her plump, toned, derriere. ")));
+		}
+		
+		[Test]
+		public function isabellaAppearance_playerLowLibido() : void 
+		{
+			player.lib = 0;
+			
+			cut.isaAppearance();
+			
+			assertThat(cut.collectedOutput, not(hasItem(equalTo("Every once in a while when the wind blows just right you get a pleasing view of her well lubricated womanhood between her legs. "))));
+		}
+		
+		[Test]
+		public function isabellaAppearance_playerHighLibido() : void 
+		{
+			player.lib = 100;
+			
+			cut.isaAppearance();
+			
+			assertThat(cut.collectedOutput, hasItem(equalTo("Every once in a while when the wind blows just right you get a pleasing view of her well lubricated womanhood between her legs. ")));
+		}
+		
+		[Test]
+		public function isabellaAppearance_lastStageOfPregnancy() : void 
+		{
+			for (var i : int = 0; i < ADVANCE_PREGNANCY; i++ ) {
+				isabellaScene.pregnancy.pregnancyAdvance();
+			}
+			
+			cut.isaAppearance();
+			
+			assertThat(cut.collectedOutput, hasItem(containsString("it kicked")));
+		}
+	}
+}
+
+import classes.Scenes.NPCs.IsabellaFollowerScene;
+
+/**
+ * Class to collect scene text output so the test can compare it to expected values.
+ */
+class IsabellaFollowerSceneForTest extends IsabellaFollowerScene {
+	public var collectedOutput:Vector.<String> = new Vector.<String>(); 
+	
+	override protected function outputText(output:String, purgeText:Boolean = false, parseAsMarkdown:Boolean = false):void {
+		collectedOutput.push(output);
+	}
+	
+	/**
+	 * This is to avoid making the appearance function public
+	 */
+	public function isaAppearance() : void {
+		this.isabellasAppearance();
+	}
+	
+	override protected function isabellasAppearance():void {
+		super.isabellasAppearance();
+	}
+ }

--- a/test/classes/Scenes/NPCs/IsabellaFollowerSceneTest.as
+++ b/test/classes/Scenes/NPCs/IsabellaFollowerSceneTest.as
@@ -58,8 +58,6 @@ package classes.Scenes.NPCs
 			kGAMECLASS.player = player;
         }
 		
-		//FIXME text comparison makes for brittle tests, it would drive proofreaders nuts -> replace with const
-
 		[Test]
 		public function isabellaAppearance_withUnsupportedPregnancyType() : void 
 		{
@@ -68,7 +66,7 @@ package classes.Scenes.NPCs
 			
 			cut.isaAppearance();
 			
-			assertThat(cut.collectedOutput, hasItem(equalTo("you cannot help but question as to whether or not your seed was \"planted\" in the Bovine Braud's womb.")));
+			assertThat(cut.collectedOutput, hasItem(equalTo(IsabellaFollowerScene.DESC_APPEAR_NO_EVENTS_FOR_PREG_TYPE)));
 		}
 		
 		[Test]
@@ -82,7 +80,7 @@ package classes.Scenes.NPCs
 
 			cut.isaAppearance();
 			
-			assertThat(cut.collectedOutput, not(hasItem(equalTo("and your potent babymaking skills, "))));
+			assertThat(cut.collectedOutput, not(hasItem(equalTo(IsabellaFollowerScene.DESC_APPEAR_PLAYER_HIGH_CUMQ))));
 		}
 		
 		[Test]
@@ -90,13 +88,14 @@ package classes.Scenes.NPCs
 		{
 			isabellaScene.pregnancy.knockUpForce()
 			isabellaScene.pregnancy.knockUpForce(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_ISABELLA)
+			//TODO Use mocking library so we can avoid stuff like this
 			player.createPerk(PerkLib.FerasBoonSeeder, 0, 0, 0, 0);
 			player.createCock(6, 1, CockTypesEnum.HUMAN);
 			assertThat(player.cumQ(), greaterThan(500)); // guard assert 
 			
 			cut.isaAppearance();
 			
-			assertThat(cut.collectedOutput, hasItem(equalTo("and your potent babymaking skills, ")));
+			assertThat(cut.collectedOutput, hasItem(equalTo(IsabellaFollowerScene.DESC_APPEAR_PLAYER_HIGH_CUMQ)));
 		}
 		
 		[Test]
@@ -106,7 +105,7 @@ package classes.Scenes.NPCs
 			
 			cut.isaAppearance();
 			
-			assertThat(cut.collectedOutput, hasItem(equalTo("The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Isabella's top is sheer, white silk that barely hides anything from you, least of all her exotic, quad-tipped nipples. Unlike most of the rest of her, her face is not spotted with dark and white patches. Instead it is pure, unbroken chocolate in color. Two small, bovine horns sprout from her head, emerging from the tangle of her unruly, red curls. She even has a pair of cow ears that flick back and forth from time to time.")));
+			assertThat(cut.collectedOutput, hasItem(equalTo(IsabellaFollowerScene.DESC_APPEAR_EVENT_NOT_PREGNANT)));
 		}
 		
 		[Test]
@@ -114,7 +113,7 @@ package classes.Scenes.NPCs
 		{
 			cut.isaAppearance();
 			
-			assertThat(cut.collectedOutput, hasItem(equalTo("The cow-girl is about seven and a half feet tall. Instead of feet, she has hooves, complete with fur that grows part-way up her legs. Her olive skirt only covers the upper portion of her dusky, spotted thighs, and it flares out deliciously from her swaying hips. Since you did the deed you often find her on her plump, toned, derriere. ")));
+			assertThat(cut.collectedOutput, hasItem(equalTo(IsabellaFollowerScene.DESC_APPEAR_EVENT_FIRST_STAGE_PREGNANT)));
 		}
 		
 		[Test]
@@ -124,7 +123,7 @@ package classes.Scenes.NPCs
 			
 			cut.isaAppearance();
 			
-			assertThat(cut.collectedOutput, not(hasItem(equalTo("Every once in a while when the wind blows just right you get a pleasing view of her well lubricated womanhood between her legs. "))));
+			assertThat(cut.collectedOutput, not(hasItem(equalTo(IsabellaFollowerScene.DESC_APPEAR_PLAYER_HIGH_LIBIDO))));
 		}
 		
 		[Test]
@@ -134,7 +133,7 @@ package classes.Scenes.NPCs
 			
 			cut.isaAppearance();
 			
-			assertThat(cut.collectedOutput, hasItem(equalTo("Every once in a while when the wind blows just right you get a pleasing view of her well lubricated womanhood between her legs. ")));
+			assertThat(cut.collectedOutput, hasItem(equalTo(IsabellaFollowerScene.DESC_APPEAR_PLAYER_HIGH_LIBIDO)));
 		}
 		
 		[Test]
@@ -146,7 +145,7 @@ package classes.Scenes.NPCs
 			
 			cut.isaAppearance();
 			
-			assertThat(cut.collectedOutput, hasItem(containsString("it kicked")));
+			assertThat(cut.collectedOutput, hasItem(containsString(IsabellaFollowerScene.DESC_APPEAR_EVENT_LAST_STAGE_PREGNANT)));
 		}
 	}
 }

--- a/test/classes/Scenes/NPCs/IsabellaSceneTest.as
+++ b/test/classes/Scenes/NPCs/IsabellaSceneTest.as
@@ -1,0 +1,118 @@
+package classes.Scenes.NPCs 
+{
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import classes.helper.StageLocator;
+	
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.CoC;
+	import classes.PregnancyStore;
+	import classes.Scenes.NPCs.IsabellaFollowerScene;
+	
+	public class IsabellaSceneTest 
+	{
+		private var cut : IsabellaScene;
+		private var player:Player;
+		
+		private static const INCUBATION_DELTA : int = 10;
+		/**
+		 * This is used to skip time to the last pregnancy stage
+		 */
+		private static const ADVANCE_PREGNANCY : int = PregnancyStore.INCUBATION_ISABELLA - (IsabellaScene.ISABELLA_PREGNANCY_LAST_STAGE - INCUBATION_DELTA);
+		
+		public function IsabellaSceneTest() 
+		{
+		}
+		
+		[BeforeClass]
+		public static function setUpClass():void {
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+		
+		private function setUpIsabella() : void {
+			cut = new IsabellaScene();
+		}
+		
+		[Before]
+        public function setUp():void {
+			setUpIsabella();
+			
+			cut.pregnancy.knockUpForce();
+			
+			// preggers time!
+			cut.pregnancy.knockUpForce(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.INCUBATION_ISABELLA)
+			
+			player = new Player();
+			kGAMECLASS.player = player;
+        }
+		
+		[Test]
+		public function isabellaNotPregnant_afterPregnancyClear() : void 
+		{
+			cut.pregnancy.knockUpForce();
+			
+			// law of demeter violation ahoi!
+			assertThat(cut.pregnancy.isPregnant, equalTo(false));
+		}
+		
+		[Test]
+		public function isabellaPregnant_afterKnockUp() : void 
+		{
+			assertThat(cut.pregnancy.isPregnant, equalTo(true));
+		}
+		
+		[Test]
+		public function isabellaIncubationProgress_afterKnockUp() : void 
+		{
+			assertThat(cut.pregnancy.incubation, equalTo(PregnancyStore.INCUBATION_ISABELLA));
+		}
+		
+				
+		[Test]
+		public function isabellaIncubationProgress_lastStageOfPregnancy() : void 
+		{
+			for (var i : int = 0; i < ADVANCE_PREGNANCY; i++ ) {
+				cut.pregnancy.pregnancyAdvance();
+			}
+			
+			assertThat(cut.pregnancy.incubation, between(0, IsabellaScene.ISABELLA_PREGNANCY_LAST_STAGE));
+		}
+		
+		[Test]
+		public function isabellaPregnancyEventStage_withUnsupportedPregnancyType() : void 
+		{
+			cut.pregnancy.knockUpForce()
+			
+			cut.pregnancy.knockUpForce(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_ISABELLA)
+			
+			assertThat(cut.pregnancy.event, 1);
+		}
+		
+		[Test]
+		public function isabellaPregnancyEventStage_afterKnockUp() : void 
+		{
+			cut.pregnancy.knockUpForce()
+			
+			cut.pregnancy.knockUpForce(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.INCUBATION_ISABELLA)
+			
+			assertThat(cut.pregnancy.event, 2);
+		}
+				
+		[Test]
+		public function isabellaPregnancyEventStage_lastStageOfPregnancy() : void 
+		{
+			for (var i : int = 0; i < ADVANCE_PREGNANCY; i++ ) {
+				cut.pregnancy.pregnancyAdvance();
+			}
+			
+			assertThat(cut.pregnancy.event, equalTo(10));
+		}
+	}
+}

--- a/test/classes/Scenes/NPCsSuit.as
+++ b/test/classes/Scenes/NPCsSuit.as
@@ -1,5 +1,6 @@
 package classes.Scenes {
 
+import classes.Scenes.NPCs.IsabellaSceneTest;
 import classes.Scenes.NPCs.JojoSceneTest;
 
 [Suite]
@@ -7,5 +8,6 @@ import classes.Scenes.NPCs.JojoSceneTest;
 	public class NPCsSuit
 	{
 		 public var jojoSceneTest:JojoSceneTest;
+		 public var isabellaSceneTest : IsabellaSceneTest;
 	}
 }

--- a/test/classes/Scenes/NPCsSuit.as
+++ b/test/classes/Scenes/NPCsSuit.as
@@ -2,6 +2,7 @@ package classes.Scenes {
 
 import classes.Scenes.NPCs.IsabellaSceneTest;
 import classes.Scenes.NPCs.JojoSceneTest;
+import classes.Scenes.NPCs.IsabellaFollowerSceneTest;
 
 [Suite]
 [RunWith("org.flexunit.runners.Suite")]
@@ -9,5 +10,6 @@ import classes.Scenes.NPCs.JojoSceneTest;
 	{
 		 public var jojoSceneTest:JojoSceneTest;
 		 public var isabellaSceneTest : IsabellaSceneTest;
+		 public var isabellaFollowerSceneTest:IsabellaFollowerSceneTest;
 	}
 }


### PR DESCRIPTION
Tests for Isabella appearance and pregnancy stage start / end.
Originally intended for the now fixed #494, they can still be used as regression tests.