### PR TITLE
Tag deprecated code with metadata tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,4 @@ Please don't use deprecated code for new content. If you find any deprecated cod
 
 * `choices` and `simpleChoices`: Those are really old code used for setting up a choice of buttons. Remember that there are now 15 buttons so use `addButton` instead.
 * Lots and lots of local variables for gating scenes. Those are prominient in many of the victory scene choices. Just remove the variables and change the way the buttons are gated, check the newer code for that.
+* Deprecated functions, variables and classes can be marked with `[Deprecated]` metadata tags to generate compiler warnings. [Adobe metadata documentation](http://help.adobe.com/en_US/flex/using/WS2db454920e96a9e51e63e3d11c0bf680e1-7ffe.html), [Deprecated metadata](http://help.adobe.com/en_US/flex/using/WS2db454920e96a9e51e63e3d11c0bf680e1-7ffe.html#WS2db454920e96a9e51e63e3d11c0bf69084-7a6c)

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -186,9 +186,9 @@
 			return kGAMECLASS.createCallBackFunction(func,arg);
 		}
 
-		/** Create a function that will pass multiple arguments. 
-		 * @deprecated	This function is deprecated.
+		/** [DEPRECATED] Create a function that will pass multiple arguments. 
 		 */
+		[Deprecated(message="This function is deprecated.")]
 		protected function createCallBackFunction2(func:Function, ...args):Function
 		{
 			return kGAMECLASS.createCallBackFunction2.apply(null,[func].concat(args));
@@ -254,8 +254,9 @@
 			kGAMECLASS.hideMenus();
 		}
 		
-		/** Creates a menu with 10 buttons. 
-		 * @deprecated	This is deprecated. Use a series of addButton instead.
+
+		[Deprecated(replacement = "Use a series of BaseContent.addButton instead")]
+		/**[DEPRECATED] Creates a menu with 10 buttons. 
 		 */
 		protected function choices(text1:String, butt1:Function,
 								text2:String, butt2:Function,
@@ -281,8 +282,9 @@
 			);
 		}
 
-		/** Creates a menu with 5 buttons. 
-		 * @deprecated	This is deprecated. Use a series of addButton instead.
+		[Deprecated(replacement = "Use a series of BaseContent.addButton instead.")]
+		/**
+		 * [DEPRECATED] Creates a menu with 5 buttons. 
 		 */
 		protected function simpleChoices(text1:String, butt1:Function,
 								text2:String, butt2:Function,

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -903,9 +903,7 @@ package classes
 			return -1;
 		}
 
-		/**
-		 * @deprecated Replace with indexOfStatusEffect(), statusEffectByType(), or hasStatusEffect()
-		 */
+		[Deprecated(replacement="indexOfStatusEffect(), statusEffectByType(), or hasStatusEffect() instead")]
 		public function findStatusEffect(stype:StatusEffectType):int {
 			return indexOfStatusEffect(stype);
 		}
@@ -2083,7 +2081,7 @@ package classes
 			return false
 		}
 		
-		// Deprecated
+		[Deprecated]
 		public function hasSock(arg:String = ""):Boolean
 		{
 			var index:int = cocks.length;

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -259,7 +259,9 @@ public static const IZMA_INCUBATION:int                                         
 public static const IZMA_CHILDREN_SHARKGIRLS:int                                    =  251; // Izma sharkgirls
 public static const IZMA_CHILDREN_TIGERSHARKS:int                                   =  252; // Izma tigersharks
 public static const IZMA_TIME_TILL_NEW_BOOK_AVAILABLE:int                           =  253; // Izma Nu Book Countdown
+[Deprecated(message="No longer used")]
 public static const TAKEN_WEAPON_RACK_DEPRECATED:int                                =  254; // Weapon Rack owned? (1 = yes) (NO LONGER USED)
+[Deprecated(message="No longer used")]
 public static const TAKEN_ARMOUR_RACK_DEPRECATED:int                                =  255; // Armor Rack owned? (2 = yes) (NO LONGER USED)
 public static const ISABELLA_CAMP_APPROACHED:int                                    =  256; // PC decided to approach Isabella's camp yet? 1
 public static const ISABELLA_MET:int                                                =  257; // Met Isabella?
@@ -2199,6 +2201,7 @@ public static const JOJO_ANAL_CATCH_COUNTER:int                                 
 public static const KIHA_UNDERGARMENTS:int                                          = 2191; //0 if nude, 1 if wearing panties, 2 if wearing loincloth. (Spider-silk only)
 public static const KIHA_PREGNANCY_TYPE:int                                         = 2192;
 public static const KIHA_INCUBATION:int                                             = 2193;
+[Deprecated(message="Not used anymore, might be reclaimed.")]
 public static const KIHA_EGG_COUNTER:int                                            = 2194; //Not used anymore, might be reclaimed.
 public static const KIHA_CHILDREN_BOYS:int                                          = 2195;
 public static const KIHA_CHILDREN_GIRLS:int                                         = 2196;

--- a/classes/classes/baseContentInclude.as
+++ b/classes/classes/baseContentInclude.as
@@ -234,8 +234,8 @@ protected function hideMenus():void {
 	kGAMECLASS.hideMenus();
 }
 
-/** Creates a menu with 10 buttons.
- * @deprecated    This is deprecated. Use a series of addButton instead.
+[Deprecated(replacement="Use a series of BaseContent.addButton instead.")]
+/**[DEPRECATED] Creates a menu with 10 buttons.
  */
 protected function choices(text1:String, butt1:Function,
 						   text2:String, butt2:Function,
@@ -260,9 +260,8 @@ protected function choices(text1:String, butt1:Function,
 			text0, butt0
 	);
 }
-
-/** Creates a menu with 5 buttons.
- * @deprecated    This is deprecated. Use menu() + series of addButton instead.
+[Deprecated(replacement="Use menu() + series of addButton instead.")]
+/**[DEPRECATED] Creates a menu with 5 buttons.
  */
 protected function simpleChoices(text1:String, butt1:Function,
 								 text2:String, butt2:Function,

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -15,6 +15,7 @@ public static const SKIN_TYPE_PLAIN:int                                         
 public static const SKIN_TYPE_FUR:int                                               =    1;
 public static const SKIN_TYPE_LIZARD_SCALES:int                                     =    2;
 public static const SKIN_TYPE_GOO:int                                               =    3;
+[Deprecated(message="silently discarded upon loading a saved game.")]
 public static const SKIN_TYPE_UNDEFINED:int                                         =    4; // DEPRECATED, silently discarded upon loading a saved game
 public static const SKIN_TYPE_DRAGON_SCALES:int                                     =    5;
 public static const SKIN_TYPE_FISH_SCALES:int                                       =    6; // NYI, for future use
@@ -182,6 +183,7 @@ public static const LOWER_BODY_TYPE_HUMAN:int                                   
 public static const LOWER_BODY_TYPE_HOOFED:int                                      =   1;
 public static const LOWER_BODY_TYPE_DOG:int                                         =   2;
 public static const LOWER_BODY_TYPE_NAGA:int                                        =   3;
+[Deprecated(replacement="LOWER_BODY_TYPE_HOOFED and legCount=4")]
 public static const LOWER_BODY_TYPE_CENTAUR:int                                     =   4; // DEPRECATED, use LOWER_BODY_TYPE_HOOFED and legCount=4
 public static const LOWER_BODY_TYPE_DEMONIC_HIGH_HEELS:int                          =   5;
 public static const LOWER_BODY_TYPE_DEMONIC_CLAWS:int                               =   6;
@@ -202,6 +204,7 @@ public static const LOWER_BODY_TYPE_FERRET:int                                  
 public static const LOWER_BODY_TYPE_CLOVEN_HOOFED:int                               =  21;
 //public static const LOWER_BODY_TYPE_RHINO:int                                       =  22;
 public static const LOWER_BODY_TYPE_ECHIDNA:int                                     =  23;
+[Deprecated(replacement="LOWER_BODY_TYPE_CLOVEN_HOOFED and legCount=4")]
 public static const LOWER_BODY_TYPE_DEERTAUR:int                                    =  24; // DEPRECATED, use LOWER_BODY_TYPE_CLOVEN_HOOFED and legCount=4
 public static const LOWER_BODY_TYPE_SALAMANDER:int                                  =  25;
 


### PR DESCRIPTION
Use the `[Deprecated]` [metadata tag](http://help.adobe.com/en_US/flex/using/WS2db454920e96a9e51e63e3d11c0bf680e1-7ffe.html#WS2db454920e96a9e51e63e3d11c0bf69084-7a6c) to mark deprecated code.
The `[DEPRECATED]` prefix in the documentation is arbitrary, i was looking for something that grabs the users attention, as [ASDoc](http://help.adobe.com/en_US/flex/using/WSd0ded3821e0d52fe1e63e3d11c2f44bc36-7ff6.html) does not support the `@deprecated` tag.

Currently results in 651 compiler warnings.

FlashDevelop marks the first letter of a deprecated function with a squiggly line, but it is easy to miss.