### PR TITLE
Use Loggers instead of trace()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,24 @@ Please don't use deprecated code for new content. If you find any deprecated cod
 * `choices` and `simpleChoices`: Those are really old code used for setting up a choice of buttons. Remember that there are now 15 buttons so use `addButton` instead.
 * Lots and lots of local variables for gating scenes. Those are prominient in many of the victory scene choices. Just remove the variables and change the way the buttons are gated, check the newer code for that.
 * Deprecated functions, variables and classes can be marked with `[Deprecated]` metadata tags to generate compiler warnings. [Adobe metadata documentation](http://help.adobe.com/en_US/flex/using/WS2db454920e96a9e51e63e3d11c0bf680e1-7ffe.html), [Deprecated metadata](http://help.adobe.com/en_US/flex/using/WS2db454920e96a9e51e63e3d11c0bf680e1-7ffe.html#WS2db454920e96a9e51e63e3d11c0bf69084-7a6c)
+
+## Logging
+
+Please don't use `trace()`, but instead use `ILogger` based loggers.
+
+e.g.:
+```actionscript
+	import classes.internals.LoggerFactory;
+	import mx.logging.ILogger;
+	
+	public class Foo {
+		private static const LOGGER:ILogger = LoggerFactory.getLogger(Foo);
+		
+		private var bar:int = 5;
+		
+		public function Foo() {
+			LOGGER.error("This is an error message.");
+			LOGGER.debug("Bar has the value of {0}.", bar);
+		}
+	}
+```

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -109,6 +109,9 @@ the text from being too boring.
 	import flash.utils.ByteArray;
 	import flash.system.Capabilities;
 	import flash.display.Sprite;
+	import mx.logging.targets.TraceTarget;
+	import mx.logging.Log;
+	import mx.logging.LogEventLevel;
 
 	/****
 		classes.CoC: The Document class of Corruption of the Champions.
@@ -122,6 +125,15 @@ the text from being too boring.
 
 	public class CoC extends MovieClip 
 	{
+		{
+			/*
+			 * This is a static initializer block, used as an ugly hack to setup
+			 * logging before any of the class variables are initialized.
+			 * This is done because they could log messages during construction.
+			 */
+			
+			 CoC.setUpLogging();
+		}
 
 		// Include the functions. ALL THE FUNCTIONS
 		include "../../includes/input.as";
@@ -353,6 +365,24 @@ the text from being too boring.
 
 		public var timeQ:Number = 0;
 		public var campQ:Boolean = false;
+		
+		private static var traceTarget:TraceTarget;
+		
+		private static function setUpLogging():void {
+			traceTarget = new TraceTarget();
+
+			//TODO clever way to set log level at start up. Read from file in CWD?
+			traceTarget.level = LogEventLevel.ALL;
+
+			//Add date, time, category, and log level to the output
+			traceTarget.includeDate = true;
+			traceTarget.includeTime = true;
+			traceTarget.includeCategory = true;
+			traceTarget.includeLevel = true;
+
+			// let the logging begin!
+			Log.addTarget(traceTarget);
+		}
 		
 		/**
 		 * Create the main game instance.

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -371,8 +371,12 @@ the text from being too boring.
 		private static function setUpLogging():void {
 			traceTarget = new TraceTarget();
 
-			//TODO clever way to set log level at start up. Read from file in CWD?
-			traceTarget.level = LogEventLevel.ALL;
+			traceTarget.level = LogEventLevel.WARN;
+			
+			CONFIG::debug
+			{
+				traceTarget.level = LogEventLevel.DEBUG;
+			}
 
 			//Add date, time, category, and log level to the output
 			traceTarget.includeDate = true;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -6,6 +6,8 @@
 	import classes.GlobalFlags.kACHIEVEMENTS;
 	import classes.Scenes.Inventory;
 	import classes.Scenes.Places.TelAdre.Katherine;
+	import classes.internals.LoggerFactory;
+	import mx.logging.ILogger;
 
 	CONFIG::AIR 
 	{
@@ -29,6 +31,7 @@
 
 
 public class Saves extends BaseContent {
+	private static const LOGGER:ILogger = LoggerFactory.getLogger(Saves);
 
 	private static const SAVE_FILE_CURRENT_INTEGER_FORMAT_VERSION:int		= 816;
 		//Didn't want to include something like this, but an integer is safer than depending on the text version number from the CoC class.
@@ -652,8 +655,9 @@ public function savePermObject(isFile:Boolean):void {
 }
 
 public function loadPermObject():void {
-	var saveFile:* = SharedObject.getLocal("CoC_Main", "/");
-	trace("Loading achievements!")
+	var permObjectFileName:String = "CoC_Main";
+	var saveFile:* = SharedObject.getLocal(permObjectFileName, "/");
+	LOGGER.info("Loading achievements from {0}!", permObjectFileName);
 	//Initialize the save file
 	//var saveFile:Object = loader.data.readObject();
 	if (saveFile.data.exists)
@@ -696,7 +700,7 @@ public function loadPermObject():void {
 
 		if (saveFile.data.permObjVersionID != undefined) {
 			getGame().permObjVersionID = saveFile.data.permObjVersionID;
-			trace("Found internal permObjVersionID:", getGame().permObjVersionID);
+			LOGGER.debug("Found internal permObjVersionID:{0}", getGame().permObjVersionID);
 		}
 
 		if (getGame().permObjVersionID < 1039900) {
@@ -707,7 +711,7 @@ public function loadPermObject():void {
 			achievements[kACHIEVEMENTS.GENERAL_BAD_ENDER] = 0;
 			getGame().permObjVersionID = 1039900;
 			savePermObject(false);
-			trace("PermObj internal versionID updated:", getGame().permObjVersionID);
+			LOGGER.debug("PermObj internal versionID updated:{0}", getGame().permObjVersionID);
 		}
 	}
 }

--- a/classes/classes/Scenes/Dungeons/D3/D3.as
+++ b/classes/classes/Scenes/Dungeons/D3/D3.as
@@ -12,13 +12,17 @@ package classes.Scenes.Dungeons.D3
 	import classes.PerkLib;
 	import classes.CockTypesEnum;
 	import classes.PregnancyStore;
+	import classes.internals.LoggerFactory;
+	import mx.logging.ILogger;
 	
 	/**
 	 * ...
 	 * @author Gedan
 	 */
 	public class D3 extends BaseContent
-	{		
+	{
+		private static const LOGGER:ILogger = LoggerFactory.getLogger(D3);
+		
 		public var jeanClaude:JeanClaudeScenes = new JeanClaudeScenes();
 		public var doppleganger:DopplegangerScenes = new DopplegangerScenes();
 		public var incubusMechanic:IncubusMechanicScenes = new IncubusMechanicScenes();
@@ -35,15 +39,13 @@ package classes.Scenes.Dungeons.D3
 		
 		public function configureRooms():void {
 			var tRoom:room;
+			LOGGER.info("Setting up D3 rooms...");
+			LOGGER.debug("Dungeons are {0}", kGAMECLASS.dungeons);
+			
 			if (kGAMECLASS.dungeons != null) {
-				trace("OK");
+				LOGGER.debug("Rooms are {0}", kGAMECLASS.dungeons.rooms);
 			}
-			if (kGAMECLASS.dungeons.rooms) {
-				trace("Debugging... ")
-			}
-			else {
-				trace("Nope");
-			}
+		
 			// Entrance
 			tRoom = new room();
 			tRoom.RoomName = "entrance";

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -20,10 +20,14 @@ package classes.Scenes
 	import classes.Scenes.Dungeons.DungeonCore;
 	import flash.events.KeyboardEvent;
 	import flash.ui.Keyboard;
+	import classes.internals.LoggerFactory;
+	import mx.logging.ILogger;
 
 	use namespace kGAMECLASS;
 
 	public class Inventory extends BaseContent {
+		private static const LOGGER:ILogger = LoggerFactory.getLogger(Inventory);
+		
 		private static const inventorySlotName:Array = ["first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth"];
 		
 		private var itemStorage:Array;
@@ -299,27 +303,34 @@ package classes.Scenes
 		//Clear storage slots
 		public function clearStorage():void {
 			//Various Errors preventing action
-			if (itemStorage == null) trace("ERROR: Cannot clear storage because storage does not exist.");
+			if (itemStorage == null){
+				LOGGER.error("Cannot clear storage because it does not exist.");
+			}
 			else {
-				trace("Attempted to remove " + itemStorage.length + " storage slots.");
+				LOGGER.debug("Attempted to remove {0} storage slots.", itemStorage.length);
 				itemStorage.splice(0, itemStorage.length);
 			}
 		}
 		
 		public function clearGearStorage():void {
 			//Various Errors preventing action
-			if (gearStorage == null) trace("ERROR: Cannot clear storage because storage does not exist.");
+			if (gearStorage == null) {
+				LOGGER.error("Cannot clear gear storage because it does not exist.");
+			}
 			else {
-				trace("Attempted to remove " + gearStorage.length + " storage slots.");
+				LOGGER.debug("Attempted to remove {0} gear storage slots.", gearStorage.length);
 				gearStorage.splice(0, gearStorage.length);
 			}
 		}
 		
 		public function initializeGearStorage():void {
 			//Completely empty storage array
-			if (gearStorage == null) trace("ERROR: Cannot clear gearStorage because storage does not exist.");
+			if (gearStorage == null) {
+				//TODO refactor this to use clearGearStorage()
+				LOGGER.error("Cannot clear gearStorage because storage does not exist.");
+			}
 			else {
-				trace("Attempted to remove " + gearStorage.length + " gearStorage slots.");
+				LOGGER.debug("Attempted to remove {0} gear storage slots.", gearStorage.length);
 				gearStorage.splice(0, gearStorage.length);
 			}
 			//Rebuild a new one!

--- a/classes/classes/internals/LoggerFactory.as
+++ b/classes/classes/internals/LoggerFactory.as
@@ -1,0 +1,37 @@
+package classes.internals 
+{
+	import flash.errors.IllegalOperationError;
+	import flash.utils.getQualifiedClassName;
+	import mx.logging.Log;
+	import mx.logging.ILogger;
+	
+	/**
+	 * Factory to create loggers for classes.
+	 */
+	public class LoggerFactory 
+	{
+		/**
+		 * Symbols that cannot be used in a category name
+		 */
+		public static const ILLEGAL_SYMBOLS:String = "[]~$^&\/(){}<>+=`!#%?,:;'\"@";
+		
+		private static const CLASS_DELIMITER:RegExp = /::/g;
+		private static const CLASS_DELIMITER_REPLACEMENT:String = ".";
+		
+		public function LoggerFactory() 
+		{
+			throw new IllegalOperationError("This class cannot be instantiated.");
+		}
+		
+		/**
+		 * Create a logger for the given class. Loggers are cached by mx.logging.Log, so using the same Class
+		 * multiple times will return the same logger instance.
+		 * @param	clazz to create a logger for
+		 * @return a new logger for the class
+		 */
+		public static function getLogger(clazz:Class):ILogger {
+			var sanitizedClassname:String = getQualifiedClassName(clazz).replace(CLASS_DELIMITER, CLASS_DELIMITER_REPLACEMENT);
+			return Log.getLogger(sanitizedClassname);
+		}
+	}
+}

--- a/classes/classes/internals/LoggerFactory.as
+++ b/classes/classes/internals/LoggerFactory.as
@@ -15,8 +15,8 @@ package classes.internals
 		 */
 		public static const ILLEGAL_SYMBOLS:String = "[]~$^&\/(){}<>+=`!#%?,:;'\"@";
 		
-		private static const CLASS_DELIMITER:RegExp = /::/g;
-		private static const CLASS_DELIMITER_REPLACEMENT:String = ".";
+		private static const PACKAGE_DELIMITER:RegExp = /::/g;
+		private static const PACKAGE_DELIMITER_REPLACEMENT:String = ".";
 		
 		public function LoggerFactory() 
 		{
@@ -30,8 +30,8 @@ package classes.internals
 		 * @return a new logger for the class
 		 */
 		public static function getLogger(clazz:Class):ILogger {
-			var sanitizedClassname:String = getQualifiedClassName(clazz).replace(CLASS_DELIMITER, CLASS_DELIMITER_REPLACEMENT);
-			return Log.getLogger(sanitizedClassname);
+			var sanitizedFQN:String = getQualifiedClassName(clazz).replace(PACKAGE_DELIMITER, PACKAGE_DELIMITER_REPLACEMENT);
+			return Log.getLogger(sanitizedFQN);
 		}
 	}
 }

--- a/test/ClassesSuit.as
+++ b/test/ClassesSuit.as
@@ -1,5 +1,6 @@
 package {
 	import classes.HelperSuit;
+	import classes.InternalsSuit;
 	import classes.ScenesSuit;
 	import classes.ItemsSuit;
 
@@ -30,5 +31,6 @@ package {
 		 public var savesTest:SavesTest;
 		 public var playerEventsTest:PlayerEventsTest;
 		 public var playerEventsVaginaLoosenessRecoveryTest:PlayerEventsVaginaLoosenessRecoveryTest;
+		 public var internalsSuit:InternalsSuit;
 	}
 }

--- a/test/classes/HelperSuit.as
+++ b/test/classes/HelperSuit.as
@@ -1,5 +1,6 @@
 package classes {
 
+import classes.helper.MemoryLogTargetTest;
 import classes.helper.StageLocatorTest;
 
 [Suite]
@@ -7,5 +8,6 @@ import classes.helper.StageLocatorTest;
 	public class HelperSuit
 	{
 		 public var stageLocatorTest:StageLocatorTest;
+		 public var memoryLogTargetTest:MemoryLogTargetTest;
 	}
 }

--- a/test/classes/InternalsSuit.as
+++ b/test/classes/InternalsSuit.as
@@ -1,0 +1,12 @@
+package classes {
+	import classes.helper.MemoryLogTarget;
+	import classes.helper.MemoryLogTargetTest;
+	import classes.internals.LoggerFactoryTest;
+	
+	[Suite]
+	[RunWith("org.flexunit.runners.Suite")]
+	public class InternalsSuit
+	{
+		public var loggerFactoryTest:LoggerFactoryTest;
+	}
+}

--- a/test/classes/helper/MemoryLogTarget.as
+++ b/test/classes/helper/MemoryLogTarget.as
@@ -1,0 +1,73 @@
+package classes.helper 
+{
+	import flash.errors.IllegalOperationError;
+	import mx.logging.ILogger;
+	import mx.logging.LogEventLevel;
+	import mx.logging.AbstractTarget;
+	import mx.logging.LogEvent;
+	
+	/**
+	 * Log target for collecting log messages in memory.
+	 */
+	public class MemoryLogTarget extends AbstractTarget
+	{
+		public static const PREFIX_DEBUG:String = "DEBUG:";
+		public static const PREFIX_ERROR:String = "ERROR:";
+		public static const PREFIX_FATAL:String = "FATAL:";
+		public static const PREFIX_INFO:String = "INFO:";
+		public static const PREFIX_WARNING:String = "WARN:";
+		
+		private var _collectedMessages:Vector.<String>;
+		
+		public function get collectedMessages():Vector.<String> {
+			return _collectedMessages;
+		}
+
+		/**
+		 * Create a new logging target with an empty internal vector to store
+		 * messages.
+		 */
+		public function MemoryLogTarget() 
+		{
+			_collectedMessages = new Vector.<String>();
+			super();
+		}
+		
+		/**
+		 * Handle a log event.
+		 * @param	event to handle
+		 */
+		public override function logEvent(event:LogEvent):void {
+			log(event.level, event.message);
+		}
+		
+		/**
+		 * Store the given event with a prefix
+		 * @param	level of the log event
+		 * @param	message of the log event
+		 */
+		private function log(level:int, message:String):void {
+			switch (level) {
+				case LogEventLevel.DEBUG:
+					_collectedMessages.push(PREFIX_DEBUG + message);
+					break;
+					
+				case LogEventLevel.INFO:
+					_collectedMessages.push(PREFIX_INFO + message);
+					break;
+				
+				case LogEventLevel.FATAL:
+					_collectedMessages.push(PREFIX_FATAL + message);
+					break;
+					
+				case LogEventLevel.ERROR:
+					_collectedMessages.push(PREFIX_ERROR + message);
+					break;
+					
+				case LogEventLevel.WARN:
+					_collectedMessages.push(PREFIX_WARNING + message);
+					break;
+			}
+		}
+	}
+}

--- a/test/classes/helper/MemoryLogTargetTest.as
+++ b/test/classes/helper/MemoryLogTargetTest.as
@@ -1,0 +1,85 @@
+package classes.helper 
+{
+	import classes.helper.MemoryLogTarget;
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import mx.logging.ILogger;
+	import mx.logging.Log;
+	
+	public class MemoryLogTargetTest 
+	{
+		private static const TEST_MESSAGE:String = "this is a test";
+		
+		private var cut:MemoryLogTarget;
+		private var logger:ILogger;
+		
+		public function MemoryLogTargetTest() 
+		{
+		}
+		
+		[Before]
+		public function setUp():void {
+			cut = new MemoryLogTarget();
+			Log.addTarget(cut);
+			logger = Log.getLogger("test");
+		}
+		
+		[After]
+		public function tearDown():void {
+			Log.removeTarget(cut);
+		}
+		
+		private function expectedMessage(prefix:String):String {
+			return prefix + TEST_MESSAGE;
+		}
+		
+		[Test]
+		public function debugLevelMessage():void {
+			logger.debug(TEST_MESSAGE);
+			
+			assertThat(cut.collectedMessages, hasItem(equalTo(expectedMessage(MemoryLogTarget.PREFIX_DEBUG))));
+		}
+		
+		[Test]
+		public function infoLevelMessage():void {
+			logger.info(TEST_MESSAGE);
+			
+			assertThat(cut.collectedMessages, hasItem(equalTo(expectedMessage(MemoryLogTarget.PREFIX_INFO))));
+		}
+				
+		[Test]
+		public function warningLevelMessage():void {
+			logger.warn(TEST_MESSAGE);
+			
+			assertThat(cut.collectedMessages, hasItem(equalTo(expectedMessage(MemoryLogTarget.PREFIX_WARNING))));
+		}
+		
+		[Test]
+		public function errorLevelMessage():void {
+			logger.error(TEST_MESSAGE);
+			
+			assertThat(cut.collectedMessages, hasItem(equalTo(expectedMessage(MemoryLogTarget.PREFIX_ERROR))));
+		}
+		
+		[Test]
+		public function fatalLevelMessage():void {
+			logger.fatal(TEST_MESSAGE);
+			
+			assertThat(cut.collectedMessages, hasItem(equalTo(expectedMessage(MemoryLogTarget.PREFIX_FATAL))));
+		}
+		
+		[Test]
+		public function multipleMessages():void {
+			logger.info(TEST_MESSAGE);
+			logger.warn(TEST_MESSAGE);
+			
+			assertThat(cut.collectedMessages, arrayWithSize(2));
+		}
+	}
+}

--- a/test/classes/internals/LoggerFactoryTest.as
+++ b/test/classes/internals/LoggerFactoryTest.as
@@ -1,0 +1,36 @@
+package classes.internals 
+{
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import mx.logging.ILogger;
+	import mx.logging.Log;
+	
+	import classes.helper.MemoryLogTarget;
+	import classes.helper.StageLocator;
+	
+	public class LoggerFactoryTest 
+	{
+		public function LoggerFactoryTest() 
+		{
+		}
+		
+		[Test]
+		public function createLoggerForClass():void {
+			var logger:ILogger = LoggerFactory.getLogger(StageLocator);
+		}
+		
+		[Test]
+		public function loggersAreCached():void {
+			var logger:ILogger = LoggerFactory.getLogger(StageLocator);
+			var logger2:ILogger = LoggerFactory.getLogger(StageLocator);
+			
+			assertThat(logger, strictlyEqualTo(logger2));
+		}
+	}
+}


### PR DESCRIPTION
- Factory class for easy logger creation
- Logging setup in `CoC` class
- Replaced some trace logging as an example
- Logging documented in `CONTRIBUTING.md`
- In Memory log target for testing