### PR TITLE
Profiling API

### DIFF
--- a/classes/classes/Scenes/DebugMenu.as
+++ b/classes/classes/Scenes/DebugMenu.as
@@ -5,6 +5,8 @@ package classes.Scenes
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.MainViewManager;
+	import classes.internals.Profiling;
+
 	import flash.utils.describeType;
 	import flash.utils.*
 	
@@ -36,6 +38,7 @@ package classes.Scenes
 		
 		public function accessDebugMenu():void {
 			//buildArray();
+			Profiling.LogProfilingReport();
 			if (!getGame().inCombat) {
 				hideMenus();
 				mainView.nameBox.visible = false;

--- a/classes/classes/internals/Profiling.as
+++ b/classes/classes/internals/Profiling.as
@@ -19,7 +19,7 @@ public class Profiling {
 		return true;
 	}
 	private static function shouldReportProfiling(classname:String, origMethodName:String, dt:Number, pfcount:int):Boolean {
-		return true;//dt > 100;
+		return dt > 100;
 	}
 	public static function LogProfilingReport():void {
 		for (var key:String in PF_COUNT) {

--- a/classes/classes/internals/Profiling.as
+++ b/classes/classes/internals/Profiling.as
@@ -1,0 +1,89 @@
+/**
+ * Created by aimozg on 13.05.2017.
+ */
+package classes.internals {
+import mx.logging.ILogger;
+
+public class Profiling {
+	function Profiling() {
+	}
+
+	private static const PF_LOGGER:ILogger        = LoggerFactory.getLogger(Profiling);
+	private static var PF_DEPTH:int               = 0; // Callstack depth
+	private static const PF_NAME:Array            = [];// Callstack method names
+	private static const PF_START:Array           = [];// Callstack of Begin() times
+	private static const PF_ARGS:Array            = [];// Callstack of method arguments
+	private static const PF_COUNT:Object          = {};// method -> times called
+	private static const PF_TIME:Object           = {};// method -> total execution time
+	private static function shouldProfile(classname:String, methodName:String):Boolean {
+		return true;
+	}
+	private static function shouldReportProfiling(classname:String, origMethodName:String, dt:Number, pfcount:int):Boolean {
+		return true;//dt > 100;
+	}
+	public static function LogProfilingReport():void {
+		for (var key:String in PF_COUNT) {
+			var s:String    = "[PROFILE] ";
+			s += key;
+			var pfcount:int = PF_COUNT[key];
+			s += ", called " + pfcount + " times";
+			var pftime:*    = PF_TIME[key];
+			s += ", total time ";
+			if (pftime > 10000) s += Math.floor(pftime / 1000) + "s";
+			else s += pftime + "ms";
+			if (pftime > 0 && pfcount > 0) {
+				s += ", avg time " + (pftime / pfcount).toFixed(1) + "ms";
+			}
+			PF_LOGGER.info(s);
+		}
+	}
+	public static function Begin(classname:String, methodName:String, ...rest:Array):void {
+		if (!shouldProfile(classname, methodName)) return;
+		methodName           = classname + "." + methodName;
+		PF_NAME[PF_DEPTH]    = methodName;
+		PF_START[PF_DEPTH]   = new Date().getTime();
+		PF_ARGS[PF_DEPTH]    = rest;
+		PF_COUNT[methodName] = (PF_COUNT[methodName] | 0) + 1;
+		PF_DEPTH++;
+	}
+	public static function End(classname:String, methodName:String):void {
+		if (!shouldProfile(classname, methodName)) return;
+		var origMethodName:String = methodName;
+		methodName                = classname + "." + methodName;
+		var t1:Number             = new Date().getTime();
+		PF_DEPTH--;
+		while (PF_DEPTH >= 0 && PF_NAME[PF_DEPTH] != methodName) {
+			PF_LOGGER.error("[ERROR] Inconsistent callstack, expected '" + methodName + "', got '" + PF_NAME[PF_DEPTH] + "'(" +
+							PF_ARGS[PF_DEPTH].join() + ")");
+			PF_DEPTH--;
+		}
+		if (PF_DEPTH < 0) {
+			PF_LOGGER.error("[ERROR] Empty callstack, expected '" + methodName + "'");
+			PF_DEPTH = 0;
+			return;
+		}
+		var dt:Number       = t1 - PF_START[PF_DEPTH];
+		PF_TIME[methodName] = (PF_TIME[methodName] | 0) + dt;
+		var pfcount:int     = PF_COUNT[methodName];
+		var args:Array      = PF_ARGS[PF_DEPTH];
+		if (shouldReportProfiling(classname, origMethodName, dt, pfcount)) {
+			var s:String = "[PROFILE] ";
+			for (var i:int = PF_DEPTH; i-- > 0;) s += "  ";
+			s += methodName;
+			if (args.length > 0) s += "(" + args.join(", ") + ")";
+			s += " " + dt + "ms";
+			if (pfcount > 1) {
+				s += ", called " + pfcount + " times";
+				var pftime:* = PF_TIME[methodName];
+				if (pftime > 0) {
+					s += ", total time ";
+					if (pftime > 10000) s += Math.floor(pftime / 1000) + "s";
+					else s += pftime + "ms";
+					s += ", avg time " + (pftime / pfcount).toFixed(1) + "ms";
+				}
+			}
+			PF_LOGGER.info(s);
+		}
+	}
+}
+}

--- a/classes/classes/internals/profiling/Begin.as
+++ b/classes/classes/internals/profiling/Begin.as
@@ -1,0 +1,10 @@
+/**
+ * Created by aimozg on 13.05.2017.
+ */
+package classes.internals.profiling {
+import classes.internals.Profiling;
+
+public function Begin(classname:String, methodName:String, ...rest:Array):void {
+	Profiling.Begin.apply(null,[classname,methodName].concat(rest));
+}
+}

--- a/classes/classes/internals/profiling/End.as
+++ b/classes/classes/internals/profiling/End.as
@@ -1,0 +1,10 @@
+/**
+ * Created by aimozg on 13.05.2017.
+ */
+package classes.internals.profiling {
+import classes.internals.Profiling;
+
+public function End(classname:String, methodName:String):void {
+	Profiling.End(classname,methodName);
+}
+}

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -1,5 +1,6 @@
 import classes.*;
 import flash.text.TextFormat;
+import classes.internals.Profiling;
 
 public static const MAX_BUTTON_INDEX:int = 14;
 
@@ -685,10 +686,12 @@ public function testDynStatsEvent():void {
  */
 public function dynStats(... args):void
 {
+	Profiling.Begin("engineCore","dynStats");
 	// Check num of args, we should have a multiple of 2
 	if ((args.length % 2) != 0)
 	{
 		trace("dynStats aborted. Keys->Arguments could not be matched");
+		Profiling.End("engineCore","dynStats");
 		return;
 	}
 	
@@ -743,6 +746,7 @@ public function dynStats(... args):void
 		else
 		{
 			trace("dynStats aborted. Expected a key and got SHIT");
+			Profiling.End("engineCore","dynStats");
 			return;
 		}
 	}
@@ -766,7 +770,7 @@ public function dynStats(... args):void
 		  newLust - player.lust,
 		  newCor - player.cor,
 		  argVals[8],argVals[9]);
-	
+	Profiling.End("engineCore","dynStats");
 }
 
 public function stats(stre:Number, toug:Number, spee:Number, intel:Number, libi:Number, sens:Number, lust2:Number, corr:Number, resisted:Boolean = true, noBimbo:Boolean = false):void

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -1,6 +1,10 @@
 import classes.*;
 import flash.text.TextFormat;
+
+// at least one import or other usage of *class* so it won't be marked unused.
 import classes.internals.Profiling;
+import classes.internals.profiling.Begin;
+import classes.internals.profiling.End;
 
 public static const MAX_BUTTON_INDEX:int = 14;
 
@@ -686,7 +690,7 @@ public function testDynStatsEvent():void {
  */
 public function dynStats(... args):void
 {
-	Profiling.Begin("engineCore","dynStats");
+	Begin("engineCore","dynStats");
 	// Check num of args, we should have a multiple of 2
 	if ((args.length % 2) != 0)
 	{
@@ -770,7 +774,7 @@ public function dynStats(... args):void
 		  newLust - player.lust,
 		  newCor - player.cor,
 		  argVals[8],argVals[9]);
-	Profiling.End("engineCore","dynStats");
+	End("engineCore","dynStats");
 }
 
 public function stats(stre:Number, toug:Number, spee:Number, intel:Number, libi:Number, sens:Number, lust2:Number, corr:Number, resisted:Boolean = true, noBimbo:Boolean = false):void

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -4,7 +4,8 @@ import classes.Player;
 import classes.Items.Consumable;
 import classes.Scenes.Areas.Lake;
 import classes.Scenes.Camp.ScarredBlade;
-import classes.internals.Profiling;
+import classes.internals.profiling.Begin;
+import classes.internals.profiling.End;
 
 import coc.view.MainView;
 
@@ -118,9 +119,9 @@ public function errorPrint(details:* = null):void
 //Argument is time passed.  Pass to event parser if nothing happens.
 // The time argument is never actually used atm, everything is done with timeQ instead...
 public function goNext(time:Number, needNext:Boolean):Boolean  {
-	Profiling.Begin("eventParser","goNext",time);
+	Begin("eventParser","goNext",time);
 	var rslt:Boolean = goNextWrapped(time,needNext);
-	Profiling.End("eventParser","goNext");
+	End("eventParser","goNext");
 	return rslt;
 }
 private function goNextWrapped(time:Number, needNext:Boolean):Boolean  {

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -4,6 +4,8 @@ import classes.Player;
 import classes.Items.Consumable;
 import classes.Scenes.Areas.Lake;
 import classes.Scenes.Camp.ScarredBlade;
+import classes.internals.Profiling;
+
 import coc.view.MainView;
 
 //Used to jump the fuck out of pregnancy scenarios for menus.
@@ -116,6 +118,12 @@ public function errorPrint(details:* = null):void
 //Argument is time passed.  Pass to event parser if nothing happens.
 // The time argument is never actually used atm, everything is done with timeQ instead...
 public function goNext(time:Number, needNext:Boolean):Boolean  {
+	Profiling.Begin("eventParser","goNext",time);
+	var rslt:Boolean = goNextWrapped(time,needNext);
+	Profiling.End("eventParser","goNext");
+	return rslt;
+}
+private function goNextWrapped(time:Number, needNext:Boolean):Boolean  {
 	//Update system time
 	//date = new Date();
 	//trace ("MONTH: " + date.month + " DATE: " + date.date + " MINUTES: " + date.minutes);


### PR DESCRIPTION
This is a set of functions I've used when examining performance problems in Xianxia mod.
Each piece of code, explicitly wrapped between `Begin...End`, tracks number of calls and execution time.
Coverage and verbosity of output can be configured (hard-coded in `shouldProfile`/`shouldReportProfiling`); I find "record everything but report only calls >= 100 ms" comfortable default.

Sample output:
```
[PROFILE]         Player.getMaxStats.perks 0ms, called 600 times, total time 69ms, avg time 0.1ms
[PROFILE]         Player.getMaxStats.racial 8ms, called 600 times, total time 5280ms, avg time 8.8ms
[PROFILE]         Player.getMaxStats.perks2 0ms, called 600 times, total time 533ms, avg time 0.9ms
[PROFILE]         Player.getMaxStats.effects 0ms, called 600 times, total time 196ms, avg time 0.3ms
[PROFILE]       Player.getMaxStats 11ms, called 600 times, total time 6107ms, avg time 10.2ms
[PROFILE]     MainViewManager.refreshStats.showHideBars 0ms, called 100 times, total time 4ms, avg time 0.0ms
[PROFILE]     MainViewManager.refreshStats.calc 56ms, called 100 times, total time 5664ms, avg time 56.6ms
[PROFILE]     MainViewManager.refreshStats.bars 0ms, called 100 times, total time 67ms, avg time 0.7ms
[PROFILE]     MainViewManager.refreshStats.stats 0ms, called 100 times, total time 1ms, avg time 0.0ms
[PROFILE]     MainViewManager.refreshStats.hacks 0ms, called 100 times, total time 18ms, avg time 0.2ms
[PROFILE]     MainViewManager.refreshStats.time 0ms, called 100 times, total time 6ms, avg time 0.1ms
[PROFILE]     MainViewManager.setTheme 1ms, called 100 times, total time 26ms, avg time 0.3ms
[PROFILE]   MainViewManager.refreshStats 60ms, called 100 times, total time 5795ms, avg time 58.0ms
[PROFILE] engineCore.statScreenRefresh 58ms, called 100 times, total time 5795ms, avg time 58.0ms
```

An optional `...args` in the `Begin()` allows finer tracking of call site. Keep in mind that different arguments still contribute to the same method.
```
[PROFILE] eventParser.goNext(1) 16ms, called 2 times, total time 105ms, avg time 52.5ms
```

To get a full profiling report over all class-method pairs, call `Profiling.LogProfilingReport();`.
In this example, it is called on debug menu enter.
```
[PROFILE]   engineCore.dynStats 1ms, called 6 times, total time 9ms, avg time 1.5ms
[PROFILE] engineCore.dynStats 5ms, called 6 times, total time 14ms, avg time 2.3ms
[PROFILE] engineCore.dynStats 2ms, called 7 times, total time 16ms, avg time 2.3ms
```