### PR TITLE
Kitsune fur- and hairColor fixes

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -2670,6 +2670,22 @@ package classes
 			return skinType == SKIN_TYPE_PLAIN;
 		}
 
+		// Yet another workaround for Kitsunes ... (Stadler76)
+		public function get hairOrFurColors():String
+		{
+			if (!isFluffy())
+				return hairColor;
+
+			if (!underBody.skin.isFluffy())
+				return furColor;
+
+			// Uses formatStringArray in case we add more skin layers
+			return formatStringArray([
+				furColor,
+				underBody.skin.furColor,
+			]);
+		}
+
 		public function isBiped():Boolean
 		{
 			return legCount == 2;

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -2670,16 +2670,16 @@ package classes
 			return skinType == SKIN_TYPE_PLAIN;
 		}
 
-		// Yet another workaround for Kitsunes ... (Stadler76)
 		public function get hairOrFurColors():String
 		{
 			if (!isFluffy())
 				return hairColor;
 
-			if (!underBody.skin.isFluffy())
+			if (!underBody.skin.isFluffy() || ["no", furColor].indexOf(underBody.skin.furColor) != -1)
 				return furColor;
 
 			// Uses formatStringArray in case we add more skin layers
+			// If more layers are added, we'd probably need some remove duplicates function
 			return formatStringArray([
 				furColor,
 				underBody.skin.furColor,

--- a/classes/classes/Parser/singleArgLookups.as
+++ b/classes/classes/Parser/singleArgLookups.as
@@ -47,6 +47,7 @@
 				"hair"						: function(thisPtr:*):* { return kGAMECLASS.player.hairDescript(); },
 				"haircolor"					: function(thisPtr:*):* { return kGAMECLASS.player.hairColor; },
 				"hairorfur"					: function(thisPtr:*):* { return kGAMECLASS.player.hairOrFur(); },
+				"hairorfurcolors"			: function(thisPtr:*):* { return kGAMECLASS.player.hairOrFurColors; },
 				"he"						: function(thisPtr:*):* { return kGAMECLASS.player.mf("he", "she"); },
 				"he2"						: function(thisPtr:*):* { return kGAMECLASS.player2.mf("he", "she"); },
 				"him"						: function(thisPtr:*):* { return kGAMECLASS.player.mf("him", "her"); },

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1520,13 +1520,13 @@ use namespace kGAMECLASS;
 				kitsuneCounter++;
 			//If the character's kitsune score is greater than 1 and:
 			//If the character has "blonde","black","red","white", or "silver" hair, +1
-			if (kitsuneCounter > 0 && (InCollection(furColor, KitsuneScene.basicKitsuneHair) || InCollection(furColor, KitsuneScene.elderKitsuneColors)))
+			if (kitsuneCounter > 0 && (InCollection(hairOrFurColors, convertMixedToStringArray(KitsuneScene.basicKitsuneHair)) || InCollection(hairOrFurColors, KitsuneScene.elderKitsuneColors)))
 				kitsuneCounter++;
 			//If the character's femininity is 40 or higher, +1
 			if (kitsuneCounter > 0 && femininity >= 40)
 				kitsuneCounter++;
 			//If the character has fur, scales, or gooey skin, -1
-			if (hasFur() && !InCollection(furColor, KitsuneScene.basicKitsuneFur) && !InCollection(furColor, KitsuneScene.elderKitsuneColors))
+			if (hasFur() && !InCollection(hairOrFurColors, convertMixedToStringArray(KitsuneScene.basicKitsuneFur)) && !InCollection(hairOrFurColors, KitsuneScene.elderKitsuneColors))
 				kitsuneCounter--;
 			if (hasScales())
 				kitsuneCounter -= 2;

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -814,8 +814,8 @@ package classes
 			else if (player.tailType == TAIL_TYPE_FOX) 
 			{
 				if (player.tailVenom <= 1) 
-					outputText("  A swishing " + player.furColor + " fox's brush extends from your " + player.assDescript() + ", curling around your body - the soft fur feels lovely.");
-				else outputText("  " + Num2Text(player.tailVenom) + " swishing " + player.furColor + " fox's tails extend from your " + player.assDescript() + ", curling around your body - the soft fur feels lovely.");
+					outputText("  A swishing [hairOrFurColors] fox's brush extends from your [ass], curling around your body - the soft fur feels lovely.");
+				else outputText("  " + Num2Text(player.tailVenom) + " swishing [hairOrFurColors] fox's tails extend from your [ass], curling around your body - the soft fur feels lovely.");
 			}
 			else if (player.tailType == TAIL_TYPE_DRACONIC) 
 			{


### PR DESCRIPTION
Fixes #734

### Changes
- Added the getter `creature.hairOrFurColors` to return combined fur colors.
- Added the parser tag `[hairorforcolors]`
- `kitsuneScore()` should be working as intended again, too.