### PR TITLE
Serialize interface

### DIFF
--- a/classes/classes/internals/Serializable.as
+++ b/classes/classes/internals/Serializable.as
@@ -10,15 +10,15 @@ package classes.internals
 	public interface Serializable 
 	{
 		/**
-		 * Serialize a class so it can be stored. Any state that is not serialized will be lost and replace with the
+		 * Serialize a class so it can be stored. Any state that is not serialized will be lost and replaced with the
 		 * default value on deserialization.
-		 * The variables need to be stored manually. If you only have primitive public variables, use AMF directly and SerializeAMF for Vectors for simpler
-		 * serialization.
-		 * The class is responsible for initalizing its storage by creating an empty arrary.
+		 * The class variables need to be stored manually.
+		 * The object that is passed in must be initialized so class can write to it.
 		 * 
 		 * e.g.:
 		 * relativeRootObject.foo = intValue;
 		 * relativeRootObject.bar = StringValue;
+		 * relativeRootObject.baz = [];
 		 * this.complexObject.serialize(relativeRootObject.baz);
 		 * 
 		 * @param	relativeRootObject the object this class should write to 
@@ -28,7 +28,6 @@ package classes.internals
 		/**
 		 * Deserialize a class, restoring it's state. Deserialization requires some form of default constructor, this can be achieved
 		 * with all parameters having a default value.
-		 * Objects stored with AMF have to be restored in Saves.as.
 		 * 
 		 * @param	relativeRootObject the object this class should read from
 		 */

--- a/classes/classes/internals/Serializable.as
+++ b/classes/classes/internals/Serializable.as
@@ -12,8 +12,9 @@ package classes.internals
 		/**
 		 * Serialize a class so it can be stored. Any state that is not serialized will be lost and replace with the
 		 * default value on deserialization.
-		 * The variables can either be stored manually, or if only public variables are used, AMF can be used to simplify the process.
-		 * The class is responsible for initalizing it's storage, either by creating an empty arrary or assigining an object.
+		 * The variables need to be stored manually. If you only have primitive public variables, use AMF directly and SerializeAMF for Vectors for simpler
+		 * serialization.
+		 * The class is responsible for initalizing its storage by creating an empty arrary.
 		 * 
 		 * e.g.:
 		 * relativeRootObject.foo = intValue;
@@ -27,6 +28,7 @@ package classes.internals
 		/**
 		 * Deserialize a class, restoring it's state. Deserialization requires some form of default constructor, this can be achieved
 		 * with all parameters having a default value.
+		 * Objects stored with AMF have to be restored in Saves.as.
 		 * 
 		 * @param	relativeRootObject the object this class should read from
 		 */

--- a/classes/classes/internals/Serializable.as
+++ b/classes/classes/internals/Serializable.as
@@ -1,0 +1,35 @@
+package classes.internals 
+{
+	
+	/**
+	 * Interface for serialization and de-serialization.
+	 * This is used to store class state in an object, so it can be persisted either
+	 * to a shared object or file.
+	 * The interface also provides a function to reverse the process.
+	 */
+	public interface Serializable 
+	{
+		/**
+		 * Serialize a class so it can be stored. Any state that is not serialized will be lost and replace with the
+		 * default value on deserialization.
+		 * The variables can either be stored manually, or if only public variables are used, AMF can be used to simplify the process.
+		 * The class is responsible for initalizing it's storage, either by creating an empty arrary or assigining an object.
+		 * 
+		 * e.g.:
+		 * relativeRootObject.foo = intValue;
+		 * relativeRootObject.bar = StringValue;
+		 * this.complexObject.serialize(relativeRootObject.baz);
+		 * 
+		 * @param	relativeRootObject the object this class should write to 
+		 */
+		function serialize(relativeRootObject:*):void;
+		
+		/**
+		 * Deserialize a class, restoring it's state. Deserialization requires some form of default constructor, this can be achieved
+		 * with all parameters having a default value.
+		 * 
+		 * @param	relativeRootObject the object this class should read from
+		 */
+		function deserialize(relativeRootObject:*):void;
+	}
+}

--- a/classes/classes/internals/SerializableAMF.as
+++ b/classes/classes/internals/SerializableAMF.as
@@ -1,0 +1,9 @@
+package classes.internals 
+{
+	/**
+	 * Interface for marking classes that should be serialized with AMF
+	 */
+	public interface SerializableAMF 
+	{
+	}
+}

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -68,5 +68,22 @@ package classes.internals
 			
 			return serialized;
 		}
+		
+		/**
+		 * Casts a vector from one type to another. DOES NO VALIDATION.
+		 * @param	destinationVector vector where casted elements will be put
+		 * @param	sourceVector where elements for casting will be read from
+		 * @param	destinationType the class to cast to
+		 */
+		public static function castVector(destinationVector:*, sourceVector:*, destinationType:Class):void {
+			/**
+			 * If anyone has a better idea, i'm all ears.
+			 * Implement your solution and see if the tests pass.
+			 */
+			
+			for each(var element:* in sourceVector) {
+				destinationVector.push(element as destinationType);
+			}
+		}
 	}
 }

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -1,5 +1,6 @@
 package classes.internals 
 {
+	import classes.Items.Armors.Nothing;
 	import flash.errors.IllegalOperationError;
 	/**
 	 * A class providing utility methods to make serialization and deserialization easier.
@@ -27,6 +28,29 @@ package classes.internals
 			}
 			
 			return serialized;
+		}
+		
+		/**
+		 * Deserializes a Array into a Vector of Serializable
+		 * @param	serializedVector an Array containing the serialized vector
+		 * @param	type of the serialized Vector
+		 * @return a deserialized Vector
+		 */
+		public static function deserializeVector(serializedVector:Array, type:Class):Vector.<Serializable> {
+			// 'is' will only work on an instance
+			if (!(new type() is Serializable)) {
+				throw new ArgumentError("Type must implement Serializable");
+			}
+			
+			var deserialized:Vector.<Serializable> = new Vector.<Serializable>();
+			
+			for each(var element:Object in serializedVector) {
+				var instance:Serializable = new type();
+				instance.deserialize(element)
+				deserialized.push(instance);
+			}
+			
+			return deserialized;
 		}
 		
 		

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -28,5 +28,21 @@ package classes.internals
 			
 			return serialized;
 		}
+		
+		
+		/**
+		 * Serializes a Vector into an array using AMF.
+		 * @param	vector to serialize
+		 * @return a array containing the serialized vector
+		 */
+		public static function serializeVectorWithAMF(vector:Vector.<SerializableAMF>):Array {
+			var serialized:* = [];
+			
+			for each(var element:SerializableAMF in vector) {
+				serialized.push(element);
+			}
+			
+			return serialized;
+		}
 	}
 }

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -70,6 +70,27 @@ package classes.internals
 		}
 		
 		/**
+		 * Deserializes a Array into a Vector using AMF
+		 * @param	serializedVector an Array containing the serialized vector
+		 * @param	type of the serialized Vector
+		 * @return a deserialized Vector
+		 */
+		public static function deserializeVectorWithAMF(serializedVector:Array, type:Class):Vector.<SerializableAMF> {
+			// 'is' will only work on an instance
+			if (!(new type() is SerializableAMF)) {
+				throw new ArgumentError("Type must implement SerializableAMF");
+			}
+			
+			var deserialized:Vector.<SerializableAMF> = new Vector.<SerializableAMF>();
+			
+			for each(var element:Object in serializedVector) {
+				deserialized.push(element as type);
+			}
+			
+			return deserialized;
+		}
+		
+		/**
 		 * Casts a vector from one type to another. DOES NO VALIDATION.
 		 * @param	destinationVector vector where casted elements will be put
 		 * @param	sourceVector where elements for casting will be read from

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -32,25 +32,30 @@ package classes.internals
 		
 		/**
 		 * Deserializes a Array into a Vector of Serializable
+		 * @param   destinationVector Vector where deserialized items will be written
 		 * @param	serializedVector an Array containing the serialized vector
 		 * @param	type of the serialized Vector
 		 * @return a deserialized Vector
 		 */
-		public static function deserializeVector(serializedVector:Array, type:Class):Vector.<Serializable> {
+		public static function deserializeVector(destinationVector:Vector.<*>, serializedVector:Array, type:Class):void {
 			// 'is' will only work on an instance
 			if (!(new type() is Serializable)) {
 				throw new ArgumentError("Type must implement Serializable");
 			}
 			
-			var deserialized:Vector.<Serializable> = new Vector.<Serializable>();
+			if (destinationVector == null) {
+				throw new ArgumentError("Destination Vector cannot be null");
+			}
+			
+			if (serializedVector == null) {
+				throw new ArgumentError("Serialized Vector cannot be null");
+			}
 			
 			for each(var element:Object in serializedVector) {
 				var instance:Serializable = new type();
 				instance.deserialize(element)
-				deserialized.push(instance);
+				destinationVector.push(instance);
 			}
-			
-			return deserialized;
 		}
 		
 		

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -1,0 +1,32 @@
+package classes.internals 
+{
+	import flash.errors.IllegalOperationError;
+	/**
+	 * A class providing utility methods to make serialization and deserialization easier.
+	 */
+	public class SerializationUtils 
+	{
+		public function SerializationUtils() 
+		{
+			throw new IllegalOperationError("This class cannot be instantiated");
+		}
+		
+		/**
+		 * Serializes a Vector into an array.
+		 * @param	vector to serialize
+		 * @return a array containing the serialized vector
+		 */
+		public static function serializeVector(vector:Vector.<Serializable>):Array {
+			var serialized:* = [];
+			
+			for each(var element:Serializable in vector) {
+				var obj:Object = new Object();
+				serialized.push(obj);
+				
+				element.serialize(obj);
+			}
+			
+			return serialized;
+		}
+	}
+}

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -17,11 +17,11 @@ package classes.internals
 		 * @param	vector to serialize
 		 * @return a array containing the serialized vector
 		 */
-		public static function serializeVector(vector:Vector.<Serializable>):Array {
+		public static function serializeVector(vector:Vector.<*>):Array {
 			var serialized:* = [];
 			
 			for each(var element:Serializable in vector) {
-				var obj:Object = new Object();
+				var obj:Array = [];
 				serialized.push(obj);
 				
 				element.serialize(obj);

--- a/test/classes/InternalsSuit.as
+++ b/test/classes/InternalsSuit.as
@@ -2,11 +2,13 @@ package classes {
 	import classes.helper.MemoryLogTarget;
 	import classes.helper.MemoryLogTargetTest;
 	import classes.internals.LoggerFactoryTest;
+	import classes.internals.SerializationUtilTest;
 	
 	[Suite]
 	[RunWith("org.flexunit.runners.Suite")]
 	public class InternalsSuit
 	{
 		public var loggerFactoryTest:LoggerFactoryTest;
+		public var serializationUtilTest:SerializationUtilTest;
 	}
 }

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -81,6 +81,39 @@ package classes.internals
 			
 			assertThat(testObject[TEST_INSTANCES - 1], instanceOf(AMFSerializationDummy));
 		}
+		
+		[Test]
+		public function deserializeVectorSize():void {
+			testObject = SerializationUtils.serializeVector(testVector);
+			
+			var vector:Vector.<Serializable> = SerializationUtils.deserializeVector(testObject, SerializationDummy);
+			
+			assertThat(vector, arrayWithSize(TEST_INSTANCES));
+		}
+		
+		[Test]
+		public function deserializeVectorType():void {
+			testObject = SerializationUtils.serializeVector(testVector);
+			
+			var vector:Vector.<Serializable> = SerializationUtils.deserializeVector(testObject, SerializationDummy);
+			
+			assertThat(vector[TEST_INSTANCES - 1], instanceOf(SerializationDummy));
+		}
+		
+		[Test]
+		public function deserializeVectorLastElementProperties():void {
+			testObject = SerializationUtils.serializeVector(testVector);
+			
+			var vector:Vector.<Serializable> = SerializationUtils.deserializeVector(testObject, SerializationDummy);
+			
+			assertThat(vector[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1}));
+			assertThat((vector[TEST_INSTANCES - 1] as SerializationDummy).getBar(), equalTo(TEST_INSTANCES));
+		}
+		
+		[Test(expected="ArgumentError")]
+		public function deserializeWithNonSerializableType():void {
+			SerializationUtils.deserializeVector(new Array(), String);
+		}
 	}
 }
 
@@ -93,10 +126,14 @@ class SerializationDummy implements Serializable
 	public var foo:int;
 	private var bar:int;
 	
-	public function SerializationDummy(foo:int, bar:int)
+	public function SerializationDummy(foo:int = -1, bar:int = -1)
 	{
 		this.foo = foo;
 		this.bar = bar;
+	}
+	
+	public function getBar():int {
+		return this.bar;
 	}
 	
 	public function serialize(relativeRootObject:*):void

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -114,6 +114,25 @@ package classes.internals
 		public function deserializeWithNonSerializableType():void {
 			SerializationUtils.deserializeVector(new Array(), String);
 		}
+		
+		[Test]
+		public function castVectorCheckProperties():void {
+			var destinationVector:Vector.<SerializationDummy> = new Vector.<SerializationDummy>();
+			
+			SerializationUtils.castVector(destinationVector, testVector, SerializationDummy);
+			
+			assertThat(destinationVector[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1}));
+			assertThat(destinationVector[TEST_INSTANCES - 1].getBar(), equalTo(TEST_INSTANCES));
+		}
+		
+		[Test]
+		public function castVectorCheckType():void {
+			var destinationVector:Vector.<SerializationDummy> = new Vector.<SerializationDummy>();
+			
+			SerializationUtils.castVector(destinationVector, testVector, SerializationDummy);
+			
+			assertThat(destinationVector[TEST_INSTANCES - 1], instanceOf(SerializationDummy));
+		}
 	}
 }
 

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -39,6 +39,10 @@ package classes.internals
 			}
 		}
 		
+		private function getTestObject():* {
+			return SerializationUtils.serializeVector(testVector as Vector.<*>);
+		}
+		
 		[Before]
 		public function setUp():void
 		{
@@ -53,7 +57,7 @@ package classes.internals
 		[Test]
 		public function serializeVectorObjectSize():void
 		{
-			testObject = SerializationUtils.serializeVector(testVector);
+			testObject = getTestObject();
 			
 			assertThat(testObject, arrayWithSize(TEST_INSTANCES));
 		}
@@ -61,7 +65,7 @@ package classes.internals
 		[Test]
 		public function serializeVectorLastObjectValue():void
 		{
-			testObject = SerializationUtils.serializeVector(testVector);
+			testObject = getTestObject();
 			
 			assertThat(testObject[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1, bar: TEST_INSTANCES}));
 		}
@@ -84,7 +88,7 @@ package classes.internals
 		
 		[Test]
 		public function deserializeVectorSize():void {
-			testObject = SerializationUtils.serializeVector(testVector);
+			testObject = getTestObject();
 			
 			var vector:Vector.<Serializable> = SerializationUtils.deserializeVector(testObject, SerializationDummy);
 			
@@ -93,7 +97,7 @@ package classes.internals
 		
 		[Test]
 		public function deserializeVectorType():void {
-			testObject = SerializationUtils.serializeVector(testVector);
+			testObject = getTestObject();
 			
 			var vector:Vector.<Serializable> = SerializationUtils.deserializeVector(testObject, SerializationDummy);
 			
@@ -102,7 +106,7 @@ package classes.internals
 		
 		[Test]
 		public function deserializeVectorLastElementProperties():void {
-			testObject = SerializationUtils.serializeVector(testVector);
+			testObject = getTestObject();
 			
 			var vector:Vector.<Serializable> = SerializationUtils.deserializeVector(testObject, SerializationDummy);
 			

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -133,6 +133,37 @@ package classes.internals
 			
 			assertThat(destinationVector[TEST_INSTANCES - 1], instanceOf(SerializationDummy));
 		}
+		
+		[Test(expected="ArgumentError")]
+		public function deserializeWithNonSerializableAMFType():void {
+			SerializationUtils.deserializeVectorWithAMF(new Array(), String);
+		}
+		
+		private function deserializeAMF():Vector.<SerializableAMF> {
+			testObject = SerializationUtils.serializeVectorWithAMF(testAMFVector);
+			return SerializationUtils.deserializeVectorWithAMF(testObject, AMFSerializationDummy);
+		}
+		
+		[Test]
+		public function deserializeVectorWithAMFSize():void {
+			var vector:Vector.<SerializableAMF> = deserializeAMF();
+			
+			assertThat(vector, arrayWithSize(TEST_INSTANCES));
+		}
+		
+		[Test]
+		public function deserializeVectorWithAMFType():void {
+			var vector:Vector.<SerializableAMF> = deserializeAMF();
+			
+			assertThat(vector[TEST_INSTANCES - 1], instanceOf(SerializableAMF));
+		}
+		
+		[Test]
+		public function deserializeVectorWithAMFProperty():void {
+			var vector:Vector.<SerializableAMF> = deserializeAMF();
+			
+			assertThat(vector[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1, bar: TEST_INSTANCES}));
+		}
 	}
 }
 
@@ -173,7 +204,7 @@ class AMFSerializationDummy implements SerializableAMF
 	public var foo:int;
 	public var bar:int;
 	
-	public function AMFSerializationDummy(foo:int, bar:int)
+	public function AMFSerializationDummy(foo:int = -2, bar:int = -2)
 	{
 		this.foo = foo;
 		this.bar = bar;

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -18,6 +18,7 @@ package classes.internals
 		private var testObject:*;
 		private var testVector:Vector.<Serializable>;
 		private var testAMFVector:Vector.<SerializableAMF>;
+		private var deserializedVector:Vector.<*>
 		
 		public function SerializationUtilTest()
 		{
@@ -49,6 +50,7 @@ package classes.internals
 			testObject = null;
 			testVector = new Vector.<Serializable>();
 			testAMFVector = new Vector.<SerializableAMF>();
+			deserializedVector = new Vector.<*>();
 			
 			buildVector(TEST_INSTANCES);
 			buildAmfVector(TEST_INSTANCES);
@@ -90,33 +92,43 @@ package classes.internals
 		public function deserializeVectorSize():void {
 			testObject = getTestObject();
 			
-			var vector:Vector.<Serializable> = SerializationUtils.deserializeVector(testObject, SerializationDummy);
+			SerializationUtils.deserializeVector(deserializedVector, testObject, SerializationDummy);
 			
-			assertThat(vector, arrayWithSize(TEST_INSTANCES));
+			assertThat(deserializedVector, arrayWithSize(TEST_INSTANCES));
 		}
 		
 		[Test]
 		public function deserializeVectorType():void {
 			testObject = getTestObject();
 			
-			var vector:Vector.<Serializable> = SerializationUtils.deserializeVector(testObject, SerializationDummy);
+			SerializationUtils.deserializeVector(deserializedVector,testObject, SerializationDummy);
 			
-			assertThat(vector[TEST_INSTANCES - 1], instanceOf(SerializationDummy));
+			assertThat(deserializedVector[TEST_INSTANCES - 1], instanceOf(SerializationDummy));
 		}
 		
 		[Test]
 		public function deserializeVectorLastElementProperties():void {
 			testObject = getTestObject();
 			
-			var vector:Vector.<Serializable> = SerializationUtils.deserializeVector(testObject, SerializationDummy);
+			SerializationUtils.deserializeVector(deserializedVector, testObject, SerializationDummy);
 			
-			assertThat(vector[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1}));
-			assertThat((vector[TEST_INSTANCES - 1] as SerializationDummy).getBar(), equalTo(TEST_INSTANCES));
+			assertThat(deserializedVector[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1}));
+			assertThat((deserializedVector[TEST_INSTANCES - 1] as SerializationDummy).getBar(), equalTo(TEST_INSTANCES));
 		}
 		
 		[Test(expected="ArgumentError")]
 		public function deserializeWithNonSerializableType():void {
-			SerializationUtils.deserializeVector(new Array(), String);
+			SerializationUtils.deserializeVector(new Vector.<*>(), new Array(), String);
+		}
+				
+		[Test(expected="ArgumentError")]
+		public function deserializeWithNullDestination():void {
+			SerializationUtils.deserializeVector(null, new Array(), SerializationDummy);
+		}
+		
+		[Test(expected="ArgumentError")]
+		public function deserializeWithNullSource():void {
+			SerializationUtils.deserializeVector(new Vector.<*>(), null, SerializationDummy);
 		}
 		
 		[Test]

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -7,8 +7,9 @@ package classes.internals
 	import org.hamcrest.object.*;
 	import org.hamcrest.text.*;
 	import org.hamcrest.collection.*;
-
+	
 	import classes.internals.Serializable;
+	import classes.internals.SerializableAMF;
 	
 	public class SerializationUtilTest
 	{
@@ -16,6 +17,7 @@ package classes.internals
 		
 		private var testObject:*;
 		private var testVector:Vector.<Serializable>;
+		private var testAMFVector:Vector.<SerializableAMF>;
 		
 		public function SerializationUtilTest()
 		{
@@ -29,12 +31,23 @@ package classes.internals
 			}
 		}
 		
+		private function buildAmfVector(instances:int):void
+		{
+			for (var i:int = 0; i < instances; i++)
+			{
+				testAMFVector.push(new AMFSerializationDummy(i, i + 1));
+			}
+		}
+		
 		[Before]
 		public function setUp():void
 		{
 			testObject = null;
 			testVector = new Vector.<Serializable>();
+			testAMFVector = new Vector.<SerializableAMF>();
+			
 			buildVector(TEST_INSTANCES);
+			buildAmfVector(TEST_INSTANCES);
 		}
 		
 		[Test]
@@ -50,12 +63,30 @@ package classes.internals
 		{
 			testObject = SerializationUtils.serializeVector(testVector);
 			
-			assertThat(testObject[TEST_INSTANCES - 1], hasProperties({foo : TEST_INSTANCES-1, bar : TEST_INSTANCES}));
+			assertThat(testObject[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1, bar: TEST_INSTANCES}));
+		}
+		
+		[Test]
+		public function serializeVectorWithAMFObjectSize():void
+		{
+			testObject = SerializationUtils.serializeVectorWithAMF(testAMFVector);
+			
+			assertThat(testObject, arrayWithSize(TEST_INSTANCES));
+		}
+		
+		[Test]
+		public function serializeVectorWithAMFLastObjectValue():void
+		{
+			testObject = SerializationUtils.serializeVectorWithAMF(testAMFVector);
+			
+			assertThat(testObject[TEST_INSTANCES - 1], instanceOf(AMFSerializationDummy));
 		}
 	}
 }
 
 import classes.internals.Serializable;
+import classes.internals.SerializableAMF;
+import flash.errors.IllegalOperationError;
 
 class SerializationDummy implements Serializable
 {
@@ -78,5 +109,17 @@ class SerializationDummy implements Serializable
 	{
 		this.foo = relativeRootObject.foo;
 		this.bar = relativeRootObject.bar;
+	}
+}
+
+class AMFSerializationDummy implements SerializableAMF
+{
+	public var foo:int;
+	public var bar:int;
+	
+	public function AMFSerializationDummy(foo:int, bar:int)
+	{
+		this.foo = foo;
+		this.bar = bar;
 	}
 }

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -1,0 +1,82 @@
+package classes.internals
+{
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+
+	import classes.internals.Serializable;
+	
+	public class SerializationUtilTest
+	{
+		private static const TEST_INSTANCES:int = 5;
+		
+		private var testObject:*;
+		private var testVector:Vector.<Serializable>;
+		
+		public function SerializationUtilTest()
+		{
+		}
+		
+		private function buildVector(instances:int):void
+		{
+			for (var i:int = 0; i < instances; i++)
+			{
+				testVector.push(new SerializationDummy(i, i + 1));
+			}
+		}
+		
+		[Before]
+		public function setUp():void
+		{
+			testObject = null;
+			testVector = new Vector.<Serializable>();
+			buildVector(TEST_INSTANCES);
+		}
+		
+		[Test]
+		public function serializeVectorObjectSize():void
+		{
+			testObject = SerializationUtils.serializeVector(testVector);
+			
+			assertThat(testObject, arrayWithSize(TEST_INSTANCES));
+		}
+		
+		[Test]
+		public function serializeVectorLastObjectValue():void
+		{
+			testObject = SerializationUtils.serializeVector(testVector);
+			
+			assertThat(testObject[TEST_INSTANCES - 1], hasProperties({foo : TEST_INSTANCES-1, bar : TEST_INSTANCES}));
+		}
+	}
+}
+
+import classes.internals.Serializable;
+
+class SerializationDummy implements Serializable
+{
+	public var foo:int;
+	private var bar:int;
+	
+	public function SerializationDummy(foo:int, bar:int)
+	{
+		this.foo = foo;
+		this.bar = bar;
+	}
+	
+	public function serialize(relativeRootObject:*):void
+	{
+		relativeRootObject.foo = foo;
+		relativeRootObject.bar = bar;
+	}
+	
+	public function deserialize(relativeRootObject:*):void
+	{
+		this.foo = relativeRootObject.foo;
+		this.bar = relativeRootObject.bar;
+	}
+}


### PR DESCRIPTION
- Interface for simple serialization
- Serialization code can be moved from `Save.as` to the respective class
  - `Save.as` knows way too much about other classes
  - Better coupling, if i do a major rewrite inside a class that uses serialization, `Save.as` won't be affected
- Allows for truly private variables
- Caveat: Classes must either have a **no-args constructor** *or* **default values for all parameters**
- Can build complex classes that can recursively serialize / deserialize
- Allows for easy testing of serialization / deserialization code
- Proof of concept: [`Saves.as`](https://github.com/brrritssocold/Corruption-of-Champions-Mod/blob/bdb60edcb1fc8940ca2ffadf0800e82b0ec53148/classes/classes/Saves.as#L945) [`VaginaClass.as`](https://github.com/brrritssocold/Corruption-of-Champions-Mod/blob/bdb60edcb1fc8940ca2ffadf0800e82b0ec53148/classes/classes/VaginaClass.as#L142)