### PR TITLE
Fix equinum overdose bad end if lowerBody is hoofed and isTaur

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -859,7 +859,7 @@
 			outputText("You down the potion, grimacing at the strong taste.", true);
 			//CHANCE OF BAD END - 20% if face/tail/skin/cock are appropriate.
 			//If hooved bad end doesn't appear till centaured
-			if (player.hasFur() && player.faceType == FACE_HORSE && player.tailType == TAIL_TYPE_HORSE && (player.lowerBody != LOWER_BODY_TYPE_HOOFED)) {
+			if (player.hasFur() && player.faceType == FACE_HORSE && player.tailType == TAIL_TYPE_HORSE && (player.lowerBody != LOWER_BODY_TYPE_HOOFED || player.isTaur())) {
 				//WARNINGS
 				//Repeat warnings
 				if (player.hasStatusEffect(StatusEffects.HorseWarning) && rand(3) == 0) {


### PR DESCRIPTION
Around the time, when player.legCount and Taurinum was implemented `LOWER_BODY_TYPE_HOOFED` disabled the overdose bad end of Equinum even after you became a centaur. Well, this one-liner fixes this.

Did a brief test and that should do the trick without issues.