### PR TITLE
Merge a couple underbody types

### DIFF
--- a/classes/classes/BodyParts/Readme.md
+++ b/classes/classes/BodyParts/Readme.md
@@ -130,7 +130,7 @@ player.skin.restore(false); // Restores all values including the skin tone
 #### Property table
 | Property | Access example          | Description / Examples                                                 |
 |----------|-------------------------|------------------------------------------------------------------------|
-| `type`   | `player.underBody.type` | **The type**<br>`player.underBody.type = UNDER_BODY_TYPE_DRAGON;`      |
+| `type`   | `player.underBody.type` | **The type**<br>`player.underBody.type = UNDER_BODY_TYPE_REPTILE;`     |
 | `skin`   | `player.underBody.skin` | **The skin on the underbody**<br>`player.underBody.skin = new Skin();` |
 
 #### Additional methods
@@ -157,7 +157,7 @@ player.skin.setProps({
 	adj: "",
 	desc: "scales"
 });
-player.underBody.type = UNDER_BODY_TYPE_LIZARD;
+player.underBody.type = UNDER_BODY_TYPE_REPTILE;
 player.underBody.copySkin({ // copy the main skin props to the underBody skin ...
 	desc: "ventral scales"  // ... and only override the desc
 });
@@ -170,7 +170,7 @@ player.skin.setProps({
 	adj: "",
 	desc: "scales"
 });
-player.underBody.type = UNDER_BODY_TYPE_LIZARD;
+player.underBody.type = UNDER_BODY_TYPE_REPTILE;
 player.underBody.copySkin();                     // copy the main skin props to the underBody skin ...
 player.underBody.skin.desc = "ventral scales";   // ... and only override the desc
 ```
@@ -180,14 +180,14 @@ Let's say, we intend to have some kind of turtle girl TF in CoC, the TF code *co
 
 ```as3
 // First step: The player grows lizard scales on his/her skin and/or underbody
-if ((!player.hasLizardScales() || [UNDER_BODY_TYPE_LIZARD, UNDER_BODY_TYPE_TURTLE].indexOf(player.underBody.type) == -1) && player.lowerBody == LOWER_BODY_TYPE_TURTLE /* && ... */) {
+if ((!player.hasLizardScales() || [UNDER_BODY_TYPE_REPTILE, UNDER_BODY_TYPE_TURTLE].indexOf(player.underBody.type) == -1) && player.lowerBody == LOWER_BODY_TYPE_TURTLE /* && ... */) {
 	outputText("... You grow " + player.skin.tone + " scales on your skin!");
 	player.skin.setProps({
 		type: SKIN_TYPE_LIZARD_SCALES,
 		adj: "",
 		desc: "scales"
 	});
-	player.underBody.type = UNDER_BODY_TYPE_LIZARD;
+	player.underBody.type = UNDER_BODY_TYPE_REPTILE;
 	player.underBody.copySkin({ // copy the main skin props to the underBody skin ...
 		desc: "ventral scales"  // ... and only override the desc
 	});
@@ -195,7 +195,7 @@ if ((!player.hasLizardScales() || [UNDER_BODY_TYPE_LIZARD, UNDER_BODY_TYPE_TURTL
 }
 
 // Second step: The player grows the signature turtle shell on his/her belly
-if (player.hasLizardScales() && player.underBody.type == UNDER_BODY_TYPE_LIZARD && player.lowerBody == LOWER_BODY_TYPE_TURTLE /* && ... */) {
+if (player.hasLizardScales() && player.underBody.type == UNDER_BODY_TYPE_REPTILE && player.lowerBody == LOWER_BODY_TYPE_TURTLE /* && ... */) {
 	outputText("... The [underBody.skinFurScales] on your belly start to harden to become a sturdy frontal shell to protect your body as a natural armor");
 	player.underBody.type = UNDER_BODY_TYPE_TURTLE; // We're done, yay!
 	changes++;

--- a/classes/classes/BodyParts/Readme.md
+++ b/classes/classes/BodyParts/Readme.md
@@ -254,7 +254,7 @@ If set to true (the default), the underBody is restored before setting the other
 
 ##### Example
 ```as3
-player.setFurColor(catFurColors, {type: UNDER_BODY_TYPE_FUR}, true);
+player.setFurColor(catFurColors, {type: UNDER_BODY_TYPE_FURRY}, true);
 ```
 See the example above for potential `catFurColors`
 

--- a/classes/classes/Items/Consumables/Clovis.as
+++ b/classes/classes/Items/Consumables/Clovis.as
@@ -112,7 +112,7 @@ package classes.Items.Consumables
 				player.skinType = SKIN_TYPE_WOOL;
 				player.skinDesc = "wool";
 				player.setFurColor(sheepWoolColors, {
-					type: UNDER_BODY_TYPE_WOOL
+					type: UNDER_BODY_TYPE_FURRY
 				}, true);
 				changes++;
 			}

--- a/classes/classes/Items/Consumables/EmberTFs.as
+++ b/classes/classes/Items/Consumables/EmberTFs.as
@@ -113,7 +113,7 @@ package classes.Items.Consumables
 				           +" They are smooth and look nearly as tough as iron.");
 				player.skin.setProps({type: SKIN_TYPE_DRAGON_SCALES, adj: "tough", desc: "shield-shaped dragon scales"});
 				//def bonus of scales
-				player.underBody.type = UNDER_BODY_TYPE_DRAGON;
+				player.underBody.type = UNDER_BODY_TYPE_REPTILE;
 				player.underBody.copySkin({        // copy the main skin props to the underBody skin ...
 					desc: "ventral dragon scales"  // ... and only override the desc
 				});

--- a/classes/classes/Items/Consumables/Reptilum.as
+++ b/classes/classes/Items/Consumables/Reptilum.as
@@ -344,7 +344,7 @@ package classes.Items.Consumables
 					adj: "",
 					desc: "scales"
 				});
-				player.underBody.type = UNDER_BODY_TYPE_LIZARD;
+				player.underBody.type = UNDER_BODY_TYPE_REPTILE;
 				player.underBody.copySkin({ // copy the main skin props to the underBody skin ...
 					desc: "ventral scales", // ... and only override the desc
 					tone: newSkinTones[1]   // ... and the color (tone)

--- a/classes/classes/Items/Consumables/WhiskerFruit.as
+++ b/classes/classes/Items/Consumables/WhiskerFruit.as
@@ -311,7 +311,7 @@ package classes.Items.Consumables
 				outputText("\n\nYour " + player.skinDesc + " begins to tingle, then itch. ");
 				player.skinType = SKIN_TYPE_FUR;
 				player.skinDesc = "fur";
-				player.setFurColor(catFurColors, {type: UNDER_BODY_TYPE_FUR}, true);
+				player.setFurColor(catFurColors, {type: UNDER_BODY_TYPE_FURRY}, true);
 				outputText("You reach down to scratch your arm absent-mindedly and pull your fingers away to find strands of " + player.furColor + " fur. Wait, fur?  What just happened?! You spend a moment examining yourself and discover that <b>you are now covered in glossy, soft fur.</b>");
 				changes++;
 			}

--- a/classes/classes/Items/Consumables/WolfPepper.as
+++ b/classes/classes/Items/Consumables/WolfPepper.as
@@ -329,7 +329,7 @@ package classes.Items.Consumables
 				player.skinType = SKIN_TYPE_FUR;
 				player.skinDesc = "fur";
 				player.setFurColor(wolfFurColors, {
-					type: UNDER_BODY_TYPE_FUR
+					type: UNDER_BODY_TYPE_FURRY
 				}, true);
 				outputText("You reach down to scratch your arm absent-mindedly and pull your fingers away to find strands of " + player.furColor + " fur. You stare at it. Fur. Wait, you just grew fur?! What happened?! Your mind reeling, you do know one thing for sure: <b>you now have fur!</b>");
 				changes++;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -3742,7 +3742,7 @@ package classes.Items
 							colorChoices = KitsuneScene.basicKitsuneFur;
 				else
 					colorChoices = foxFurColors;
-				player.setFurColor(colorChoices, {type: UNDER_BODY_TYPE_FUR}, true);
+				player.setFurColor(colorChoices, {type: UNDER_BODY_TYPE_FURRY}, true);
 				changes++;
 			}
 			//[Grow Fox Legs]
@@ -4014,7 +4014,7 @@ package classes.Items
 			var tone:Array = mystic ? ["dark", "ebony", "ashen", "sable", "milky white"] : ["tan", "olive", "light"];
 			//[Change Skin Type: remove fur or scales, change skin to Tan, Olive, or Light]
 			var theFurColor:String = player.furColor;
-			if (player.hasFur() && player.underBody.type == UNDER_BODY_TYPE_FUR && player.furColor != player.underBody.skin.furColor)
+			if (player.hasFur() && player.underBody.type == UNDER_BODY_TYPE_FURRY && player.furColor != player.underBody.skin.furColor)
 				theFurColor = player.furColor + " and " + player.underBody.skin.furColor;
 
 			if ((player.hasFur() 

--- a/classes/classes/PlayerHelper.as
+++ b/classes/classes/PlayerHelper.as
@@ -65,8 +65,7 @@ package classes
 		public function hasReptileUnderBody(withSnakes:Boolean = false):Boolean
 		{
 			var underBodies:Array = [
-				UNDER_BODY_TYPE_LIZARD,
-				UNDER_BODY_TYPE_DRAGON,
+				UNDER_BODY_TYPE_REPTILE,
 			];
 
 			if (withSnakes) {

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1846,7 +1846,10 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		}
 		else
 			player.underBody = saveFile.data.underBody;
-		
+
+		if (player.underBody.type == UNDER_BODY_TYPE_DRAGON)
+			player.underBody.type = UNDER_BODY_TYPE_REPTILE;
+
 		//Sexual Stuff
 		player.balls = saveFile.data.balls;
 		player.cumMultiplier = saveFile.data.cumMultiplier;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1847,8 +1847,11 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		else
 			player.underBody = saveFile.data.underBody;
 
-		if (player.underBody.type == UNDER_BODY_TYPE_DRAGON)
-			player.underBody.type = UNDER_BODY_TYPE_REPTILE;
+		// Fix deprecated and merged underBody-types
+		switch (player.underBody.type) {
+			case UNDER_BODY_TYPE_DRAGON: player.underBody.type = UNDER_BODY_TYPE_REPTILE; break;
+			case UNDER_BODY_TYPE_WOOL:   player.underBody.type = UNDER_BODY_TYPE_FURRY;   break;
+		}
 
 		//Sexual Stuff
 		player.balls = saveFile.data.balls;

--- a/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
+++ b/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
@@ -1059,7 +1059,7 @@ public class ErlKingScene extends BaseContent implements Encounter
 				player.skinAdj = "";
 				player.skinDesc = "fur";
 				player.furColor = "brown";
-				player.underBody.type = UNDER_BODY_TYPE_FUR;
+				player.underBody.type = UNDER_BODY_TYPE_FURRY;
 				player.underBody.copySkin({furColor: "white"});
 				changes++;
 			}

--- a/classes/classes/Scenes/DebugMenu.as
+++ b/classes/classes/Scenes/DebugMenu.as
@@ -1381,7 +1381,7 @@ import classes.Items.*
 			player.skinAdj = "tough";
 			player.skinDesc = "shield-shaped dragon scales";
 			player.furColor = player.hairColor;
-			player.underBody.type = UNDER_BODY_TYPE_DRAGON;
+			player.underBody.type = UNDER_BODY_TYPE_REPTILE;
 			player.underBody.copySkin({        // copy the main skin props to the underBody skin ...
 				desc: "ventral dragon scales"  // ... and only override the desc
 			});

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -1,4 +1,4 @@
-// The comment structure in the following section is very specific, as the comment contents
+﻿// The comment structure in the following section is very specific, as the comment contents
 // are actually parsed into regexes that are used by my refactoring tool to refactor
 // the relevant descriptions.
 
@@ -225,8 +225,8 @@ public static const LOWER_BODY_TYPE_IMP:int                                     
 
 // underBody
 public static const UNDER_BODY_TYPE_NONE:int                                        =   0;
-public static const UNDER_BODY_TYPE_LIZARD:int                                      =   1;
-public static const UNDER_BODY_TYPE_DRAGON:int                                      =   2;
+public static const UNDER_BODY_TYPE_REPTILE:int                                     =   1;
+public static const UNDER_BODY_TYPE_DRAGON:int                                      =   2; // Deprecated. Changed to 1 (UNDER_BODY_TYPE_REPTILE) upon loading a savegame
 public static const UNDER_BODY_TYPE_FUR:int                                         =   3;
 public static const UNDER_BODY_TYPE_NAGA:int                                        =   4;
 public static const UNDER_BODY_TYPE_WOOL:int                                        =   5;

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -227,9 +227,9 @@ public static const LOWER_BODY_TYPE_IMP:int                                     
 public static const UNDER_BODY_TYPE_NONE:int                                        =   0;
 public static const UNDER_BODY_TYPE_REPTILE:int                                     =   1;
 public static const UNDER_BODY_TYPE_DRAGON:int                                      =   2; // Deprecated. Changed to 1 (UNDER_BODY_TYPE_REPTILE) upon loading a savegame
-public static const UNDER_BODY_TYPE_FUR:int                                         =   3;
+public static const UNDER_BODY_TYPE_FURRY:int                                       =   3;
 public static const UNDER_BODY_TYPE_NAGA:int                                        =   4;
-public static const UNDER_BODY_TYPE_WOOL:int                                        =   5;
+public static const UNDER_BODY_TYPE_WOOL:int                                        =   5; // Deprecated. Changed to 3 (UNDER_BODY_TYPE_FURRY) upon loading a savegame
 
 // piercingtypesNOPEDISABLED
 public static const PIERCING_TYPE_NONE:int                                          =   0;


### PR DESCRIPTION
`player.underBody.type` is mainly meant to give a hint, how to handle, respectively 'display' different underbodies. Its not necessary to have multiple underBody-types, when these are handled exactly the same way, hence why I merged a few of them.