### PR TITLE
Perk Requirements API and [Perks > Database] menu

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,7 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0" is_locked="false">
     <option name="myName" value="Project Default" />
-    <option name="myLocal" value="false" />
     <inspection_tool class="JSCommentMatchesSignature" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSMethodCanBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSSuspiciousNameCombination" enabled="false" level="WARNING" enabled_by_default="false">
@@ -13,6 +12,7 @@
     <inspection_tool class="JSUnusedLocalSymbols" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myIgnoreUnusedFunctionParameters" value="true" />
     </inspection_tool>
+    <inspection_tool class="ReservedWordUsedAsNameJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -174,6 +174,7 @@ the text from being too boring.
 		public var playerAppearance:PlayerAppearance = new PlayerAppearance();
 		public var playerInfo:PlayerInfo = new PlayerInfo();
 		public var saves:Saves = new Saves(gameStateDirectGet, gameStateDirectSet);
+		public var perkTree:PerkTree = new PerkTree();
 		// Items/
 		public var mutations:Mutations = Mutations.init();
 		public var consumables:ConsumableLib = new ConsumableLib();

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -493,5 +493,229 @@ package classes
 		{
 			return new PerkType(id, name, desc, longDesc, keepOnAscension);
 		}
+		private static function initRequirements():void {
+			//------------
+			// STRENGTH
+			//------------
+			StrongBack.requireStr(25);
+			StrongBack2.requireStr(25)
+					   .requirePerk(StrongBack);
+			//Tier 1 Strength Perks
+			//Thunderous Strikes - +20% basic attack damage while str > 80.
+			ThunderousStrikes.requireStr(80)
+							 .requireLevel(6);
+			//Weapon Mastery - Doubles weapon damage bonus of 'large' type weapons. (Minotaur Axe, M. Hammer, etc)
+			WeaponMastery.requireStr(60)
+						 .requireLevel(6);
+			BrutalBlows.requireStr(75)
+					   .requireLevel(6);
+			IronFists.requireStr(50)
+					 .requireLevel(6);
+			IronFists2.requireStr(65)
+					  .requireLevel(6)
+					  .requireNGPlus(1)
+					  .requirePerk(IronFists);
+			IronFists3.requireStr(80)
+					  .requireLevel(6)
+					  .requireNGPlus(1)
+					  .requirePerk(IronFists2);
+			Parry.requireStr(50)
+				 .requireSpe(50)
+				 .requireLevel(6);
+			//Tier 2 Strength Perks
+			Berzerker.requireStr(75)
+					 .requireLevel(12);
+			HoldWithBothHands.requireStr(80)
+							 .requireLevel(12);
+			ShieldSlam.requireStr(80)
+					  .requireTou(60)
+					  .requireLevel(12);
+			//Tier 3 Strength Perks
+			ColdFury.requireStr(75)
+					.requireLevel(18)
+					.requirePerk(Berzerker)
+					.requirePerk(ImprovedSelfControl);
+			//------------
+			// TOUGHNESS
+			//------------
+			//slot 2 - toughness perk 1
+			Tank.requireTou(25);
+			//slot 2 - regeneration perk
+			Regeneration.requireTou(50)
+						.requirePerk(Tank);
+			ImprovedEndurance.requireStr(50)
+							 .requireTou(50);
+			//Tier 1 Toughness Perks
+			Tank2.requireTou(60)
+				 .requireLevel(6)
+				 .requirePerk(Tank);
+			Regeneration2.requireTou(70)
+						 .requireLevel(6)
+						 .requirePerk(Regeneration);
+			ImmovableObject.requireTou(75)
+						   .requireLevel(6);
+			ShieldMastery.requireTou(50)
+						 .requireLevel(6);
+			//Tier 2 Toughness Perks
+			Resolute.requireTou(75)
+					.requireLevel(12);
+			Juggernaut.requireTou(75)
+					  .requireLevel(12);
+			IronMan.requireTou(60)
+				   .requireLevel(12);
+			//------------
+			// SPEED
+			//------------
+			//slot 3 - speed perk
+			Evade.requireSpe(25);
+			//slot 3 - run perk
+			Runner.requireSpe(25);
+			//slot 3 - Double Attack perk
+			DoubleAttack.requireSpe(50)
+						.requirePerk(Evade)
+						.requirePerk(Runner);
+
+			//Tier 1 Speed Perks
+			//Speedy Recovery - Regain Fatigue 50% faster speed.
+			SpeedyRecovery.requireSpe(60)
+						  .requireLevel(6)
+						  .requirePerk(Evade);
+			//Agility - A small portion of your speed is applied to your defense rating when wearing light armors.
+			Agility.requireSpe(75)
+				   .requireLevel(6)
+				   .requirePerk(Runner);
+			Unhindered.requireSpe(75)
+					  .requireLevel(6)
+					  .requirePerk(Evade)
+					  .requirePerk(Agility);
+			LightningStrikes.requireSpe(60)
+							.requireLevel(6);
+			/*
+			 Brawler.requireStr(60).requireSpe(60);
+			 */ //Would it be fitting to have Urta teach you?
+			//Tier 2 Speed Perks
+			LungingAttacks.requireSpe(75)
+						  .requireLevel(12);
+			Blademaster.requireStr(60)
+					   .requireSpe(80)
+					   .requireLevel(12);
+			//------------
+			// INTELLIGENCE
+			//------------
+			//Slot 4 - precision - -10 enemy toughness for damage calc
+			Precision.requireInt(25);
+			//Spellpower - boosts spell power
+			Spellpower.requireInt(50);
+			Mage.requireInt(50)
+				.requirePerk(Spellpower);
+			//Tier 1 Intelligence Perks
+			Tactician.requireInt(50)
+					 .requireLevel(6);
+			Channeling.requireInt(60)
+					  .requireLevel(6)
+					  .requirePerk(Spellpower)
+					  .requirePerk(Mage)
+					  .requireCustomFunction(function (player:Player):Boolean {
+						  return player.spellCount() > 0;
+					  }, "Any Spell");
+			Medicine.requireInt(60)
+					.requireLevel(6);
+			StaffChanneling.requireInt(60)
+						   .requireLevel(6)
+						   .requirePerk(Channeling);
+			//Tier 2 Intelligence perks
+			Archmage.requireInt(75)
+					.requireLevel(12)
+					.requirePerk(Mage);
+			FocusedMind.requireInt(75)
+					   .requireLevel(12)
+					   .requirePerk(Mage);
+
+			RagingInferno.requireInt(75)
+						 .requireLevel(12)
+						 .requirePerk(Archmage)
+						 .requirePerk(Channeling)
+						 .requireCustomFunction(function (player:Player):Boolean {
+							 return player.hasStatusEffect(StatusEffects.KnowsWhitefire)
+									 || player.hasPerk(FireLord)
+									 || player.hasPerk(Hellfire)
+									 || player.hasPerk(EnlightenedNinetails)
+									 || player.hasPerk(CorruptedNinetails);
+						 }, "Any Fire Spell");
+			// Spell-boosting perks
+			// Battlemage: auto-use Might
+			Battlemage.requireInt(80)
+					  .requireLevel(12)
+					  .requirePerk(Channeling)
+					  .requireStatusEffect(StatusEffects.KnowsMight, "Might Spell");
+			// Spellsword: auto-use Charge Weapon
+			Spellsword.requireInt(80)
+					  .requireLevel(12)
+					  .requirePerk(Channeling)
+					  .requireStatusEffect(StatusEffects.KnowsCharge, "Charge Weapon Spell");
+
+			//------------
+			// LIBIDO
+			//------------
+			//slot 5 - libido perks
+
+			//Slot 5 - Fertile+ increases cum production and fertility (+15%)
+			FertilityPlus.requireLib(25);
+			FertilityPlus.defaultValue1 = 15;
+			FertilityPlus.defaultValue2 = 1.75;
+			ImprovedSelfControl.requireInt(50).requireLib(25);
+			//Slot 5 - minimum libido
+			ColdBlooded.requireMinLust(20);
+			ColdBlooded.defaultValue1 = 20;
+			HotBlooded.requireLib(50);
+			HotBlooded.defaultValue1 = 20;
+			//Tier 1 Libido Perks
+			//Slot 5 - minimum libido
+			//Slot 5 - Fertility- decreases cum production and fertility.
+			FertilityMinus.requireLevel(6)
+						  .requireLibLessThan(25);
+			FertilityMinus.defaultValue1 = 15;
+			FertilityMinus.defaultValue2 = 0.7;
+			WellAdjusted.requireLevel(6).requireLib(60);
+			//Slot 5 - minimum libido
+			Masochist.requireLevel(6).requireLib(60).requireCor(50);
+			//------------
+			// SENSITIVITY
+			//------------
+			//Nope.avi
+			//------------
+			// CORRUPTION
+			//------------
+			//Slot 7 - Corrupted Libido - lust raises 10% slower.
+			CorruptedLibido.requireCor(25);
+			CorruptedLibido.defaultValue1 = 20;
+			//Slot 7 - Seduction (Must have seduced Jojo
+			Seduction.requireCor(50);
+			//Slot 7 - Nymphomania
+			Nymphomania.requirePerk(CorruptedLibido)
+					   .requireCor(75);
+			//Slot 7 - UNFINISHED :3
+			Acclimation.requirePerk(CorruptedLibido)
+					   .requireMinLust(20)
+					   .requireCor(50);
+			//Tier 1 Corruption Perks - acclimation over-rides
+			Sadist.requireLevel(6)
+				  .requirePerk(CorruptedLibido)
+				  .requireCor(60);
+			ArousingAura.requireLevel(6)
+						.requirePerk(CorruptedLibido)
+						.requireCor(70);
+			//Tier 1 Misc Perks
+			Resistance.requireLevel(6);
+			Survivalist.requireLevel(6)
+					   .requireHungerEnabled();
+			//Tier 2 Misc Perks
+			Survivalist2.requireLevel(12)
+						.requirePerk(Survivalist)
+						.requireHungerEnabled();
+		}
+		{
+			initRequirements();
+		}
 	}
 }

--- a/classes/classes/PerkTree.as
+++ b/classes/classes/PerkTree.as
@@ -1,0 +1,73 @@
+/**
+ * Created by aimozg on 22.05.2017.
+ */
+package classes {
+import classes.GlobalFlags.kFLAGS;
+import classes.GlobalFlags.kGAMECLASS;
+import classes.GlobalFlags.kGAMECLASS;
+
+import flash.utils.Dictionary;
+
+public class PerkTree extends BaseContent {
+	private var pdata:Dictionary = new Dictionary();
+
+	public function PerkTree() {
+		var library:Dictionary = PerkType.getPerkLibrary();
+		var perk:PerkType;
+		for each(perk in library) {
+			//var perk:PerkType = library[k];
+			pdata[perk.id] = {
+				perk   : perk,
+				ctxt   : perk.allRequirementDesc(),
+				unlocks: []
+			};
+		}
+		for each(perk in library) {
+			for each (var c:Object in perk.requirements) {
+				switch (c.type) {
+					case "perk":
+						var p2:PerkType = c.perk;
+						pdata[p2.id].unlocks.push(perk);
+						break;
+					case "anyperk":
+						var ps:Array = c.perks;
+						for each(p2 in ps) pdata[p2.id].unlocks.push(perk);
+						break;
+				}
+			}
+		}
+		/*for each(var pd:Object in pdata) {
+			var s:Array = [];
+			for each (perk in pd.unlocks) s.push(perk.name);
+			if (s.length>0 || pd.ctxt) trace("Perk " + pd.perk.name + (pd.ctxt ? "; requires " + pd.ctxt : "") + (s.length > 0 ? "; unlocks " + s.join(", ") : ""));
+		}*/
+	}
+	/**
+	 * Returns Array of PerkType
+	 */
+	public function listUnlocks(p:PerkType):Array {
+		return pdata[p.id].unlocks;
+	}
+	/**
+	 * Returns Array of PerkType
+	 */
+	public static function obtainablePerks():Array {
+		var rslt:Array=[];
+		for each(var perk:PerkType in PerkType.getPerkLibrary()) {
+			if (perk.requirements.length > 0) {
+				rslt.push(perk);
+			}
+		}
+		return rslt.sortOn("name");
+	}
+	/**
+	 * Returns Array of PerkType
+	 */
+	public static function availablePerks(player:Player):Array {
+		return obtainablePerks().filter(
+				function (perk:PerkType,idx:int,array:Array):Boolean {
+					return !player.hasPerk(perk) && perk.available(player);
+				});
+	}
+}
+}

--- a/classes/classes/PerkType.as
+++ b/classes/classes/PerkType.as
@@ -3,7 +3,10 @@
  */
 package classes
 {
-	import flash.utils.Dictionary;
+import classes.GlobalFlags.kFLAGS;
+import classes.GlobalFlags.kGAMECLASS;
+
+import flash.utils.Dictionary;
 
 	public class PerkType extends BaseContent
 	{
@@ -23,6 +26,10 @@ package classes
 		private var _desc:String;
 		private var _longDesc:String;
 		private var _keepOnAscension:Boolean;
+		public var defaultValue1:Number = 0;
+		public var defaultValue2:Number = 0;
+		public var defaultValue3:Number = 0;
+		public var defaultValue4:Number = 0;
 
 		/**
 		 * Unique perk id, should be kept in future game versions
@@ -55,12 +62,12 @@ package classes
 		{
 			return _longDesc;
 		}
-		
+
 		public function keepOnAscension(respec:Boolean = false):Boolean
 		{
 			if (_keepOnAscension)
-				return true;						
-			
+				return true;
+
 			return _longDesc != _desc && !respec; // dirty condition
 		}
 
@@ -81,6 +88,239 @@ package classes
 		public function toString():String
 		{
 			return "\""+_id+"\"";
+		}
+
+		/**
+		 * Array of:
+		 * {
+		 *   fn: (Player)=>Boolean,
+		 *   text: String,
+		 *   type: String
+		 *   // additional depending on type
+		 * }
+		 */
+		public var requirements:Array = [];
+
+		/**
+		 * @return "requirement1, requirement2, ..."
+		 */
+		public function allRequirementDesc():String {
+			var s:Array = [];
+			for each (var c:Object in requirements) {
+				if (c.text) s.push(c.text);
+			}
+			return s.join(", ");
+		}
+		public function available(player:Player):Boolean {
+			for each (var c: Object in requirements) {
+				if (!c.fn(player)) return false;
+			}
+			return true;
+		}
+
+		public function requireCustomFunction(playerToBoolean:Function, requirementText:String, internalType:String = "custom"):PerkType {
+			requirements.push({
+				fn  : playerToBoolean,
+				text: requirementText,
+				type: internalType
+			});
+			return this;
+		}
+
+		public function requireLevel(value:int):PerkType {
+			requirements.push({
+				fn  : fnRequireAttr("level", value),
+				text: "Level " + value,
+				type: "level",
+				value: value
+			});
+			return this;
+		}
+		public function requireStr(value:int):PerkType {
+			requirements.push({
+				fn  : fnRequireAttr("str", value),
+				text: "Strength " + value,
+				type: "attr",
+				attr: "str",
+				value: value
+			});
+			return this;
+		}
+		public function requireTou(value:int):PerkType {
+			requirements.push({
+				fn  : fnRequireAttr("tou", value),
+				text: "Toughness " + value,
+				type: "attr",
+				attr: "tou",
+				value: value
+			});
+			return this;
+		}
+		public function requireSpe(value:int):PerkType {
+			requirements.push({
+				fn  : fnRequireAttr("spe", value),
+				text: "Speed " + value,
+				type: "attr",
+				attr: "spe",
+				value: value
+			});
+			return this;
+		}
+		public function requireInt(value:int):PerkType {
+			requirements.push({
+				fn  : fnRequireAttr("inte", value),
+				text: "Intellect " + value,
+				type: "attr",
+				attr: "inte",
+				value: value
+			});
+			return this;
+		}
+		public function requireWis(value:int):PerkType {
+			requirements.push({
+				fn  : fnRequireAttr("wis", value),
+				text: "Wisdom " + value,
+				type: "attr",
+				attr: "wis",
+				value: value
+			});
+			return this;
+		}
+		public function requireLib(value:int):PerkType {
+			requirements.push({
+				fn  : fnRequireAttr("lib", value),
+				text: "Libido " + value,
+				type: "attr",
+				attr: "lib",
+				value: value
+			});
+			return this;
+		}
+		public function requireCor(value:int):PerkType {
+			requirements.push({
+				fn  : function(player:Player):Boolean {
+					return player.cor < value - player.corruptionTolerance();
+				},
+				text: "Corruption " + value,
+				type: "cor",
+				value: value
+			});
+			return this;
+		}
+		public function requireLibLessThan(value:int):PerkType {
+			requirements.push({
+				fn  : function(player:Player):Boolean {
+					return player.lib < value;
+				},
+				text: "Libido &lt; " + value,
+				type: "attr-lt",
+				attr: "lib",
+				value: value
+			});
+			return this;
+		}
+		public function requireNGPlus(value:int):PerkType {
+			requirements.push({
+				fn  : function(player:Player):Boolean {
+					return player.newGamePlusMod() >= value;
+				},
+				text: "New Game+ " + value,
+				type: "ng+",
+				value: value
+			});
+			return this;
+		}
+		/* [INTREMOD: xianxia]
+		public function requirePrestigeJobSlot():PerkType {
+			requirements.push({
+				fn  : function(player:Player):Boolean {
+					return player.maxPrestigeJobs() > 0;
+				},
+				text: "Free Prestige Job Slot",
+				type: "prestige"
+			});
+			return this;
+		}
+		*/
+		public function requireHungerEnabled():PerkType {
+			requirements.push({
+				fn  : function(player:Player):Boolean {
+					return kGAMECLASS.flags[kFLAGS.HUNGER_ENABLED] > 0;
+				},
+				text: "Hunger enabled",
+				type: "hungerflag"
+			});
+			return this;
+		}
+		public function requireMinLust(value:int):PerkType {
+			requirements.push({
+				fn  : function(player:Player):Boolean {
+					return player.minLust() >= value;
+				},
+				text: "Min. Lust "+value,
+				type: "minlust",
+				value: value
+			});
+			return this;
+		}
+		/* [INTERMOD: xianxia]
+		public function requireMaxSoulforce(value:int):PerkType {
+			requirements.push({
+				fn  : function(player:Player):Boolean {
+					return player.maxSoulforce() >= value;
+				},
+				text: "Max. Soulforce "+value,
+				type: "soulforce",
+				value: value
+			});
+			return this;
+		}
+		*/
+		private function fnRequireAttr(attrname:String,value:int):Function {
+			return function(player:Player):Boolean {
+				return player[attrname] >= value;
+			};
+		}
+		public function requireStatusEffect(effect:StatusEffectType, text:String):PerkType {
+			requirements.push({
+				fn  : function (player:Player):Boolean {
+					return player.hasStatusEffect(effect);
+				},
+				text: text,
+				type: "effect",
+				effect: effect
+			});
+			return this;
+		}
+		public function requirePerk(perk:PerkType):PerkType {
+			requirements.push({
+				fn  : function (player:Player):Boolean {
+					return player.findPerk(perk) >= 0;
+				},
+				text: perk.name,
+				type: "perk",
+				perk: perk
+			});
+			return this;
+		}
+		public function requireAnyPerk(...perks:Array):PerkType {
+			if (perks.length == 0) throw ("Incorrect call of requireAnyPerk() - should NOT be empty");
+			var text:Array = [];
+			for each (var perk:PerkType in perks) {
+				text.push(perk.allRequirementDesc());
+			}
+			requirements.push({
+				fn  : function (player:Player):Boolean {
+					for each (var perk:PerkType in perks) {
+						if (player.findPerk(perk) >= 0) return true;
+					}
+					return false;
+				},
+				text: text.join(" or "),
+				type: "anyperk",
+				perks: perks
+			});
+			return this;
 		}
 	}
 }

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -1,6 +1,8 @@
 package classes 
 {
-	import flash.events.Event;
+import classes.GlobalFlags.kGAMECLASS;
+
+import flash.events.Event;
 	import fl.controls.ComboBox;;
 	import fl.data.DataProvider;
 	import classes.*;
@@ -656,7 +658,8 @@ package classes
 				outputText("\n<b>You can adjust your Corruption Tolerance threshold.</b>");
 				addButton(button++,"Tol. Options",ascToleranceOption,null,null,null,"Set whether or not Corruption Tolerance is applied.");
 			}
-}
+			addButton(9, "Database", perkDatabase);
+		}
 
 		public function doubleAttackOptions():void {
 			clearOutput();
@@ -719,6 +722,40 @@ package classes
 			ascToleranceOption();
 		}
 
+		public function perkDatabase(page:int=0, count:int=20):void {
+			var allPerks:Array = PerkTree.obtainablePerks();
+			clearOutput();
+			var perks:Array = allPerks.slice(page*count,(page+1)*count);
+			displayHeader("All Perks ("+(1+page*count)+"-"+(page*count+perks.length)+
+					"/"+allPerks.length+")");
+			for each (var ptype:PerkType in perks) {
+				var pclass:PerkClass = player.perk(player.findPerk(ptype));
+
+				var color:String;
+				if (pclass) color='#000000'; // has perk
+				else if (ptype.available(player)) color='#228822'; // can take on next lvl
+				else color='#aa8822'; // requirements not met
+
+				outputText("<font color='" +color +"'><b>"+ptype.name+"</b></font>: ");
+				outputText(pclass?ptype.desc(pclass):ptype.longDesc);
+				if (!pclass && ptype.requirements.length>0) {
+					var reqs:Array = [];
+					for each (var cond:Object in ptype.requirements) {
+						if (cond.fn(player)) color='#000000';
+						else color='#aa2222';
+						reqs.push("<font color='"+color+"'>"+cond.text+"</font>");
+					}
+					outputText("<ul><li><b>Requires:</b> " + reqs.join(", ")+".</li></ul>");
+				} else {
+					outputText("\n");
+				}
+			}
+			if (page>0) addButton(0,"Prev",perkDatabase,page-1);
+			else addButtonDisabled(0,"Prev");
+			if ((page+1)*count<allPerks.length) addButton(1,"Next",perkDatabase,page+1);
+			else addButtonDisabled(1,"Next");
+			addButton(9, "Back", playerMenu);
+		}
 		
 		//------------
 		// LEVEL UP
@@ -884,7 +921,7 @@ package classes
 		private function perkBuyMenu():void {
 			clearOutput();
 			var perkList:Array = buildPerkList();
-			
+			mainView.aCb.dataProvider = new DataProvider(perkList);
 			if (perkList.length == 0) {
 				outputText("<b>You do not qualify for any perks at present.  </b>In case you qualify for any in the future, you will keep your " + num2Text(player.perkPoints) + " perk point");
 				if (player.perkPoints > 1) outputText("s");
@@ -924,285 +961,28 @@ package classes
 			var selected:PerkClass = ComboBox(event.target).selectedItem.perk;
 			mainView.aCb.move(210, 85);
 			outputText("You have selected the following perk:\n\n");
-			outputText("<b>" + selected.perkName + ":</b> " + selected.perkLongDesc + "\n\nIf you would like to select this perk, click <b>Okay</b>.  Otherwise, select a new perk, or press <b>Skip</b> to make a decision later.");
+			outputText("<b>" + selected.perkName + ":</b> " + selected.perkLongDesc);
+			var unlocks:Array = kGAMECLASS.perkTree.listUnlocks(selected.ptype);
+			if (unlocks.length>0){
+				outputText("\n\n<b>Unlocks:</b> <ul>");
+				for each (var pt:PerkType in unlocks) outputText("<li><b>"+pt.name+"</b> ("+pt.longDesc+")</li>");
+				outputText("</ul>");
+			}
+			outputText("\n\nIf you would like to select this perk, click <b>Okay</b>.  Otherwise, select a new perk, or press <b>Skip</b> to make a decision later.");
 			menu();
 			addButton(0, "Okay", perkSelect, selected);
 			addButton(1, "Skip", perkSkip);
 		}
 
 		public function buildPerkList():Array {
+			var player:Player  = kGAMECLASS.player;
+			var perks:Array = PerkTree.availablePerks(player);
 			var perkList:Array = [];
-			function _add(p:PerkClass):void{
-				perkList.push({label: p.perkName,perk:p});
+			for each(var perk:PerkType in perks) {
+				var p:PerkClass = new PerkClass(perk,
+						perk.defaultValue1, perk.defaultValue2, perk.defaultValue3, perk.defaultValue4);
+				perkList.push({label: p.perkName, perk: p});
 			}
-			//------------
-			// STRENGTH
-			//------------
-			if (player.str >= 25) {
-				_add(new PerkClass(PerkLib.StrongBack));
-			}
-			if (player.findPerk(PerkLib.StrongBack) >= 0 && player.str >= 50) {
-				_add(new PerkClass(PerkLib.StrongBack2));
-			}
-			//Tier 1 Strength Perks
-			if (player.level >= 6) {
-				//Thunderous Strikes - +20% basic attack damage while str > 80.
-				if (player.str >= 80) {
-					_add(new PerkClass(PerkLib.ThunderousStrikes));
-				}
-				//Weapon Mastery - Doubles weapon damage bonus of 'large' type weapons. (Minotaur Axe, M. Hammer, etc)
-				if (player.str > 60) {
-					_add(new PerkClass(PerkLib.WeaponMastery));
-				}
-				if (player.str >= 75)
-					_add(new PerkClass(PerkLib.BrutalBlows));
-				if (player.str >= 50)
-					_add(new PerkClass(PerkLib.IronFists));
-				if (player.str >= 65 && player.findPerk(PerkLib.IronFists) >= 0 && player.newGamePlusMod() >= 1)
-					_add(new PerkClass(PerkLib.IronFists2));
-				if (player.str >= 80 && player.findPerk(PerkLib.IronFists2) >= 0 && player.newGamePlusMod() >= 1)
-					_add(new PerkClass(PerkLib.IronFists3));
-				if (player.str >= 50 && player.spe >= 50)
-					_add(new PerkClass(PerkLib.Parry));
-			}
-			//Tier 2 Strength Perks
-			if (player.level >= 12) {
-				if (player.str >= 75)
-					_add(new PerkClass(PerkLib.Berzerker));
-				if (player.str >= 80)
-					_add(new PerkClass(PerkLib.HoldWithBothHands));
-				if (player.str >= 80 && player.tou >= 60)
-					_add(new PerkClass(PerkLib.ShieldSlam));
-			}
-			//Tier 3 Strength Perks
-			if (player.level >= 18) {
-				if (player.findPerk(PerkLib.Berzerker) >= 0 && player.findPerk(PerkLib.ImprovedSelfControl) >= 0 && player.str >= 75)
-					_add(new PerkClass(PerkLib.ColdFury));
-			}
-			//------------
-			// TOUGHNESS
-			//------------
-			//slot 2 - toughness perk 1
-			if (player.findPerk(PerkLib.Tank) < 0 && player.tou >= 25) {
-				_add(new PerkClass(PerkLib.Tank));
-			}
-			//slot 2 - regeneration perk
-			if (player.findPerk(PerkLib.Tank) >= 0 && player.tou >= 50) {
-				_add(new PerkClass(PerkLib.Regeneration));
-			}
-			if (player.tou >= 50 && player.str >= 50) {
-				_add(new PerkClass(PerkLib.ImprovedEndurance));
-			}
-			//Tier 1 Toughness Perks
-			if (player.level >= 6) {
-				if (player.findPerk(PerkLib.Tank) >= 0 && player.tou >= 60) {
-					_add(new PerkClass(PerkLib.Tank2));
-				}
-				if (player.findPerk(PerkLib.Regeneration) >= 0 && player.tou >= 70) {
-					_add(new PerkClass(PerkLib.Regeneration2));
-				}
-				if (player.tou >= 75) {
-					_add(new PerkClass(PerkLib.ImmovableObject));
-				}
-				if (player.tou >= 50) {
-					_add(new PerkClass(PerkLib.ShieldMastery));
-				}
-			}
-			//Tier 2 Toughness Perks
-			if (player.level >= 12) {
-				if (player.tou >= 75) {
-					_add(new PerkClass(PerkLib.Resolute));
-				}
-				if (player.tou >= 75) {
-					_add(new PerkClass(PerkLib.Juggernaut));
-				}
-				if (player.tou >= 60) {
-					_add(new PerkClass(PerkLib.IronMan));
-				}
-			}
-			//------------
-			// SPEED
-			//------------
-			//slot 3 - speed perk
-			if (player.spe >= 25) {
-					_add(new PerkClass(PerkLib.Evade));
-			}
-			//slot 3 - run perk
-			if (player.spe >= 25) {
-					_add(new PerkClass(PerkLib.Runner));
-			}
-			//slot 3 - Double Attack perk
-			if (player.findPerk(PerkLib.Evade) >= 0 && player.findPerk(PerkLib.Runner) >= 0 && player.spe >= 50) {
-					_add(new PerkClass(PerkLib.DoubleAttack));
-			}
-
-			//Tier 1 Speed Perks
-			if (player.level >= 6) {
-				//Speedy Recovery - Regain Fatigue 50% faster speed.
-				if (player.findPerk(PerkLib.Evade) >= 0 && player.spe >= 60) {
-					_add(new PerkClass(PerkLib.SpeedyRecovery));
-				}
-				//Agility - A small portion of your speed is applied to your defense rating when wearing light armors.
-				if (player.spe > 75 && player.findPerk(PerkLib.Runner) >= 0) {
-					_add(new PerkClass(PerkLib.Agility));
-				}
-				if (player.spe >= 75 && player.findPerk(PerkLib.Evade) >= 0 && player.findPerk(PerkLib.Agility) >= 0) {
-						_add(new PerkClass(PerkLib.Unhindered));
-				}
-				if (player.spe >= 60) {
-					_add(new PerkClass(PerkLib.LightningStrikes));
-				}
-				/*if (player.spe >= 60 && player.str >= 60) {
-					_add(new PerkClass(PerkLib.Brawler));
-				}*/ //Would it be fitting to have Urta teach you?
-			}
-			//Tier 2 Speed Perks
-			if (player.level >= 12) {
-				if (player.spe >= 75) {
-					_add(new PerkClass(PerkLib.LungingAttacks));
-				}
-				if (player.spe >= 80 && player.str >= 60) {
-					_add(new PerkClass(PerkLib.Blademaster));
-				}
-			}
-			//------------
-			// INTELLIGENCE
-			//------------
-			//Slot 4 - precision - -10 enemy toughness for damage calc
-			if (player.inte >= 25) {
-					_add(new PerkClass(PerkLib.Precision));
-			}
-			//Spellpower - boosts spell power
-			if (player.inte >= 50) {
-					_add(new PerkClass(PerkLib.Spellpower));
-			}
-			if (player.findPerk(PerkLib.Spellpower) >= 0 && player.inte >= 50) {
-					_add(new PerkClass(PerkLib.Mage));
-			}
-			//Tier 1 Intelligence Perks
-			if (player.level >= 6) {
-				if (player.inte >= 50)
-					_add(new PerkClass(PerkLib.Tactician));
-				if (player.spellCount() > 0 && player.findPerk(PerkLib.Spellpower) >= 0 && player.findPerk(PerkLib.Mage) >= 0 && player.inte >= 60) {
-					_add(new PerkClass(PerkLib.Channeling));
-				}
-				if (player.inte >= 60) {
-					_add(new PerkClass(PerkLib.Medicine));
-				}
-				if (player.findPerk(PerkLib.Channeling) >= 0 && player.inte >= 60) {
-						_add(new PerkClass(PerkLib.StaffChanneling));
-				}
-			}
-			//Tier 2 Intelligence perks
-			if (player.level >= 12) {
-				if (player.findPerk(PerkLib.Mage) >= 0 && player.inte >= 75) {
-					_add(new PerkClass(PerkLib.Archmage));
-				}
-				if (player.inte >= 75) {
-						if (player.findPerk(PerkLib.Mage) >= 0)
-							_add(new PerkClass(PerkLib.FocusedMind));
-						
-						if (player.findPerk(PerkLib.Archmage) >= 0 && player.findPerk(PerkLib.Channeling) >= 0  &&
-						(player.hasStatusEffect(StatusEffects.KnowsWhitefire)
-						|| player.findPerk(PerkLib.FireLord) >= 0 
-						|| player.findPerk(PerkLib.Hellfire) >= 0 
-						|| player.findPerk(PerkLib.EnlightenedNinetails) >= 0
-						|| player.findPerk(PerkLib.CorruptedNinetails) >= 0))
-							_add(new PerkClass(PerkLib.RagingInferno));
-				}
-				// Spell-boosting perks
-				// Battlemage: auto-use Might
-				if (player.findPerk(PerkLib.Channeling) >= 0 && player.hasStatusEffect(StatusEffects.KnowsMight) && player.inte >= 80) {
-						_add(new PerkClass(PerkLib.Battlemage));
-				}
-				// Spellsword: auto-use Charge Weapon
-				if (player.findPerk(PerkLib.Channeling) >= 0 && player.hasStatusEffect(StatusEffects.KnowsCharge) && player.inte >= 80) {
-						_add(new PerkClass(PerkLib.Spellsword));
-				}
-			}
-			
-			//------------
-			// LIBIDO
-			//------------
-			//slot 5 - libido perks
-
-			//Slot 5 - Fertile+ increases cum production and fertility (+15%)
-			if (player.lib >= 25) {
-					_add(new PerkClass(PerkLib.FertilityPlus,15,1.75,0,0));
-			}
-			if (player.lib >= 25 && player.inte >= 50) {
-				_add(new PerkClass(PerkLib.ImprovedSelfControl));
-			}
-			//Slot 5 - minimum libido
-			if (player.minLust() >= 20) {
-					_add(new PerkClass(PerkLib.ColdBlooded,20,0,0,0));
-			}
-			if (player.lib >= 50) {
-					_add(new PerkClass(PerkLib.HotBlooded,20,0,0,0));
-			}
-			//Tier 1 Libido Perks
-			if (player.level >= 6) {
-				//Slot 5 - minimum libido
-				//Slot 5 - Fertility- decreases cum production and fertility.
-				if (player.lib < 25) {
-						_add(new PerkClass(PerkLib.FertilityMinus, 15, 0.7, 0, 0));
-				}
-				if (player.lib >= 60) {
-					_add(new PerkClass(PerkLib.WellAdjusted));
-				}
-				//Slot 5 - minimum libido
-				if (player.lib >= 60 && player.cor >= (50 - player.corruptionTolerance())) {
-					_add(new PerkClass(PerkLib.Masochist));
-				}
-			}
-			//------------
-			// SENSITIVITY
-			//------------
-			//Nope.avi
-			//------------
-			// CORRUPTION
-			//------------
-			//Slot 7 - Corrupted Libido - lust raises 10% slower.
-			if (player.cor >= (25 - player.corruptionTolerance())) {
-					_add(new PerkClass(PerkLib.CorruptedLibido,20,0,0,0));
-			}
-			//Slot 7 - Seduction (Must have seduced Jojo
-			if (player.cor >= (50 - player.corruptionTolerance())) {
-					_add(new PerkClass(PerkLib.Seduction));
-			}
-			//Slot 7 - Nymphomania
-			if (player.findPerk(PerkLib.CorruptedLibido) >= 0 && player.cor >= (75 - player.corruptionTolerance())) {
-					_add(new PerkClass(PerkLib.Nymphomania));
-			}
-			//Slot 7 - UNFINISHED :3
-			if (player.minLust() >= 20 && player.findPerk(PerkLib.CorruptedLibido) >= 0 && player.cor >= (50 - player.corruptionTolerance())) {
-					_add(new PerkClass(PerkLib.Acclimation));
-			}
-			//Tier 1 Corruption Perks - acclimation over-rides
-			if (player.level >= 6)
-			{
-				if (player.cor >= (60 - player.corruptionTolerance()) && player.findPerk(PerkLib.CorruptedLibido) >= 0) {
-					_add(new PerkClass(PerkLib.Sadist));
-				}
-				if (player.findPerk(PerkLib.CorruptedLibido) >= 0 && player.cor >= (70 - player.corruptionTolerance())) {
-					_add(new PerkClass(PerkLib.ArousingAura));
-				}
-			}
-			//Tier 1 Misc Perks
-			if (player.level >= 6) {
-				_add(new PerkClass(PerkLib.Resistance));
-				if (flags[kFLAGS.HUNGER_ENABLED] > 0) _add(new PerkClass(PerkLib.Survivalist));
-			}
-			//Tier 2 Misc Perks
-			if (player.level >= 12 && player.findPerk(PerkLib.Survivalist) > 0) {
-				if (flags[kFLAGS.HUNGER_ENABLED] > 0) _add(new PerkClass(PerkLib.Survivalist2));
-			}
-			// FILTER PERKS
-			perkList = perkList.filter(
-					function(perk:*,idx:int,array:Array):Boolean{
-						return player.findPerk(perk.perk.ptype) < 0;
-					});
-			mainView.aCb.dataProvider = new DataProvider(perkList);
 			return perkList;
 		}
 		public function applyPerk(perk:PerkClass):void {


### PR DESCRIPTION
Perk requirements moved into `PerkType` instances.
They should be configured by `PerkType.requireXXX` chainable methods in `PerkLib` static initializer.

See example usages in:
* `PlayerInfo.perkDatabase` - an in-game menu that lists all perks, their direct requirements, and marks them with different color.
* `PlayerInfo.perkBuyMenu` and `.changeHandler` - when choosing new perk, lists future perks depending on it.