### PR TITLE
Fixed crash when useItemNow called with 1 arg

### DIFF
--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -450,7 +450,7 @@ package classes.Scenes
 			addButton(14, "Abandon", callOnAbandon); //Does not doNext - immediately executes the callOnAbandon function
 		}
 		
-		private function useItemNow(item:Useable, source:ItemSlotClass):void {
+		private function useItemNow(item:Useable, source:ItemSlotClass = null):void {
 			clearOutput();
 			if (item.canUse()) { //If an item cannot be used then canUse should provide a description of why the item cannot be used
 				useItem(item, source);


### PR DESCRIPTION
The root source of this bug is how the `addButton` and `createCallbackFunction` determine the function arity - by comparing the args with -9000 or null. That makes these functions a source of potential crashes.

(cherry picked from commit 52f7482)