### PR TITLE
tweaked KnockedBack fix

### DIFF
--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -2250,7 +2250,7 @@ public function unFuckSave():void
 		}
 	}
 	
-	if (player.hasStatusEffect(StatusEffects.KnockedBack))
+	while (player.hasStatusEffect(StatusEffects.KnockedBack))
 	{
 		player.removeStatusEffect(StatusEffects.KnockedBack);
 	}


### PR DESCRIPTION
If a player ended up mashing the fight button in the bugged mimic encounter, he could stack several dozen KnockedBack status effects on his character, which a single if statement won't fix.