### PR TITLE
Fixed issue where combat wouldn't start.

### DIFF
--- a/classes/classes/Scenes/Monsters/MimicScene.as
+++ b/classes/classes/Scenes/Monsters/MimicScene.as
@@ -84,7 +84,7 @@ package classes.Scenes.Monsters
 					menu();
 					addButton(0, "Fight", function():*{
 						player.createStatusEffect(StatusEffects.KnockedBack, 0, 0, 0, 0);
-						new Mimic(mimicAppearance)
+						startCombat(new Mimic(mimicAppearance));
 					});
 					addButton(14, "Leave", camp.returnToCampUseOneHour);
 					return;


### PR DESCRIPTION
Altered mimic encounter would just create an instance of a mimic, but never actually start the combat.

Also, if the player clicked the Fight button multiple times(as any human being would, when faced with an unresponsive button), he'd get a bunch of "Knocked Back" status effects on him, that would take a long time to purge naturally. Nasty. Should probably update the "unfuck save" function to remove KnockedBack until there are no instances of it left, instead of just once.