### PR TITLE
Fix ghoul description crash

### DIFF
--- a/classes/classes/Scenes/Areas/Desert/Ghoul.as
+++ b/classes/classes/Scenes/Areas/Desert/Ghoul.as
@@ -429,7 +429,7 @@ package classes.Scenes.Areas.Desert {
 		
 		private const HORN_VARIATIONS:Array = [
 			["demon"],
-			["cow"]
+			["cow"],
 			["minotaur"],
 			["2 draconic"],
 			["4, 12-inch long draconic"],

--- a/classes/classes/Scenes/Explore/ExploreDebug.as
+++ b/classes/classes/Scenes/Explore/ExploreDebug.as
@@ -87,7 +87,8 @@ package classes.Scenes.Explore
 			function ():Monster {return new TentacleBeast();},
 			function ():Monster {return new Valkyrie();},
 			function ():Monster {return new WormMass();},
-			function ():Monster {return new Yeti();},
+			function ():Monster {return new Yeti(); },
+			function ():Monster {return new Ghoul(); },
 			// ...NPCs, quest, and named monsters second, ...
 			function ():Monster {return new Akbal();},
 			function ():Monster {return new Amily();},


### PR DESCRIPTION
A missing comma causes the array element to not be defined, which in turn causes a NPE / Null ref when it is accessed for the description.