### PR TITLE
Change java version so sonar plugin runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_install:
   - sudo apt-get install vnc4server xfce4 ant ant-optional -y
 
 install:
+  # Java 7 is used by default, but sonar requires java 8
+  - jdk_switcher  use oraclejdk8
   # download and install the flex SDK and the flash player
   - devTools/ci/setup-flex.sh
   # start a VNC session, this will be the desktop for tests


### PR DESCRIPTION
The sonar plugin requires java 8, but the default is set to java 7.

Uses the Travis CI provided switcher script to switch to oracle java 8.