### PR TITLE
Adhere to AS 3 interface naming convention

### DIFF
--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -7,7 +7,7 @@ package classes
 	import classes.Scenes.Inventory;
 	import classes.Scenes.Places.TelAdre.Katherine;
 	import classes.internals.LoggerFactory;
-	import classes.internals.Serializable;
+	import classes.internals.ISerializable;
 	import classes.internals.SerializationUtils;
 	import mx.logging.ILogger;
 

--- a/classes/classes/VaginaClass.as
+++ b/classes/classes/VaginaClass.as
@@ -1,11 +1,11 @@
 ﻿package classes
 {
-	import classes.internals.Serializable;
+	import classes.internals.ISerializable;
 	import classes.internals.Utils;
 	import mx.logging.ILogger;
 	import classes.internals.LoggerFactory;
 
-	public class VaginaClass implements Serializable
+	public class VaginaClass implements ISerializable
 	{
 		include "../../includes/appearanceDefs.as";
 		public static const DEFAULT_CLIT_LENGTH:Number = 0.5;

--- a/classes/classes/internals/ISerializable.as
+++ b/classes/classes/internals/ISerializable.as
@@ -7,7 +7,7 @@ package classes.internals
 	 * to a shared object or file.
 	 * The interface also provides a function to reverse the process.
 	 */
-	public interface Serializable 
+	public interface ISerializable 
 	{
 		/**
 		 * Serialize a class so it can be stored. Any state that is not serialized will be lost and replaced with the

--- a/classes/classes/internals/ISerializableAMF.as
+++ b/classes/classes/internals/ISerializableAMF.as
@@ -3,7 +3,7 @@ package classes.internals
 	/**
 	 * Interface for marking classes that should be serialized with AMF
 	 */
-	public interface SerializableAMF 
+	public interface ISerializableAMF 
 	{
 	}
 }

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -64,10 +64,10 @@ package classes.internals
 		 * @param	vector to serialize
 		 * @return a array containing the serialized vector
 		 */
-		public static function serializeVectorWithAMF(vector:Vector.<SerializableAMF>):Array {
+		public static function serializeVectorWithAMF(vector:Vector.<ISerializableAMF>):Array {
 			var serialized:Array = [];
 			
-			for each(var element:SerializableAMF in vector) {
+			for each(var element:ISerializableAMF in vector) {
 				serialized.push(element);
 			}
 			
@@ -80,13 +80,13 @@ package classes.internals
 		 * @param	type of the serialized Vector
 		 * @return a deserialized Vector
 		 */
-		public static function deserializeVectorWithAMF(serializedVector:Array, type:Class):Vector.<SerializableAMF> {
+		public static function deserializeVectorWithAMF(serializedVector:Array, type:Class):Vector.<ISerializableAMF> {
 			// 'is' will only work on an instance
-			if (!(new type() is SerializableAMF)) {
+			if (!(new type() is ISerializableAMF)) {
 				throw new ArgumentError("Type must implement SerializableAMF");
 			}
 			
-			var deserialized:Vector.<SerializableAMF> = new Vector.<SerializableAMF>();
+			var deserialized:Vector.<ISerializableAMF> = new Vector.<ISerializableAMF>();
 			
 			for each(var element:Object in serializedVector) {
 				deserialized.push(element as type);

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -20,7 +20,7 @@ package classes.internals
 		public static function serializeVector(vector:Vector.<*>):Array {
 			var serialized:Array = [];
 			
-			for each(var element:Serializable in vector) {
+			for each(var element:ISerializable in vector) {
 				var obj:Array = [];
 				serialized.push(obj);
 				
@@ -39,7 +39,7 @@ package classes.internals
 		 */
 		public static function deserializeVector(destinationVector:Vector.<*>, serializedVector:Array, type:Class):void {
 			// 'is' will only work on an instance
-			if (!(new type() is Serializable)) {
+			if (!(new type() is ISerializable)) {
 				throw new ArgumentError("Type must implement Serializable");
 			}
 			
@@ -52,7 +52,7 @@ package classes.internals
 			}
 			
 			for each(var element:Object in serializedVector) {
-				var instance:Serializable = new type();
+				var instance:ISerializable = new type();
 				instance.deserialize(element);
 				destinationVector.push(instance);
 			}

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -8,7 +8,7 @@ package classes.internals
 	import org.hamcrest.text.*;
 	import org.hamcrest.collection.*;
 	
-	import classes.internals.Serializable;
+	import classes.internals.ISerializable;
 	import classes.internals.SerializableAMF;
 	
 	public class SerializationUtilTest
@@ -16,7 +16,7 @@ package classes.internals
 		private static const TEST_INSTANCES:int = 5;
 		
 		private var testObject:Array;
-		private var testVector:Vector.<Serializable>;
+		private var testVector:Vector.<ISerializable>;
 		private var testAMFVector:Vector.<SerializableAMF>;
 		private var deserializedVector:Vector.<*>;
 		
@@ -44,7 +44,7 @@ package classes.internals
 		public function setUp():void
 		{
 			testObject = null;
-			testVector = new Vector.<Serializable>();
+			testVector = new Vector.<ISerializable>();
 			testAMFVector = new Vector.<SerializableAMF>();
 			deserializedVector = new Vector.<*>();
 			
@@ -179,11 +179,11 @@ package classes.internals
 	}
 }
 
-import classes.internals.Serializable;
+import classes.internals.ISerializable;
 import classes.internals.SerializableAMF;
 import flash.errors.IllegalOperationError;
 
-class SerializationDummy implements Serializable
+class SerializationDummy implements ISerializable
 {
 	public var foo:int;
 	private var bar:int;

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -9,7 +9,7 @@ package classes.internals
 	import org.hamcrest.collection.*;
 	
 	import classes.internals.ISerializable;
-	import classes.internals.SerializableAMF;
+	import classes.internals.ISerializableAMF;
 	
 	public class SerializationUtilTest
 	{
@@ -17,7 +17,7 @@ package classes.internals
 		
 		private var testObject:Array;
 		private var testVector:Vector.<ISerializable>;
-		private var testAMFVector:Vector.<SerializableAMF>;
+		private var testAMFVector:Vector.<ISerializableAMF>;
 		private var deserializedVector:Vector.<*>;
 		
 		private function buildVector(instances:int):void
@@ -45,7 +45,7 @@ package classes.internals
 		{
 			testObject = null;
 			testVector = new Vector.<ISerializable>();
-			testAMFVector = new Vector.<SerializableAMF>();
+			testAMFVector = new Vector.<ISerializableAMF>();
 			deserializedVector = new Vector.<*>();
 			
 			buildVector(TEST_INSTANCES);
@@ -151,28 +151,28 @@ package classes.internals
 			SerializationUtils.deserializeVectorWithAMF(new Array(), String);
 		}
 		
-		private function deserializeAMF():Vector.<SerializableAMF> {
+		private function deserializeAMF():Vector.<ISerializableAMF> {
 			testObject = SerializationUtils.serializeVectorWithAMF(testAMFVector);
 			return SerializationUtils.deserializeVectorWithAMF(testObject, AMFSerializationDummy);
 		}
 		
 		[Test]
 		public function deserializeVectorWithAMFSize():void {
-			var vector:Vector.<SerializableAMF> = deserializeAMF();
+			var vector:Vector.<ISerializableAMF> = deserializeAMF();
 			
 			assertThat(vector, arrayWithSize(TEST_INSTANCES));
 		}
 		
 		[Test]
 		public function deserializeVectorWithAMFType():void {
-			var vector:Vector.<SerializableAMF> = deserializeAMF();
+			var vector:Vector.<ISerializableAMF> = deserializeAMF();
 			
-			assertThat(vector[TEST_INSTANCES - 1], instanceOf(SerializableAMF));
+			assertThat(vector[TEST_INSTANCES - 1], instanceOf(ISerializableAMF));
 		}
 		
 		[Test]
 		public function deserializeVectorWithAMFProperty():void {
-			var vector:Vector.<SerializableAMF> = deserializeAMF();
+			var vector:Vector.<ISerializableAMF> = deserializeAMF();
 			
 			assertThat(vector[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1, bar: TEST_INSTANCES}));
 		}
@@ -180,7 +180,7 @@ package classes.internals
 }
 
 import classes.internals.ISerializable;
-import classes.internals.SerializableAMF;
+import classes.internals.ISerializableAMF;
 import flash.errors.IllegalOperationError;
 
 class SerializationDummy implements ISerializable
@@ -211,7 +211,7 @@ class SerializationDummy implements ISerializable
 	}
 }
 
-class AMFSerializationDummy implements SerializableAMF
+class AMFSerializationDummy implements ISerializableAMF
 {
 	public var foo:int;
 	public var bar:int;


### PR DESCRIPTION
The naming convention for Actionscript 3 interfaces is to prefix them with a capital i.