### PR TITLE
Fixing some combatMenu issues

### DIFF
--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -764,13 +764,13 @@ package classes.Scenes.Combat
 			if (player.findPerk(PerkLib.BloodMage) < 0 && player.fatigue + player.spellCost(20) > player.maxFatigue())
 			{
 				outputText("You are too tired to breathe fire.", true);
-				doNext(combat.combatMenu);
+				doNext(curry(combat.combatMenu,false));
 				return;
 			}
 			//Not Ready Yet:
 			if (player.hasStatusEffect(StatusEffects.DragonBreathCooldown)) {
 				outputText("You try to tap into the power within you, but your burning throat reminds you that you're not yet ready to unleash it again...");
-				doNext(combat.combatMenu);
+				doNext(curry(combat.combatMenu,false));
 				return;
 			}
 			player.changeFatigue(20, 1);
@@ -863,7 +863,7 @@ package classes.Scenes.Combat
 			clearOutput();
 			if (player.fatigue + 20 > player.maxFatigue()) {
 				outputText("You are too tired to breathe fire.", true);
-				doNext(combat.combatMenu);
+				doNext(curry(combat.combatMenu,false));
 				return;
 			}
 			player.changeFatigue(20);
@@ -1088,12 +1088,12 @@ package classes.Scenes.Combat
 			if (player.findPerk(PerkLib.BloodMage) < 0 && player.fatigue + player.spellCost(10) > player.maxFatigue())
 			{
 				outputText("You are too tired to focus this ability.", true);
-				doNext(combat.combatMenu);
+				doNext(curry(combat.combatMenu,false));
 				return;
 			}
 			if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 				outputText("You cannot focus to reach the enemy's mind while you're having so much difficult breathing.", true);
-				doNext(combat.combatMenu);
+				doNext(curry(combat.combatMenu,false));
 				return;
 			}
 			if (monster.short == "pod" || monster.inte == 0) {
@@ -2392,7 +2392,7 @@ package classes.Scenes.Combat
 			clearOutput();
 			if (player.fatigue + player.physicalCost(20) > player.maxFatigue()) {
 				outputText("You are too tired to perform a shield bash.");
-				doNext(combat.combatMenu);
+				doNext(curry(combat.combatMenu,false));
 				return;
 			}
 			outputText("You ready your [shield] and prepare to slam it towards " + monster.a + monster.short + ".  ");


### PR DESCRIPTION
A few abilities were ending turns(triggering regen, status updates and all that) even when you didn't actually cast them.