### PR TITLE
No need for a separate MutationsHelper-instance

### DIFF
--- a/classes/classes/Items/Consumable.as
+++ b/classes/classes/Items/Consumable.as
@@ -31,8 +31,6 @@ package classes.Items
 		protected function get flags():DefaultDict { return kGAMECLASS.flags; }
 		protected function get camp():Camp { return kGAMECLASS.camp; }
 		protected function doNext(eventNo:Function):void { kGAMECLASS.doNext(eventNo); }
-		
-		protected var mutationsHelper:MutationsHelper = new MutationsHelper();
 
 		public function Consumable(id:String, shortName:String = null, longName:String = null, value:Number = 0, description:String = null) {
 			super(id, shortName, longName, value, description);

--- a/classes/classes/Items/Consumables/Ectoplasm.as
+++ b/classes/classes/Items/Consumables/Ectoplasm.as
@@ -61,7 +61,7 @@ package classes.Items.Consumables
 				}
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Appearnace Change
 			//Hair
@@ -87,7 +87,7 @@ package classes.Items.Consumables
 					player.skinType = SKIN_TYPE_PLAIN;
 				}
 				player.underBody.restore();
-				mutationsHelper.updateClaws(player.clawType);
+				mutations.updateClaws(player.clawType);
 				changes++;
 			}
 			//Legs

--- a/classes/classes/Items/Consumables/Equinum.as
+++ b/classes/classes/Items/Consumables/Equinum.as
@@ -6,7 +6,6 @@ package classes.Items.Consumables
 	import classes.GlobalFlags.kFLAGS;
 	import classes.Items.Consumable;
 	import classes.Items.ConsumableLib;
-	import classes.Items.MutationsHelper;
 	import classes.PerkLib;
 	import classes.StatusEffects;
 	
@@ -161,14 +160,14 @@ package classes.Items.Consumables
 				}
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Restore arms to become human arms again
 			if (rand(4) === 0) {
-				mutationsHelper.restoreArms(tfSource);
+				mutations.restoreArms(tfSource);
 			}
 			//Remove feathery hair
-			mutationsHelper.removeFeatheryHair();
+			mutations.removeFeatheryHair();
 			//
 			//SEXUAL CHARACTERISTICS
 			//
@@ -504,7 +503,7 @@ package classes.Items.Consumables
 			}
 			// Remove gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) {
-				mutationsHelper.updateGills();
+				mutations.updateGills();
 			}
 
 			if (rand(3) === 0) outputText(player.modTone(60, 1));

--- a/classes/classes/Items/Consumables/FerretFruit.as
+++ b/classes/classes/Items/Consumables/FerretFruit.as
@@ -148,7 +148,7 @@ package classes.Items.Consumables
 			}
 			//If the PC has gills:
 			if (player.hasGills() && rand(4) === 0 && changes < changeLimit) {
-				mutationsHelper.updateGills();
+				mutations.updateGills();
 			}
 			//	outputText("\n\nYou grit your teeth as a stinging sensation arises in your gills.  Within moments, the sensation passes, and <b>your gills are gone!</b>");
 			//If the PC has tentacle hair:
@@ -183,7 +183,7 @@ package classes.Items.Consumables
 				}
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Turn ferret mask to full furface.
 			if (player.faceType === FACE_FERRET_MASK && player.hasFur() && player.earType === EARS_FERRET && player.tailType === TAIL_TYPE_FERRET && player.lowerBody === LOWER_BODY_TYPE_FERRET && rand(4) === 0 && changes < changeLimit)

--- a/classes/classes/Items/Consumables/GoblinAle.as
+++ b/classes/classes/Items/Consumables/GoblinAle.as
@@ -66,11 +66,11 @@ package classes.Items.Consumables
 				changes++;
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Restore arms to become human arms again
 			if (rand(4) === 0) {
-				mutationsHelper.restoreArms(tfSource);
+				mutations.restoreArms(tfSource);
 			}
 			//SEXYTIEMS
 			//Multidick killa!
@@ -166,7 +166,7 @@ package classes.Items.Consumables
 					if (rand(2) === 0) player.skinTone = "pale yellow";
 					else player.skinTone = "grayish-blue";
 				}
-				mutationsHelper.updateClaws(player.clawType);
+				mutations.updateClaws(player.clawType);
 				changes++;
 				outputText("\n\nWhoah, that was weird.  You just hallucinated that your ");
 				if (player.hasFur()) outputText("skin");
@@ -188,7 +188,7 @@ package classes.Items.Consumables
 			}
 			// Remove gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) {
-				mutationsHelper.updateGills();
+				mutations.updateGills();
 			}
 
 			//Nipples Turn Back:

--- a/classes/classes/Items/Consumables/ImpFood.as
+++ b/classes/classes/Items/Consumables/ImpFood.as
@@ -4,7 +4,6 @@ package classes.Items.Consumables
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Items.Consumable;
 	import classes.Items.ConsumableLib;
-	import classes.Items.MutationsHelper;
 	import classes.PerkLib;
 	
 	/**
@@ -53,7 +52,7 @@ package classes.Items.Consumables
 					if (rand(2) === 0) player.skinTone = "red";
 					else player.skinTone = "orange";
 					outputText("begins to lose its color, fading until you're as white as an albino.  Then, starting at the crown of your head, a reddish hue rolls down your body in a wave, turning you completely " + player.skinTone + ".");
-					mutationsHelper.updateClaws(player.clawType);
+					mutations.updateClaws(player.clawType);
 					kGAMECLASS.rathazul.addMixologyXP(20);
 				}
 				return false;
@@ -257,7 +256,7 @@ package classes.Items.Consumables
 			}
 			
 			if (rand(5) === 0 && changes < changeLimit) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			
 			//You lotta imp? Time to turn male!

--- a/classes/classes/Items/Consumables/MinotaurBlood.as
+++ b/classes/classes/Items/Consumables/MinotaurBlood.as
@@ -117,11 +117,11 @@ package classes.Items.Consumables
 				changes++;
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Restore arms to become human arms again
 			if (rand(4) === 0) {
-				mutationsHelper.restoreArms(tfSource);
+				mutations.restoreArms(tfSource);
 			}
 			//+hooves
 			if (player.lowerBody !== LOWER_BODY_TYPE_HOOFED) {
@@ -409,7 +409,7 @@ package classes.Items.Consumables
 			}
 			// Remove gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) {
-				mutationsHelper.updateGills();
+				mutations.updateGills();
 			}
 
 			if (changes < changeLimit && rand(4) === 0 && ((player.ass.analWetness > 0 && player.findPerk(PerkLib.MaraesGiftButtslut) < 0) || player.ass.analWetness > 1)) {

--- a/classes/classes/Items/Consumables/MouseCocoa.as
+++ b/classes/classes/Items/Consumables/MouseCocoa.as
@@ -128,7 +128,7 @@ package classes.Items.Consumables
         }
       }
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//bodypart changes:
 			//gain ears

--- a/classes/classes/Items/Consumables/RegularHummus.as
+++ b/classes/classes/Items/Consumables/RegularHummus.as
@@ -45,12 +45,12 @@ package classes.Items.Consumables
 			//-----------------------
 			//1st priority: Change lower body to bipedal.
 			if (rand(4) === 0 && changes < changeLimit) {
-				mutationsHelper.restoreLegs(tfSource);
+				mutations.restoreLegs(tfSource);
 			}
 			
 			//Remove Oviposition Perk
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Remove Incorporeality Perk
 			if (player.findPerk(PerkLib.Incorporeality) >= 0 && player.perkv4(PerkLib.Incorporeality) === 0 && changes < changeLimit && rand(10) === 0) {
@@ -72,7 +72,7 @@ package classes.Items.Consumables
 				else if (temp === 3) player.skinTone = "light";
 				outputText(player.skinTone + " colored.</b>");
 				player.underBody.skin.tone = player.skin.tone;
-				mutationsHelper.updateClaws(player.clawType);
+				mutations.updateClaws(player.clawType);
 			}
 			//Change skin to normal
 			if (!player.hasPlainSkin() && (player.earType === EARS_HUMAN || player.earType === EARS_ELFIN) && rand(4) === 0 && changes < changeLimit) {
@@ -87,7 +87,7 @@ package classes.Items.Consumables
 			}
 			//Restore arms to become human arms again
 			if (rand(4) === 0) {
-				mutationsHelper.restoreArms(tfSource);
+				mutations.restoreArms(tfSource);
 			}
 			//-----------------------
 			// MINOR TRANSFORMATIONS
@@ -125,7 +125,7 @@ package classes.Items.Consumables
 			}
 			//Removes gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) {
-				mutationsHelper.updateGills();
+				mutations.updateGills();
 			}
 			//Nipples Turn Back:
 			if (player.hasStatusEffect(StatusEffects.BlackNipples) && changes < changeLimit && rand(3) === 0) {
@@ -134,7 +134,7 @@ package classes.Items.Consumables
 				player.removeStatusEffect(StatusEffects.BlackNipples);
 			}
 			//Remove feathery hair
-			mutationsHelper.removeFeatheryHair();
+			mutations.removeFeatheryHair();
 			//Remove anemone hair
 			if (changes < changeLimit && player.hairType === HAIR_ANEMONE && rand(3) === 0) {
 				//-insert anemone hair removal into them under whatever criteria you like, though hair removal should precede abdomen growth; here's some sample text:
@@ -152,7 +152,7 @@ package classes.Items.Consumables
 			}
 			//Remove bassy hair
 			if ([HAIR_BASILISK_PLUME, HAIR_BASILISK_SPINES].indexOf(player.hairType) !== -1 && changes < changeLimit && rand(4) === 0)
-				mutationsHelper.removeBassyHair();
+				mutations.removeBassyHair();
 			//Restart hair growth
 			if (flags[kFLAGS.HAIR_GROWTH_STOPPED_BECAUSE_LIZARD] > 0 && changes < changeLimit && rand(3) === 0) {
 				outputText("\n\nYou feel an itching sensation in your scalp as you realize the change. <b>Your hair is growing normally again!</b>");

--- a/classes/classes/Items/Consumables/Reptilum.as
+++ b/classes/classes/Items/Consumables/Reptilum.as
@@ -225,18 +225,18 @@ package classes.Items.Consumables
 			}
 			//-VAGs
 			if (player.hasVagina() && rand(5) === 0 && player.lizardScore() > 3) {
-				mutationsHelper.updateOvipositionPerk(tfSource); // does all the magic, nuff said!
+				mutations.updateOvipositionPerk(tfSource); // does all the magic, nuff said!
 			}
 
 			//Physical changes:
 			//-Existing horns become draconic, max of 4, max length of 1'
 			if (!player.hasDragonHorns(true) && changes < changeLimit && rand(5) === 0){
-				mutationsHelper.gainDraconicHorns(tfSource);
+				mutations.gainDraconicHorns(tfSource);
 			}
 			
 			//-Hair changes
 			if (changes < changeLimit && rand(4) === 0) {
-				mutationsHelper.lizardHairChange(tfSource);
+				mutations.lizardHairChange(tfSource);
 			}
 			//Remove beard!
 			if (player.hasBeard() && changes < changeLimit && rand(3) === 0) {
@@ -265,7 +265,7 @@ package classes.Items.Consumables
 			//Gain predator arms
 			if (player.armType !== ARM_TYPE_PREDATOR && player.hasReptileScales() && player.lowerBody === LOWER_BODY_TYPE_LIZARD && changes < changeLimit && rand(3) === 0) {
 				player.armType = ARM_TYPE_PREDATOR;
-				mutationsHelper.updateClaws(CLAW_TYPE_LIZARD);
+				mutations.updateClaws(CLAW_TYPE_LIZARD);
 				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with " + player.skinFurScales() + " and short " + player.clawTone + " claws replacing your fingernails.");
 				outputText("\n<b>You now have reptilian arms.</b>");
 				changes++
@@ -273,7 +273,7 @@ package classes.Items.Consumables
 			//Claw transition
 			if (player.armType === ARM_TYPE_PREDATOR && player.hasLizardScales() && player.clawType !== CLAW_TYPE_LIZARD && changes < changeLimit && rand(3) === 0) {
 				outputText("\n\nYour " + player.claws() + " change a little to become reptilian.");
-				mutationsHelper.updateClaws(CLAW_TYPE_LIZARD);
+				mutations.updateClaws(CLAW_TYPE_LIZARD);
 				outputText(" <b>You now have " + player.claws() + ".</b>");
 				changes++
 			}
@@ -309,10 +309,10 @@ package classes.Items.Consumables
 			//-Scales – color changes to red, green, white, blue, or black.  Rarely: purple or silver.
 			if (!player.hasLizardScales() && player.earType === EARS_LIZARD && player.tailType === TAIL_TYPE_LIZARD && player.lowerBody === LOWER_BODY_TYPE_LIZARD && changes < changeLimit && rand(5) === 0) {
 				//(fur)
-				var newSkinTones:Array = mutationsHelper.newLizardSkinTone();
+				var newSkinTones:Array = mutations.newLizardSkinTone();
 				if (player.hasFur()) {
 					player.skin.tone = newSkinTones[0];
-					mutationsHelper.updateClaws(player.clawType);
+					mutations.updateClaws(player.clawType);
 					outputText("\n\nYou scratch yourself, and come away with a large clump of " + player.furColor + " fur.  Panicked, you look down"
 					          +" and realize that your fur is falling out in huge clumps.  It itches like mad, and you scratch your body"
 					          +" relentlessly, shedding the remaining fur with alarming speed.  Underneath the fur your skin feels incredibly"
@@ -326,7 +326,7 @@ package classes.Items.Consumables
 					          +" scratch yourself, and when you're finally done, you look yourself over. New scales have grown to replace your"
 					          +" peeled off [skinFurScales].");
 					player.skin.tone = newSkinTones[0];
-					mutationsHelper.updateClaws(player.clawType);
+					mutations.updateClaws(player.clawType);
 				}
 				//(no fur)
 				else {
@@ -336,7 +336,7 @@ package classes.Items.Consumables
 					          +" well that they may as well be seamless.  You peel back your " + player.armorName + " and the transformation has"
 					          +" already finished on the rest of your body.");
 					player.skin.tone = newSkinTones[0];
-					mutationsHelper.updateClaws(player.clawType);
+					mutations.updateClaws(player.clawType);
 				}
 				player.skin.setProps({
 					type: SKIN_TYPE_LIZARD_SCALES,
@@ -360,15 +360,15 @@ package classes.Items.Consumables
 			//-Lizard tongue
 			if (player.tongueType === TONGUE_SNAKE && changes < changeLimit && rand(10) < 6) {
 				// Higher (60%) chance to be 'fixed' if old variant
-				mutationsHelper.gainLizardTongue();
+				mutations.gainLizardTongue();
 			}
 
 			if ([TONGUE_LIZARD, TONGUE_SNAKE].indexOf(player.tongueType) === -1 && player.hasReptileFace() && changes < changeLimit && rand(3) === 0) {
-				mutationsHelper.gainLizardTongue();
+				mutations.gainLizardTongue();
 			}
 			//-Remove Gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) {
-				mutationsHelper.updateGills();
+				mutations.updateGills();
 			}
 			//<mod name="Reptile eyes" author="Stadler76">
 			//-Lizard eyes

--- a/classes/classes/Items/Consumables/RingtailFig.as
+++ b/classes/classes/Items/Consumables/RingtailFig.as
@@ -75,7 +75,7 @@ package classes.Items.Consumables
 				changes++;
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//bodypart changes:
 			if (player.tailType !== TAIL_TYPE_RACCOON && rand(4) === 0 && changes < changeLimit) {

--- a/classes/classes/Items/Consumables/Salamanderfirewater.as
+++ b/classes/classes/Items/Consumables/Salamanderfirewater.as
@@ -181,7 +181,7 @@ package classes.Items.Consumables
 				changes++;
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Physical changes:
 			//Tail - 1st gain reptilian tail, 2nd unlocks enhanced with fire tail whip attack
@@ -217,7 +217,7 @@ package classes.Items.Consumables
 			if (player.armType !== ARM_TYPE_SALAMANDER && player.lowerBody === LOWER_BODY_TYPE_SALAMANDER && changes < changeLimit && rand(3) === 0) {
 				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of a salamander with leathery, red scales and short, fiery-red claws replacing your fingernails.  <b>You now have salamander arms.</b>");
 				player.armType = ARM_TYPE_SALAMANDER;
-				mutationsHelper.updateClaws(CLAW_TYPE_SALAMANDER);
+				mutations.updateClaws(CLAW_TYPE_SALAMANDER);
 				changes++;
 			}
 			//Remove odd eyes
@@ -253,7 +253,7 @@ package classes.Items.Consumables
 				if (player.hasFur()) outputText("the skin under your " + player.furColor + " " + player.skinDesc + " has ");
 				else outputText("your " + player.skinDesc + (player.skinDesc.indexOf("scales") !== -1 ? " have " : " has "));
 				player.skinTone = randomChoice(humanSkinColors);
-				mutationsHelper.updateClaws(player.clawType);
+				mutations.updateClaws(player.clawType);
 				outputText("changed to become " + player.skinTone + " colored.</b>");
 			}
 			//Change skin to normal
@@ -268,7 +268,7 @@ package classes.Items.Consumables
 			}
 			//Removing gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) {
-				mutationsHelper.updateGills();
+				mutations.updateGills();
 			}
 			//FAILSAFE CHANGE
 			if (changes === 0) {

--- a/classes/classes/Items/Consumables/ShriveledTentacle.as
+++ b/classes/classes/Items/Consumables/ShriveledTentacle.as
@@ -53,7 +53,7 @@ package classes.Items.Consumables
 			//"The tingling of the tentacle
 
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			
 			//physical changes:
@@ -87,14 +87,14 @@ package classes.Items.Consumables
 			
 			//-feathery gills sprout from chest and drape sensually over nipples (cumulative swimming power boost with fin, if swimming is implemented)
 			if (rand(5) === 0 && player.gillType !== GILLS_ANEMONE && player.skinTone === "aphotic blue-black" && changes < changeLimit) {
-				mutationsHelper.updateGills(GILLS_ANEMONE);
+				mutations.updateGills(GILLS_ANEMONE);
 			}
 			
 			//-[aphotic] skin tone (blue-black)
 			if (rand(5) === 0 && changes < changeLimit && player.skinTone !== "aphotic blue-black") {
 				outputText("\n\nYou absently bite down on the last of the tentacle, then pull your hand away, wincing in pain.  How did you bite your finger so hard?  Looking down, the answer becomes obvious; <b>your hand, along with the rest of your skin, is now the same aphotic color as the dormant tentacle was!</b>");
 				player.skinTone = "aphotic blue-black";
-				mutationsHelper.updateClaws(player.clawType);
+				mutations.updateClaws(player.clawType);
 				kGAMECLASS.rathazul.addMixologyXP(20);
 				changes++;
 			}

--- a/classes/classes/Items/Consumables/SnakeOil.as
+++ b/classes/classes/Items/Consumables/SnakeOil.as
@@ -60,7 +60,7 @@ package classes.Items.Consumables
 				changes++;
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Removes wings
 			if (player.wingType > WING_TYPE_NONE && rand(3) === 0 && changes < changeLimit) {
@@ -77,7 +77,7 @@ package classes.Items.Consumables
 			}
 			//9c) II The tongue (sensitivity bonus, stored as a perk?)
 			if (changes === 0 && rand(3) === 0) {
-				mutationsHelper.gainSnakeTongue();
+				mutations.gainSnakeTongue();
 			}
 			//9c) III The fangs
 			if (changes === 0 && player.tongueType === TONGUE_SNAKE && player.faceType !== FACE_SNAKE_FANGS && rand(3) === 0 && changes < changeLimit) {
@@ -122,12 +122,12 @@ package classes.Items.Consumables
 					});
 				}
 				
-				mutationsHelper.updateClaws(player.clawType); // Just auto-fix the clawTone
+				mutations.updateClaws(player.clawType); // Just auto-fix the clawTone
 				changes++;
 			}
 			// Remove gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) {
-				mutationsHelper.updateGills();
+				mutations.updateGills();
 			}
 
 			//Default change - blah

--- a/classes/classes/Items/Consumables/SuperHummus.as
+++ b/classes/classes/Items/Consumables/SuperHummus.as
@@ -42,7 +42,7 @@ package classes.Items.Consumables
 				outputText("\n\nYou cry out as the world spins around you.  You're aware of your entire body sliding and slipping, changing and morphing, but in the sea of sensation you have no idea exactly what's changing.  You nearly black out, and then it's over.  Maybe you had best have a look at yourself and see what changed?");
 			}
 			player.armType = ARM_TYPE_HUMAN;
-			mutationsHelper.updateClaws();
+			mutations.updateClaws();
 			player.eyeType = EYES_HUMAN;
 			player.antennae = ANTENNAE_NONE;
 			player.faceType = FACE_HUMAN;
@@ -113,7 +113,7 @@ package classes.Items.Consumables
 			player.removeStatusEffect(StatusEffects.Uniball);
 			player.removeStatusEffect(StatusEffects.BlackNipples);
 			player.vaginaType(0);
-			mutationsHelper.updateOvipositionPerk(tfSource);
+			mutations.updateOvipositionPerk(tfSource);
 			
 			return false;
 		}

--- a/classes/classes/Items/Consumables/TrapOil.as
+++ b/classes/classes/Items/Consumables/TrapOil.as
@@ -243,7 +243,7 @@ package classes.Items.Consumables
 				}
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Nipples Turn Black:
 			if (!player.hasStatusEffect(StatusEffects.BlackNipples) && rand(6) === 0 && changes < changeLimit) {

--- a/classes/classes/Items/Consumables/WetCloth.as
+++ b/classes/classes/Items/Consumables/WetCloth.as
@@ -37,7 +37,7 @@ package classes.Items.Consumables
 
 			//Cosmetic changes based on 'goopyness'
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Remove wings
 			if (player.wingType > WING_TYPE_NONE) {
@@ -96,7 +96,7 @@ package classes.Items.Consumables
 					else player.skinTone = "emerald";
 					outputText(player.skinTone + "!");
 					if (player.armType !== ARM_TYPE_HUMAN || player.clawType !== CLAW_TYPE_NORMAL) {
-						mutationsHelper.restoreArms(tfSource);
+						mutations.restoreArms(tfSource);
 					}
 				}
 				return false;

--- a/classes/classes/Items/Consumables/WhiskerFruit.as
+++ b/classes/classes/Items/Consumables/WhiskerFruit.as
@@ -239,7 +239,7 @@ package classes.Items.Consumables
 				}
 			}
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Body type changes.  Teh rarest of the rare.
 			//DA EARZ
@@ -327,7 +327,7 @@ package classes.Items.Consumables
 			}
 			// Remove gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) {
-				mutationsHelper.updateGills();
+				mutations.updateGills();
 			}
 			//FAILSAFE CHANGE
 			if (changes === 0) {

--- a/classes/classes/Items/Consumables/WolfPepper.as
+++ b/classes/classes/Items/Consumables/WolfPepper.as
@@ -4,7 +4,6 @@ package classes.Items.Consumables
 	import classes.GlobalFlags.kFLAGS;
 	import classes.Items.Consumable;
 	import classes.Items.ConsumableLib;
-	import classes.Items.MutationsHelper;
 	import classes.PerkLib;
 	
 	/**
@@ -64,7 +63,7 @@ package classes.Items.Consumables
 			//PRE-CHANGES: become biped, remove horns, remove wings, give human tongue, remove claws, remove antennea
 			//no claws
 			if (rand(4) === 0) {
-				mutationsHelper.updateClaws();
+				mutations.updateClaws();
 			}
 			//remove antennae
 			if (player.antennae !== ANTENNAE_NONE && rand(3) === 0 && changes < changeLimit) {
@@ -106,19 +105,19 @@ package classes.Items.Consumables
 			}
 			//normal legs
 			if (player.lowerBody !== LOWER_BODY_TYPE_WOLF && rand(4) === 0) {
-				mutationsHelper.restoreLegs(tfSource);
+				mutations.restoreLegs(tfSource);
 			}
 			//normal arms
 			if (rand(4) === 0) {
-				mutationsHelper.restoreArms(tfSource);
+				mutations.restoreArms(tfSource);
 			}
 			//remove feather hair
 			if (rand(4) === 0) {
-				mutationsHelper.removeFeatheryHair();
+				mutations.removeFeatheryHair();
 			}
 			//remove basilisk hair
 			if (rand(4) === 0) {
-				mutationsHelper.removeBassyHair();
+				mutations.removeBassyHair();
 			}
 			//MUTATIONZ AT ANY TIME: wolf dick, add/decrease breasts, decrease breast size if above D
 			//get a wolf dick
@@ -388,7 +387,7 @@ package classes.Items.Consumables
 			}
 			//MISC CRAP
 			if (rand(5) === 0) {
-				mutationsHelper.updateOvipositionPerk(tfSource);
+				mutations.updateOvipositionPerk(tfSource);
 			}
 			if (rand(3) === 0) {
 				outputText(player.modTone(100, 4));


### PR DESCRIPTION
Like I commented in PR #667 theres no need for a separate MutationsHelper-instance in Consumable.as since this can and should be accessed through Mutations, respectively `kGAMECLASS.mutations`