### PR TITLE
Fixing trap oil crash

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -8773,6 +8773,7 @@ public function wolfPepper(type: Number, player: Player): void {
 					temp = 1;
 					while (temp < player.bRows()) {
 						if (player.breastRows[temp].breastRating < 1) player.breastRows[temp].breastRating = 1;
+						temp++;
 					}
 				}
 				changes++;


### PR DESCRIPTION
Fixed trap oil crash when player has multiple rows of breasts.