### PR TITLE
Fix roxanne scene

### DIFF
--- a/classes/classes/Scenes/Places/Bazaar/Roxanne.as
+++ b/classes/classes/Scenes/Places/Bazaar/Roxanne.as
@@ -1,9 +1,11 @@
 ﻿package classes.Scenes.Places.Bazaar{
 	import classes.*;
 	import classes.GlobalFlags.kFLAGS;
+	import mx.logging.ILogger;
+	import classes.internals.LoggerFactory;
 
 	public class Roxanne extends BazaarAbstractContent implements TimeAwareInterface {
-
+		private static const LOGGER:ILogger = LoggerFactory.getLogger(Roxanne);
 //Roxanne Poisontail
 //-no hair, 
 //-stand roughly 5'11\" in height, 
@@ -179,7 +181,7 @@ private function roxanneDrinkingContestLoseDeliberately():void {
 	roxanneDrinkingContest();
 }
 
-private function roxanneDrinkingContest():void {
+protected function roxanneDrinkingContest():void {
 	spriteSelect(78);
 	clearOutput();
 	outputText("Roxanne ", false);
@@ -235,6 +237,7 @@ private function roxanneDrinkingContest():void {
 	//If score is less than 30-50 (Strahza is inconsistant!)
 	//[Lose!] 
 	if (score < (45 + rand(20))) {
+		LOGGER.debug("Lost to Roxanne with a score of {0}", score);
 		//Increment loss count!
 		flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST]++;
 		//Set who won contast last
@@ -247,15 +250,23 @@ private function roxanneDrinkingContest():void {
 		outputText("  A scaled hand slaps your " + player.buttDescript() + " spinning you around to fall drunkenly into the pirate's soft, cushy chest.  \"<i>Don't worry, I'll be gentle,</i>\" she whispers, hooking an arm around your sagging frame.", false);
 		//CHOOSE SEX SCENE
 		//Chance of big booty butt loss!
-		if (player.buttRating > 12 && player.tone <= 50 && flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 1 && rand(2) == 0) doNext(bigBootyRoxanneContestLoss);
-		//TO huge or regular anal
-		else if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 200) doNext(roxanneFucksYourAssOHGODITSHUGE);
-		else doNext(roxanneReamsYouNormal);
+		if (player.buttRating > 12 && player.tone <= 50 && flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 1 && rand(2) == 0){
+			LOGGER.debug("Starting loss scene: Big booty");
+			doNext(bigBootyRoxanneContestLoss);
+		} else if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 200) {
+			//TO huge or regular anal
+			LOGGER.debug("Starting loss scene: Huge");
+			doNext(roxanneFucksYourAssOHGODITSHUGE);
+		} else {
+			LOGGER.debug("Starting loss scene: Normal");
+			doNext(roxanneReamsYouNormal);
+		}
 		//Reset roxanne's cock
 		flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 1;
 	}
 	//[WIN]
 	else {
+		LOGGER.debug("Won against Roxanne with a score of {0}", score);
 		//Increment win count!
 		flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON]++;
 		//Set who won contest last

--- a/classes/classes/Scenes/Places/Bazaar/Roxanne.as
+++ b/classes/classes/Scenes/Places/Bazaar/Roxanne.as
@@ -261,8 +261,6 @@ protected function roxanneDrinkingContest():void {
 			LOGGER.debug("Starting loss scene: Normal");
 			doNext(roxanneReamsYouNormal);
 		}
-		//Reset roxanne's cock
-		flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 1;
 	}
 	//[WIN]
 	else {
@@ -515,6 +513,7 @@ private function roxanneReamsYouNormal():void {
 	player.orgasm();
 	dynStats("int", -1);
 	applyHangover();
+	resetRoxanneSexTimeCounter();
 	doNext(camp.returnToCampUseFourHours);
 }
 
@@ -579,6 +578,7 @@ private function roxanneFucksYourAssOHGODITSHUGE():void {
 	player.orgasm();
 	dynStats("int", -1);
 	applyHangover();
+	resetRoxanneSexTimeCounter();
 	doNext(camp.returnToCampUseFourHours);
 }
 	
@@ -669,7 +669,12 @@ private function bigBootyRoxanneContestLoss():void {
 	player.orgasm();
 	dynStats("int", -1);
 	applyHangover();
+	resetRoxanneSexTimeCounter();
 	doNext(camp.returnToCampUseFourHours);
+}
+
+private function resetRoxanneSexTimeCounter():void {
+	flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 1;
 }
 }
 }

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -27,6 +27,8 @@ import flash.text.TextFormat;
 // 
 // model.maxHP = maxHP;
 
+public static const MAX_BUTTON_INDEX:int = 14;
+
 public function maxHP():Number {
 	return player.maxHP();
 }
@@ -206,7 +208,7 @@ public function displayHeader(string:String):void {
 }
 
 public function buttonIsVisible(index:int):Boolean {
-	if ( index < 0 || index > 14 ) {
+	if ( index < 0 || index > MAX_BUTTON_INDEX ) {
 		return undefined;
 	}
 	else {
@@ -246,7 +248,7 @@ public function buttonTextIsOneOf(index:int, possibleLabels:Array):Boolean {
 public function getButtonText(index:int):String {
 	var matches:*;
 
-	if (index < 0 || index > 14) {
+	if (index < 0 || index > MAX_BUTTON_INDEX) {
 		return '';
 	}
 	else {
@@ -510,7 +512,7 @@ public function addButton(pos:int, text:String = "", func1:Function = null, arg1
 	var callback:Function;
 
 	//Let the mainView decide if index is valid
-	if (pos > 14) {
+	if (pos > MAX_BUTTON_INDEX) {
 		trace("INVALID BUTTON");
 		return;
 	}
@@ -567,7 +569,7 @@ public function removeButton(arg:*):void {
 		buttonToRemove = mainView.indexOfButtonWithLabel( arg as String );
 	}
 	if (arg is Number) {
-		if (arg < 0 || arg > 14) return;
+		if (arg < 0 || arg > MAX_BUTTON_INDEX) return;
 		buttonToRemove = Math.round(arg);
 	}
 	mainView.hideBottomButton( buttonToRemove );
@@ -577,7 +579,7 @@ public function removeButton(arg:*):void {
  * Hides all bottom buttons.
  */
 public function menu():void { //The newer, simpler menu - blanks all buttons so addButton can be used
-	for (var i:int = 0; i <= 14; i++) {
+	for (var i:int = 0; i <= MAX_BUTTON_INDEX; i++) {
 		mainView.hideBottomButton(i);
 		mainView.bottomButtons[i].alpha = 1; // Dirty hack.
 	}

--- a/test/classes/HelperSuit.as
+++ b/test/classes/HelperSuit.as
@@ -1,5 +1,6 @@
 package classes {
 
+import classes.helper.FireButtonEventTest;
 import classes.helper.MemoryLogTargetTest;
 import classes.helper.StageLocatorTest;
 
@@ -9,5 +10,6 @@ import classes.helper.StageLocatorTest;
 	{
 		 public var stageLocatorTest:StageLocatorTest;
 		 public var memoryLogTargetTest:MemoryLogTargetTest;
+		 public var fireButtonEventTest:FireButtonEventTest;
 	}
 }

--- a/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
+++ b/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
@@ -1,0 +1,157 @@
+package classes.Scenes.Places.Bazaar{
+	import classes.Appearance;
+	import classes.helper.FireButtonEvent;
+    import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import classes.helper.StageLocator;
+	
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.CoC;
+	import classes.GlobalFlags.kFLAGS;
+     
+    public class RoxanneTest {
+		private static const EVENT_ITERATIONS:int = 20;
+		
+        private var cut:RoxanneForTest;
+		private var player:Player;
+		private var fireButtons:FireButtonEvent;
+		
+		[BeforeClass]
+		public static function setUpClass():void {
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+         
+        [Before]
+        public function setUp():void {  
+			cut = new RoxanneForTest();
+			player = new Player();
+			kGAMECLASS.player = player;
+			fireButtons = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
+			
+			player.flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 10;
+			player.flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LOSE_ON_PURPOSE] = 1;
+			
+			assertThat(player.ass.analLooseness, equalTo(0));
+        }
+		
+		/**
+		 * Many loops needed due to non-deterministic nature of buttChangeNoDisplay().
+		 * @param	testFunction function to call multiple times
+		 */
+		private function repeatEvent(testFunction:Function):void {
+			for (var i:int = 0; i < EVENT_ITERATIONS; i++) {
+				testFunction();
+			}
+		}
+		
+		[Test(description="This test may show sporadic failures due to the use of rand() in the code under test")] 
+        public function roxanneStretchLowTime():void {
+			
+			var testFunction:Function = function():void {
+				cut.roxanneDrinkingContestTest();
+				fireButtons.fireNextButtonEvent();
+			}
+
+			repeatEvent(testFunction);
+			
+			assertThat(kGAMECLASS.player.ass.analLooseness, equalTo(3));
+			assertThat(cut.collectedOutput, hasItem(startsWith("A foot interposes itself")));
+		}
+		
+		[Test] 
+        public function roxanneResetCounterLowTime():void {
+			cut.roxanneDrinkingContestTest();
+			fireButtons.fireNextButtonEvent();
+
+			assertThat(player.flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX],equalTo(1));
+			assertThat(cut.collectedOutput, hasItem(startsWith("A foot interposes itself")));
+		}
+		
+		private function setRoxanneLargeSize():void {
+			player.flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 290;
+		}
+		
+		[Test(description="This test may show sporadic failures due to the use of rand() in the code under test")] 
+        public function roxanneRepeatedStretchingWithHighTime():void {
+			setRoxanneLargeSize();
+			
+
+			var testFunction:Function = function():void {
+				cut.roxanneDrinkingContestTest();
+				fireButtons.fireNextButtonEvent();
+				setRoxanneLargeSize();
+			}
+			
+			repeatEvent(testFunction);
+			
+			assertThat(kGAMECLASS.player.ass.analLooseness, equalTo(5));
+			assertThat(cut.collectedOutput, hasItem(startsWith("Gosh, Roxanne is so strong...")));
+		}
+		
+		[Test] 
+        public function roxanneCounterResetWithHighTime():void {
+			setRoxanneLargeSize();
+			cut.roxanneDrinkingContestTest();
+			fireButtons.fireNextButtonEvent();
+			
+			assertThat(player.flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX],equalTo(1));
+			assertThat(cut.collectedOutput, hasItem(startsWith("Gosh, Roxanne is so strong...")));
+		}
+		
+		[Ignore(description="Needs injected RNG")]
+		[Test(description="This test may show sporadic failures due to the use of rand() in the code under test")] 
+        public function roxanneRepeatedStretchingWithBigBooty():void {
+			setRoxanneLargeSize();
+			player.buttRating = Appearance.BUTT_RATING_EXPANSIVE;
+
+			var testFunction:Function = function():void {
+				cut.roxanneDrinkingContestTest();
+				fireButtons.fireNextButtonEvent();
+				setRoxanneLargeSize();
+			}
+			
+			repeatEvent(testFunction);
+			
+			assertThat(kGAMECLASS.player.ass.analLooseness, equalTo(5));
+			assertThat(cut.collectedOutput, hasItem(startsWith("Gods, your head is swimming!")));
+		}
+		
+		[Ignore(description="Needs injected RNG")]
+		[Test(description="This test may show sporadic failures due to the use of rand() in the code under test")] 
+        public function roxanneCounterResetWithBigBooty():void {
+			setRoxanneLargeSize();
+			player.buttRating = Appearance.BUTT_RATING_EXPANSIVE;
+
+			var testFunction:Function = function():void {
+				cut.roxanneDrinkingContestTest();
+				fireButtons.fireNextButtonEvent();
+			}
+			
+			repeatEvent(testFunction);
+			
+			assertThat(player.flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX], equalTo(1));
+			assertThat(cut.collectedOutput, hasItem(startsWith("Gods, your head is swimming!")));
+		}
+    }
+}
+
+import classes.Scenes.Places.Bazaar.Roxanne;
+
+class RoxanneForTest extends Roxanne {
+	public var collectedOutput:Vector.<String> = new Vector.<String>(); 
+
+	public function roxanneDrinkingContestTest():void {
+		super.roxanneDrinkingContest();
+	}
+	
+	override protected function outputText(output:String, purgeText:Boolean = false, parseAsMarkdown:Boolean = false):void {
+		collectedOutput.push(output);
+	}
+}

--- a/test/classes/Scenes/Places/BazaarSuit.as
+++ b/test/classes/Scenes/Places/BazaarSuit.as
@@ -1,10 +1,12 @@
 package classes.Scenes.Places {
 	import classes.Scenes.Places.Bazaar.BlackCockTest;
+	import classes.Scenes.Places.Bazaar.RoxanneTest;
 
 [Suite]
 [RunWith("org.flexunit.runners.Suite")]
 	public class BazaarSuit
 	{
 		 public var blackCockTest:BlackCockTest;
+		 public var roxanneTest:RoxanneTest;
 	}
 }

--- a/test/classes/helper/FireButtonEvent.as
+++ b/test/classes/helper/FireButtonEvent.as
@@ -1,0 +1,57 @@
+package classes.helper 
+{
+	import classes.MainViewManager;
+	import coc.view.MainView;
+	import flash.events.MouseEvent;
+	
+	/**
+	 * Fires Button click events to simulate user button clicks.
+	 */
+	public class FireButtonEvent 
+	{
+		private static const NEXT_BUTTON_LOCATION:int = 0;
+		
+		private var mainView:MainView;
+		private var maxButtonIndex:int;
+		
+		/**
+		 * Create a new instance that can be used to fire button events.
+		 * @param	mainView the view that caontains the buttons
+		 * @param	maxButtonIndex the maximum number of buttons, should usually be CoC.MAX_BUTTON_INDEX
+		 */
+		public function FireButtonEvent(mainView:MainView, maxButtonIndex:int) 
+		{
+			this.mainView = mainView;
+			this.maxButtonIndex = maxButtonIndex;
+		}
+		
+		/**
+		 * Fires a event for the given button.
+		 * @param	buttonIndex for which the event should be fired
+		 * @throws  ArgumentError if the button is out of bounds
+		 */
+		public function fireButtonClick(buttonIndex:int):void {
+			indexRangeCheck(buttonIndex);
+			
+			mainView.bottomButtons[buttonIndex].dispatchEvent(new MouseEvent(MouseEvent.CLICK));
+		}
+		
+		private function indexRangeCheck(buttonIndex:int):void{
+			if (buttonIndex > maxButtonIndex) {
+				throw new ArgumentError("The maximum allowed button index is " + maxButtonIndex);
+			}
+			
+			if (buttonIndex < 0) {
+				throw new ArgumentError("The button index cannot be negative");
+			}
+		}
+		
+		/**
+		 * Presses the next button (Button 0).
+		 * Useful for pressing 'Next' on doNext() events.
+		 */
+		public function fireNextButtonEvent():void {
+			fireButtonClick(NEXT_BUTTON_LOCATION);
+		}
+	}
+}

--- a/test/classes/helper/FireButtonEventTest.as
+++ b/test/classes/helper/FireButtonEventTest.as
@@ -37,12 +37,6 @@ package classes.helper
 			eventTriggeredFlag = false;
 		}
 		
-		[After]
-		public function tearDown():void
-		{
-			
-		}
-		
 		private function setFlagEvent():void {
 			eventTriggeredFlag = true;
 		}

--- a/test/classes/helper/FireButtonEventTest.as
+++ b/test/classes/helper/FireButtonEventTest.as
@@ -1,0 +1,92 @@
+package classes.helper
+{
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import classes.helper.FireButtonEvent;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.CoC;
+	
+	public class FireButtonEventTest
+	{
+		private static const TEST_BUTTON_INDEX:int = 5;
+		private static const TEST_BUTTON_TEXT:String = "Testing!";
+		
+		private var cut:FireButtonEvent;
+		private var eventTriggeredFlag:Boolean;
+		
+		public function FireButtonEventTest()
+		{
+		}
+		
+		[BeforeClass]
+		public static function setUpClass():void
+		{
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+		
+		[Before]
+		public function setUp():void
+		{
+			cut = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
+			eventTriggeredFlag = false;
+		}
+		
+		[After]
+		public function tearDown():void
+		{
+			
+		}
+		
+		private function setFlagEvent():void {
+			eventTriggeredFlag = true;
+		}
+		
+		[Test(expected = "ArgumentError")]
+		public function buttonIndexOutOfRange():void {
+			cut.fireButtonClick(int.MAX_VALUE);
+		}
+		
+		[Test(expected = "ArgumentError")]
+		public function buttonIndexNegative():void {
+			cut.fireButtonClick(int.MIN_VALUE);
+		}
+		
+		[Test]
+		public function buttonEventNotTriggered():void {
+			kGAMECLASS.addButton(TEST_BUTTON_INDEX, TEST_BUTTON_TEXT, setFlagEvent);
+			
+			assertThat(eventTriggeredFlag, equalTo(false));
+		}
+		
+		[Test]
+		public function buttonEventTriggered():void {
+			kGAMECLASS.addButton(TEST_BUTTON_INDEX, TEST_BUTTON_TEXT, setFlagEvent);
+			
+			cut.fireButtonClick(TEST_BUTTON_INDEX);
+			
+			assertThat(eventTriggeredFlag, equalTo(true));
+		}
+		
+		[Test]
+		public function doNextEventNotTriggered():void {
+			kGAMECLASS.doNext(setFlagEvent);
+			
+			assertThat(eventTriggeredFlag, equalTo(false));
+		}
+		
+		[Test]
+		public function doNextEventTriggered():void {
+			kGAMECLASS.doNext(setFlagEvent);
+			
+			cut.fireNextButtonEvent();
+			
+			assertThat(eventTriggeredFlag, equalTo(true));
+		}
+	}
+}


### PR DESCRIPTION
This fixes `flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX]` getting reset before the stretch calculation.
This fixes #516.

Two tests are ignored because for them to be meaningful, the class responsible for `rand()` needs to be injected. This will allow the test to inject it's own implementation and control the program flow.
```actionscript
if (player.buttRating > 12
	&& player.tone <= 50
	&& flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 1
	&& rand(2) == 0)
{
	doNext(bigBootyRoxanneContestLoss);
} else if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 200) {
	doNext(roxanneFucksYourAssOHGODITSHUGE);
} else {
	doNext(roxanneReamsYouNormal);
}
```

Related:
[Dependency injection](https://en.wikipedia.org/wiki/Dependency_injection)