### PR TITLE
Fix compiler debug flag not set

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -39,7 +39,7 @@
 		         <load-config filename="${FLEX_HOME}/frameworks/flex-config.xml"/>
 		         <source-path path-element="${FLEX_HOME}/frameworks"/>
 				 <source-path path-element="${main.src.dir}/"/>
-		         <compiler.debug>false</compiler.debug>
+		         <compiler.debug>@{debug-flag}</compiler.debug>
 		        <library-path dir="${lib.dir}" includes="*.swc" append="true"/>
 				<define name="CONFIG::release" value="@{release-flag}"/>
 				<define name="CONFIG::debug" value="@{debug-flag}"/>


### PR DESCRIPTION
Fixes a silly copy-paste error from the build script cleanup.

- The debug flag passed into the 'build-game-binary' macro will now also set the compiler debug flag