### PR TITLE
Kill remaining warnings

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -186,14 +186,6 @@
 			return kGAMECLASS.createCallBackFunction(func,arg);
 		}
 
-		/** [DEPRECATED] Create a function that will pass multiple arguments. 
-		 */
-		[Deprecated(message="This function is deprecated.")]
-		protected function createCallBackFunction2(func:Function, ...args):Function
-		{
-			return kGAMECLASS.createCallBackFunction2.apply(null,[func].concat(args));
-		}
-
 		protected function doSFWloss():Boolean {
 			return kGAMECLASS.doSFWloss();
 		}

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -2092,7 +2092,6 @@ package classes
 			return false
 		}
 		
-		[Deprecated]
 		public function hasSock(arg:String = ""):Boolean
 		{
 			var index:int = cocks.length;

--- a/classes/classes/Scenes/DebugMenu.as
+++ b/classes/classes/Scenes/DebugMenu.as
@@ -94,7 +94,7 @@ package classes.Scenes
 			var buttonPos:int = 0; //Button positions 4 and 9 are reserved for next and previous.
 			for (var i:int = 0; i < 12; i++) {
 				if (array[((page-1) * 12) + i] != undefined) {
-					if (array[((page-1) * 12) + i] != null) addButton(buttonPos, array[((page-1) * 12) + i].shortName, inventory.takeItem, array[((page-1) * 12) + i], createCallBackFunction2(displayItemPage, array, page));
+					if (array[((page-1) * 12) + i] != null) addButton(buttonPos, array[((page-1) * 12) + i].shortName, inventory.takeItem, array[((page-1) * 12) + i], curry(displayItemPage, array, page));
 				}
 				buttonPos++;
 				if (buttonPos == 4 || buttonPos == 9) buttonPos++;

--- a/classes/classes/Scenes/Places/TelAdre/BakeryScene.as
+++ b/classes/classes/Scenes/Places/TelAdre/BakeryScene.as
@@ -289,7 +289,6 @@ private function buyFig():void {
 
 
 private function talkBakeryMenu():void {
-	//choices("Brownies",createCallBackFunction2(nomnomnom, "brownies", 3),"Cookies",2831,"Cupcakes",2833,"Doughnuts",createCallBackFunction2(nomnomnom, "doughnuts", 5),"Pound Cake",createCallBackFunction2(nomnomnom, "pound cake", 4),"Fox Berry",buyFoxBerry,"SpecialEclair",minoCum,"GiantCupcake",gcupcake,rubiT,rubiB,"Leave",telAdreMenu);
 	clearOutput();
 	outputText("Who will you talk to?\n");
 	var rubiT:String = "Waitress";

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -506,17 +506,6 @@ public function createCallBackFunction(func:Function, arg:*, arg2:* = null, arg3
 		}
 	}
 }
-public function createCallBackFunction2(func:Function,...args):Function
-{
-	if (func == null){
-		CoC_Settings.error("createCallBackFunction(null,"+args+")");
-	}
-	return function():*
-	{
-		if (CoC_Settings.haltOnErrors) logFunctionInfo(func,args);
-		return func.apply(null,args);
-	}
-}
 
 /**
  * Adds a button.


### PR DESCRIPTION
### Internal changes
- Removed the last remnants of createCallBackFunction2
- Removed `[Deprecated]` tag from Creature.hasSock()

### Notes
- `Creature.hasSock()` is being used, altough only once and I can't find any replacement for it. Hence I've removed the `[Deprecated]` tag from it (for now?)
- There are still some remainders of choices and simpleChoices (`game.choices()` and `game.simpleChoices()` + mostly in commented out code)
  Maybe someone wants to work on swiping these from the code as well?