### PR TITLE
Removed remainders of deertaur/centaur lower body checks

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1704,7 +1704,7 @@ use namespace kGAMECLASS;
 				deerCounter++;
 			if (faceType == FACE_DEER)
 				deerCounter++;
-			if (lowerBody == LOWER_BODY_TYPE_CLOVEN_HOOFED || lowerBody == LOWER_BODY_TYPE_DEERTAUR)
+			if (lowerBody == LOWER_BODY_TYPE_CLOVEN_HOOFED)
 				deerCounter++;
 			if (hornType == HORNS_ANTLERS && horns >= 4)
 				deerCounter++;

--- a/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
+++ b/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
@@ -1058,15 +1058,15 @@ package classes.Scenes.Areas.Forest
 				changes++;
 			}
 			//Change legs to cloven hooves
-			if (rand(4) == 0 && changes < changeLimit && player.earType == EARS_DEER && player.tailType == TAIL_TYPE_DEER && player.hasFur() && (player.lowerBody != LOWER_BODY_TYPE_DEERTAUR && player.lowerBody != LOWER_BODY_TYPE_CLOVEN_HOOFED)) {
+			if (rand(4) == 0 && changes < changeLimit && player.earType == EARS_DEER && player.tailType == TAIL_TYPE_DEER && player.hasFur() && player.lowerBody != LOWER_BODY_TYPE_CLOVEN_HOOFED) {
 				if (player.lowerBody == LOWER_BODY_TYPE_HOOFED) {
 					outputText("\n\nYou feel a sharp stinging sensation from your hooves, accompanied by a loud CRACK.  You look down in alarm, prancing from one hooved foot to another, realizing that your solid, heavy hooves have been replaced with delicate, cloven hooves.  You squint, also noting a subtle thinness across your legs in general--if you had to guess, you’d hazard that you’re looking <b>more deer-like than horse-like</b>.");
 				}
 				else {
 					outputText("\n\nYou feel a strange tightness from your feet and nearly topple over as your balance shifts.  You’re balancing on your toes for some reason.  You look down in amazement as your legs slim and lengthen, your feet elongating and darkening at the ends until you’re balancing on <b>two, graceful deer legs</b>.");
 				}
-				if (player.isTaur()) player.lowerBody = LOWER_BODY_TYPE_DEERTAUR;
-				else player.lowerBody = LOWER_BODY_TYPE_CLOVEN_HOOFED;
+				player.lowerBody = LOWER_BODY_TYPE_CLOVEN_HOOFED;
+				if (!player.isTaur() && !player.isBiped()) player.legCount = 2;
 				changes++;
 			}
 			// Genital Changes

--- a/classes/classes/Scenes/NPCs/MarbleScene.as
+++ b/classes/classes/Scenes/NPCs/MarbleScene.as
@@ -2942,33 +2942,6 @@ public function marbleBadEndFollowup():void {
 	//Variables for this function:
 	//morph – keeps track of player's form (human, dog-morph, centaur)
 	var morph:String = player.race(); //Now uses actual race.
-	//var morph:String = "human";
-	/*if (player.lowerBody == LOWER_BODY_TYPE_CENTAUR) morph = "centaur";
-	if (player.catScore() >= 4) morph = "cat-morph";
-	if (player.demonScore() >= 4) morph = "demon-morph";
-	if (player.dogScore() >= 4) morph = "dog-morph";
-	if (player.horseScore() >= 3) {
-		if (player.lowerBody == LOWER_BODY_TYPE_CENTAUR) morph = "centaur-morph";
-		else morph = "equine-morph";
-	}
-	if (player.mutantScore() >= 5) morph = "corrupted mutant";
-	if (player.minoScore() >= 4) morph = "minotaur-morph";
-	if (player.cowScore() >= 5) {
-		morph = "cow-";
-		if (player.gender <= 1) morph += "boi";
-		else morph += "girl";
-	}
-	if (player.beeScore() >= 4) morph = "bee-morph";
-	if (player.spiderScore() >= 4) morph = "spider-morph";
-	if (player.raccoonSocre() >= 4) morph = "raccoon-morph";
-	if (player.kitsuneScore() >= 4) morph = "kitsune-morph";
-	if (player.goblinScore() >= 5) morph = "goblin";
-	if (player.humanScore() >= 5 && morph == "corrupted mutant") morph = "somewhat human mutant";
-	if (player.lowerBody == LOWER_BODY_TYPE_CENTAUR) morph = "centaur";	
-	if (player.lowerBody == LOWER_BODY_TYPE_CENTAUR) morph = "centaur";*/
-	//gender – keeps track of player's gender (male, female, genderless, or hermaphrodite)
-	//pronouns – holds the proper pronouns for the player's gender, he/she, his/hers, him/her (should probably be multiple
-	//OH FUCK THIS!
 	//approxHeight – short description for approximately how tall is the player is, (very short, short, average height, tall, very tall)
 	var approxHeight:String = "";
 	if (player.tallness < 54) approxHeight = "very short";

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -1963,9 +1963,6 @@ package classes.Scenes.Places.Bazaar
 				outputText("\n\n");
 				switch(player.lowerBody) {
 					//Irregular lower body type
-					case LOWER_BODY_TYPE_CENTAUR: // should be done in other way now...
-						outputText("You collapse to the ground, a sharp pain encompassing your equine lower body. The pain quickly becomes so severe that you black out on the spot. Eventually you awake to find that you no longer have the lower body of a horse. You have just two legs again, and your feet look a lot like your old human feet. The only difference is that your toes are clawed, and the bottoms of your feet padded.");
-						break;
 					case LOWER_BODY_TYPE_NAGA:
 						outputText("You collapse to the ground, a sharp pain encompassing your serpentine tail. The pain quickly becomes so severe that you black out on the spot. Eventually you awake to find that you no longer have the lower body of a snake. You have two legs again, and your feet look a lot like your old human feet. The only difference is that your toes are clawed, and the bottoms of your feet padded.");
 						break;


### PR DESCRIPTION
- `Player.as` and `BlackCock.as`
  No need to check for deertaur/centaur lower body, since its being corrected upon loading a savegame
- ErlKingScene.as:
  Ditched the last remaining chance, that your lowerBody is set to `LOWER_BODY_TYPE_DEERTAUR`
- MarbleScene.as:
  Removed commented out, because totally outdated code, that contained `LOWER_BODY_TYPE_CENTAUR`