### PR TITLE
Purged parseAsMarkdown from the codebase

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -220,9 +220,9 @@
 			kGAMECLASS.rawOutputText(output, purgeText);
 		}
 
-		protected function outputText(output:String, purgeText:Boolean = false, parseAsMarkdown:Boolean = false):void
+		protected function outputText(output:String, purgeText:Boolean = false):void
 		{
-			kGAMECLASS.outputText(output, purgeText, parseAsMarkdown);
+			kGAMECLASS.outputText(output, purgeText);
 		}
 		
 		protected function clearOutput():void

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -43,17 +43,16 @@ package classes
 		 *
 		 * This must not be made possible to be called directly from the outside, use wrapper-methods instead.
 		 *
-		 * @param   text              The text to be added
-		 * @param   parseAsMarkdown   set this to true, if you want the text to be formatted, using a markdown parser (NYI, sry)
+		 * @param   text    The text to be added
 		 * @return  The instance of the class to support the 'Fluent interface' aka method-chaining
 		 */
-		protected function _addText(text:String, parseAsMarkdown:Boolean = false):Output
+		protected function _addText(text:String):Output
 		{
 			// This is cleaup in case someone hits the Data or new-game button when the event-test window is shown. 
 			// It's needed since those buttons are available even when in the event-tester
 			mainView.hideTestInputPanel();
 
-			_currentText += kGAMECLASS.parser.recursiveParser(text, parseAsMarkdown);
+			_currentText += kGAMECLASS.parser.recursiveParser(text);
 			if (debug) mainView.setOutputText(_currentText);
 
 			return this;
@@ -70,20 +69,6 @@ package classes
 		public function text(text:String):Output
 		{
 			return _addText(text);
-		}
-
-		/**
-		 * Add markdown formatted text (NYI!) to the output-buffer
-		 *
-		 * Actually this is a wrapper around _addText(text, true)
-		 * Unfortunately no one succeded to support markdown formatting for CoC, so as of speaking, this does exactly the same, as text("...")
-		 *
-		 * @param   text    The text to be formatted with markdown (NYI!)
-		 * @return  The instance of the class to support the 'Fluent interface' aka method-chaining
-		 */
-		public function markdown(text:String):Output
-		{
-			return _addText(text, true);
 		}
 
 		/**

--- a/classes/classes/Parser/Parser.as
+++ b/classes/classes/Parser/Parser.as
@@ -1060,7 +1060,7 @@ package classes.Parser
 		// textCtnt is the text you want parsed, depth is a number, which should be 0
 		// or not passed at all.
 		// You pass in the string you want parsed, and the parsed result is returned as a string.
-		public function recursiveParser(contents:String, parseAsMarkdown:Boolean = false, prettyQuotes:Boolean=true):String
+		public function recursiveParser(contents:String):String
 		{
 			if (mainParserDebug) trace("WARNING: ------------------ Parser called on string -----------------------");
 			// Eventually, when this goes properly class-based, we'll add a period, and have this.parserState.
@@ -1078,24 +1078,8 @@ package classes.Parser
 			if (printIntermediateParseStateDebug) trace("WARNING: Parser intermediate contents = ", ret)
 			// Currently, not parsing text as markdown by default because it's fucking with the line-endings.
 
-			if (prettyQuotes)
-			{
-				// Convert quotes to prettyQuotes
-				ret = this.makeQuotesPrettah(ret);
-				// Quote conversion has to go before markdown calls
-			}
-
-			if (parseAsMarkdown)
-			{
-				// trace("WARNING: markdownificating");
-				//ret = Showdown.makeHtml(ret);
-
-
-				//var regexPCloseTag:RegExp = /<\/p>/gi;
-				//ret = ret.replace(regexPCloseTag,"</p>\n");
-				// Finally, add a additional newline after each closing P tag, because flash only
-				// outputs one newline per <p></p> tag, apparently flash again feels the need to be a special snowflake
-			}
+			// Convert quotes to prettyQuotes
+			ret = this.makeQuotesPrettah(ret);
 
 			// cleanup escaped brackets
 			ret = ret.replace(/\\\]/g, "]")

--- a/includes/debug.as
+++ b/includes/debug.as
@@ -46,6 +46,7 @@ public function doThatTestingThang():void
 	//
 	//
 
+	clearOutput();
 	outputText(<![CDATA[
 
 <b>Parser Tests!</b>
@@ -295,7 +296,7 @@ convert "
 "derp a herp"
 
 
-	]]>, true, true);
+	]]>);
 
 
 	menu();
@@ -334,7 +335,8 @@ public function eventTesterGo():void {
 	trace("Temp = ", temp);
 
 	menu();
-	outputText(temp, true, true);
+	clearOutput();
+	outputText(temp);
 
 	addButton(14, "Back", eventTester);
 	output.flush();

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -137,11 +137,9 @@ public function rawOutputText(output:String, purgeText:Boolean = false):void
  * Output the text on main text interface.
  * @param	output The text to show. It can be formatted such as bold, italics, and underline tags.
  * @param	purgeText Clear the old text.
- * @param	parseAsMarkdown Parses the text using Markdown.
  */
 public function outputText(output:String, 
-						purgeText:Boolean = false, 
-						parseAsMarkdown:Boolean = false):void
+						purgeText:Boolean = false):void
 {
 	// we have to purge the output text BEFORE calling parseText, because if there are scene commands in 
 	// the parsed text, parseText() will write directly to the output
@@ -156,7 +154,7 @@ public function outputText(output:String,
 		clearOutput();
 	}
 
-	output = this.parser.recursiveParser(output, parseAsMarkdown);
+	output = this.parser.recursiveParser(output);
 
 	//OUTPUT!
 	if (purgeText) {

--- a/test/classes/Scenes/NPCs/IsabellaFollowerSceneTest.as
+++ b/test/classes/Scenes/NPCs/IsabellaFollowerSceneTest.as
@@ -158,7 +158,7 @@ import classes.Scenes.NPCs.IsabellaFollowerScene;
 class IsabellaFollowerSceneForTest extends IsabellaFollowerScene {
 	public var collectedOutput:Vector.<String> = new Vector.<String>(); 
 	
-	override protected function outputText(output:String, purgeText:Boolean = false, parseAsMarkdown:Boolean = false):void {
+	override protected function outputText(output:String, purgeText:Boolean = false):void {
 		collectedOutput.push(output);
 	}
 	

--- a/test/classes/Scenes/NPCs/JojoSceneTest.as
+++ b/test/classes/Scenes/NPCs/JojoSceneTest.as
@@ -64,7 +64,7 @@ class JojoSceneForTest extends JojoScene {
 		corruptJojoVaginalSmother();
 	}
 	
-	override protected function outputText(output:String, purgeText:Boolean = false, parseAsMarkdown:Boolean = false):void {
+	override protected function outputText(output:String, purgeText:Boolean = false):void {
 		collectedOutput.push(output);
 	}
 }

--- a/test/classes/Scenes/Places/Bazaar/BlackCockTest.as
+++ b/test/classes/Scenes/Places/Bazaar/BlackCockTest.as
@@ -64,7 +64,7 @@ class BlackCockForTest extends BlackCock {
 		haveHarryFuckYou();
 	}
 	
-	override protected function outputText(output:String, purgeText:Boolean = false, parseAsMarkdown:Boolean = false):void {
+	override protected function outputText(output:String, purgeText:Boolean = false):void {
 		collectedOutput.push(output);
 	}
 }

--- a/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
+++ b/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
@@ -151,7 +151,7 @@ class RoxanneForTest extends Roxanne {
 		super.roxanneDrinkingContest();
 	}
 	
-	override protected function outputText(output:String, purgeText:Boolean = false, parseAsMarkdown:Boolean = false):void {
+	override protected function outputText(output:String, purgeText:Boolean = false):void {
 		collectedOutput.push(output);
 	}
 }


### PR DESCRIPTION
In addition to that I've removed the third param of `Parser.recursiveParser()` along with it, since it was never being set to false. Actually it was never used at all. In other words: prettyQuotes is **always** used in the parser.