### PR TITLE
Updates and fixes for Cockatrices

### DIFF
--- a/classes/classes/Items/Consumables/GoblinAle.as
+++ b/classes/classes/Items/Consumables/GoblinAle.as
@@ -109,18 +109,16 @@ package classes.Items.Consumables
 			}
 			//GENERAL APPEARANCE STUFF BELOW
 			//REMOVAL STUFF
-			//Removes wings and antennaes!
+			//Removes wings!
 			if ((player.wingType === WING_TYPE_BEE_LIKE_SMALL || player.wingType === WING_TYPE_BEE_LIKE_LARGE || player.wingType >= WING_TYPE_HARPY) && changes < changeLimit && rand(4) === 0) {
 				if (player.wingType === WING_TYPE_SHARK_FIN) outputText("\n\nYour back tingles, feeling lighter.  Something lands behind you with a 'thump', and when you turn to look, you see your fin has fallen off.  This might be the best (and worst) booze you've ever had!  <b>You no longer have a fin!</b>");
 				else outputText("\n\nYour shoulders tingle, feeling lighter.  Something lands behind you with a 'thump', and when you turn to look you see your wings have fallen off.  This might be the best (and worst) booze you've ever had!  <b>You no longer have wings!</b>");
 				player.wingType = WING_TYPE_NONE;
 				changes++;
 			}
-			//Removes wings and antennaes!
-			if (player.antennae > ANTENNAE_NONE && changes < changeLimit && rand(3) === 0) {
-				outputText("\n\nYour " + player.hairDescript() + " itches so you give it a scratch, only to have your antennae fall to the ground.  What a relief.  <b>You've lost your antennae!</b>");
-				changes++;
-				player.antennae = ANTENNAE_NONE;
+			//Removes antennae!
+			if (player.antennae != ANTENNAE_NONE && changes < changeLimit && rand(3) === 0) {
+				mutations.removeAntennae();
 			}
 			//Remove odd eyes
 			if (changes < changeLimit && rand(5) === 0 && player.eyeType > EYES_HUMAN) {

--- a/classes/classes/Items/Consumables/RegularHummus.as
+++ b/classes/classes/Items/Consumables/RegularHummus.as
@@ -156,9 +156,7 @@ package classes.Items.Consumables
 			//-----------------------
 			//Removes antennae
 			if (player.antennae !== ANTENNAE_NONE && rand(3) === 0 && changes < changeLimit) {
-				outputText("\n\nThe muscles in your brow clench tightly, and you feel a tremendous pressure on your upper forehead.  When it passes, you touch yourself and discover your antennae have vanished!");
-				player.antennae = ANTENNAE_NONE;
-				changes++;
+				mutations.removeAntennae();
 			}
 			//Removes horns
 			if (changes < changeLimit && (player.hornType !== HORNS_NONE || player.horns !== 0) && rand(5) === 0) {

--- a/classes/classes/Items/Consumables/SnakeOil.as
+++ b/classes/classes/Items/Consumables/SnakeOil.as
@@ -70,10 +70,8 @@ package classes.Items.Consumables
 				changes++;
 			}
 			//Removes antennae
-			if (player.antennae > ANTENNAE_NONE && rand(3) === 0 && changes < changeLimit) {
-				outputText("\n\nThe muscles in your brow clench tightly, and you feel a tremendous pressure on your upper forehead.  When it passes, you touch yourself and discover your antennae have vanished!");
-				player.antennae = ANTENNAE_NONE;
-				changes++;
+			if (player.antennae != ANTENNAE_NONE && rand(3) === 0 && changes < changeLimit) {
+				mutations.removeAntennae();
 			}
 			//9c) II The tongue (sensitivity bonus, stored as a perk?)
 			if (changes === 0 && rand(3) === 0) {

--- a/classes/classes/Items/Consumables/TonOTrice.as
+++ b/classes/classes/Items/Consumables/TonOTrice.as
@@ -276,7 +276,9 @@ package classes.Items.Consumables
 				//Cock < 6 inches - increase by 1-2 inches
 				if (player.shortestCockLength() < 6 && rand(3) == 0 && changes < changeLimit) {
 					var increment:Number = player.increaseCock(player.shortestCockIndex(), 1 + rand(2));
-					outputText("Your [if (cocks > 1)shortest] cock fills to its normal size, but doesn’t just stop there. Your cock feels incredibly tight as a few more inches of length seem to pour out from your crotch. Your cock has gained " + increment + " inches.");
+					outputText("Your [if (cocks > 1)shortest] cock fills to its normal size, but doesn’t just stop there. Your cock feels incredibly"
+					          +" tight as a few more inches of length seem to pour out from your crotch."
+					          +" Your cock has gained "+ increment + " inches.");
 					changes++;
 				}
 
@@ -284,8 +286,8 @@ package classes.Items.Consumables
 				if (player.biggestCockLength() > 16 && rand(3) == 0 && changes < changeLimit) {
 					var idx:int = player.biggestCockIndex();
 						outputText("\n\nYou feel a tightness in your groin like someone tugging on your shaft from behind you. Once the sensation"
-						          +" fades you check inside your [lower armor] and see that your [if (cocks > 1)largest] [cock] has shrunk to a"
-						          +" slightly shorter length.");
+						          +" fades you check [if (hasLowerGarment)inside your [lowergarment]|your [multicock]] and see that your"
+						          +" [if (cocks > 1)largest] [cock] has shrunk to a slightly shorter length.");
 					player.cocks[idx].cockLength -= (rand(10) + 5) / 10;
 					if (player.cocks[idx].cockThickness > 3) {
 						outputText(" Your " + player.cockDescript(idx) + " definitely got a bit thinner as well.");
@@ -404,10 +406,7 @@ package classes.Items.Consumables
 			//Physical changes:
 			//Removes other antennae
 			if (player.hasNonCockatriceAntennae() && rand(3) == 0 && changes < changeLimit) {
-				outputText("\n\nThe muscles in your brow clench tightly, and you feel a tremendous pressure on your upper forehead."
-				          +" When it passes, you touch yourself and discover your antennae have vanished!");
-				player.antennae = ANTENNAE_NONE;
-				changes++;
+				mutations.removeAntennae();
 			}
 			//Gain antennae like feathers
 			if (player.antennae == ANTENNAE_NONE && player.faceType == FACE_COCKATRICE && player.earType == EARS_COCKATRICE && rand(3) == 0 && changes < changeLimit) {
@@ -492,7 +491,7 @@ package classes.Items.Consumables
 				          +" arm begins to shed. A coat of " + (player.hasCockatriceSkin() ? player.furColor : player.hairColor) + " feathers sprouts"
 				          +" from your skin, covering your upper arm and shoulder entirely, ending at your elbow in a fluffy cuff."
 				          +" A few long feathers decorate your elbows like vestigial wings. Your lower arm however as grown a layer thick leathery"
-				          +" scales and dangerous looking claws tip your fingers. As suddenly as the itching came it fades, leaving you to marvel"
+				          +" scales and dangerous looking talons tip your fingers. As suddenly as the itching came it fades, leaving you to marvel"
 				          +" over your new arms.");
 				outputText("\n<b>You now have cockatrice arms!</b>");
 				player.armType = ARM_TYPE_COCKATRICE;

--- a/classes/classes/Items/Consumables/WolfPepper.as
+++ b/classes/classes/Items/Consumables/WolfPepper.as
@@ -67,9 +67,7 @@ package classes.Items.Consumables
 			}
 			//remove antennae
 			if (player.antennae !== ANTENNAE_NONE && rand(3) === 0 && changes < changeLimit) {
-				outputText("\n\nYou tilt your head down as a wave of dizziness passes over you. Your antennae fall to the ground. You touch where they were on your head and confirm that they did indeed just fall off. <b>You have lost your antennae!</b>");
-				player.antennae = ANTENNAE_NONE;
-				changes++;
+				mutations.removeAntennae();
 			}
 			//remove horns
 			if ((player.hornType !== HORNS_NONE || player.horns > 0) && rand(3) === 0 && changes < changeLimit) {

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -163,6 +163,48 @@ package classes.Items
 			return false;
 		}
 
+		/**
+		 * Removes antennae and display different loss texts depending on the type, if any.
+		 * @param	inline  If true, display a short inline text (No bold part, no line breaks)
+		 * @return	true:   lost them, false: no change
+		 * @author	Stadler76
+		 */
+		public function removeAntennae(inline:Boolean = false):Boolean
+		{
+			if (player.antennae == ANTENNAE_NONE)
+				return false;
+
+			if (inline) {
+				switch (player.antennae) {
+					case ANTENNAE_COCKATRICE:
+					case ANTENNAE_BEE:
+					default:
+						outputText(" Antennae pop free, and float lightly down towards the floor. ");
+				}
+			} else {
+				switch (player.antennae) {
+					case ANTENNAE_COCKATRICE:
+						outputText("\n\nYou feel your antennae like feathers shrivel at the root, the pair of soft quills falling softly to the"
+						          +" ground as your pores close.");
+						outputText("\n<b>You’ve lost your antennae like feathers!</b>");
+						break;
+
+					case ANTENNAE_BEE:
+						outputText("\n\nYour [hair] itches so you give it a scratch, only to have your antennae fall to the ground. What a relief.");
+						outputText("\n<b>You've lost your antennae!</b>");
+						break;
+
+					default: // should not happen, but just in case ... (Stadler76)
+						outputText("\n\nThe muscles in your brow clench tightly, and you feel a tremendous pressure on your upper forehead."
+						          +" When it passes, you touch yourself and discover <b>your antennae have vanished</b>!");
+				}
+			}
+
+			player.antennae = ANTENNAE_NONE;
+			changes++;
+			return true;
+		}
+
 		public function removeBassyHair():Boolean
 		{
 			// Failsafe, duh

--- a/classes/classes/Parser/conditionalConverters.as
+++ b/classes/classes/Parser/conditionalConverters.as
@@ -1,6 +1,7 @@
 ﻿		//Calls are now made through kGAMECLASS rather than thisPtr. This allows the compiler to detect if/when a function is inaccessible.
 		import classes.GlobalFlags.kGAMECLASS;
 		import classes.Items.ArmorLib;
+		import classes.Items.UndergarmentLib;
 
 
 
@@ -24,6 +25,7 @@
 				"hour"				: function(thisPtr:*):* {return  kGAMECLASS.model.time.hours;},
 				"days"				: function(thisPtr:*):* {return  kGAMECLASS.model.time.days;},
 				"hasarmor"			: function(thisPtr:*):* {return  kGAMECLASS.player.armor != ArmorLib.NOTHING;},
+				"haslowergarment"	: function(thisPtr:*):* {return  kGAMECLASS.player.lowerGarment != UndergarmentLib.NOTHING;},
 				"tallness"			: function(thisPtr:*):* {return  kGAMECLASS.player.tallness;},
 				"hairlength"		: function(thisPtr:*):* {return  kGAMECLASS.player.hairLength;},
 				"femininity"		: function(thisPtr:*):* {return  kGAMECLASS.player.femininity;},

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -567,7 +567,7 @@ package classes
 				outputText("  Your arms are covered in " + (player.hasCockatriceSkin() ? player.furColor : player.hairColor) + " feathers from the"
 				          +" shoulder down to the elbow where they stop in a fluffy cuff. A handful of long feathers grow from your elbow in the form"
 				          +" of vestigial wings, and while they may not let you fly, they certainly help you jump. Your lower arm is coated in"
-				          +" leathery " + player.skinTone + " scales and your fingertips terminate in deadly looking reptilian claws.");
+				          +" leathery " + player.skinTone + " scales and your fingertips terminate in deadly looking avian talons.");
 			}
 			//Done with head bits. Move on to body stuff
 			// <mod name="BodyParts.UnderBody" author="Stadler76">

--- a/classes/classes/Scenes/Dungeons/Factory/OmnibusOverseerScene.as
+++ b/classes/classes/Scenes/Dungeons/Factory/OmnibusOverseerScene.as
@@ -183,10 +183,7 @@ package classes.Scenes.Dungeons.Factory
 					player.horns = 0;
 					player.hornType = HORNS_NONE;
 				}
-				if (player.antennae > ANTENNAE_NONE) {
-					outputText("Antennae pop free, and float lightly down towards the floor.  ");
-					player.antennae = ANTENNAE_NONE;
-				}
+				mutations.removeAntennae(true);
 			}
 			//EARS
 			if (player.earType != EARS_HUMAN) {

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -1506,9 +1506,7 @@ package classes.Scenes.Places.Bazaar
 				changes++;
 			}
 			if (rand(4) == 0 && changes < changeLimit && player.antennae != ANTENNAE_NONE) {
-				outputText("You feel heat blooming in your head, centered at your antennae. It is a feeling similar to the burn of alcohol. When you reach up to inspect them your hands find nothing but quickly dispersing smoke. <b>You no longer have a pair of antennae.</b>");
-				player.antennae = ANTENNAE_NONE;
-				changes++;
+				mutations.removeAntennae();
 			}
 			if (rand(3) == 0 && changes < changeLimit && player.cockTotal() == 1 && player.countCocksOfType(CockTypesEnum.HUMAN) == 0) {
 				outputText("\n\nYou feel a stirring in your loins as your cock grows rock hard. You " + player.clothedOrNakedLower("pull it out from your [armor], to ") + "take a look. It seems you now <b>have a human dick again</b>.");
@@ -1657,9 +1655,7 @@ package classes.Scenes.Places.Bazaar
 			}
 			//Removes antennaes!
 			if (rand(3) == 0 && changes < changeLimit && player.antennae > ANTENNAE_NONE) {
-				outputText("\n\nYour " + player.hairDescript() + " itches so you give it a scratch, only to have your antennae fall to the ground. What a relief. <b>You've lost your antennae!</b>");
-				changes++;
-				player.antennae = ANTENNAE_NONE;
+				mutations.removeAntennae();
 			}
 			//Hair turns back to normal
 			if (rand(4) == 0 && changes < changeLimit && player.hairType != HAIR_NORMAL) {


### PR DESCRIPTION
### Gameplay changes
- Cockatrice arms TF and desc: (reptilian) claws → (avian) talons
- Fixed an invalid parser tag, when Ton o' Trice shrinks your cock

### Internal changes
- Added the parser conditional `[if (haslowergarment)HERP|DERP]`
- Implemented `MutationsHelper.removeAntennae()`

### Notes
- If anyone refactors Creature.antennae to a more fitting name, remember to refactor the method name accordingly (e. g. `removeAntennae()` → `removeHeadMisc()` or whatever).
- If you don't like one or more of the antennae loss texts suggest a change or feel free to do it.
- I've added the bold '**You have lost your antennae!**' to every case, since that differs by type. Again, if you don't like it, suggest a change or change it yourself.
- I've applied this to all TFs and the omnibus overseer scene.
- Again: Texts and method name is subject to change, so suggest a change, a revert of one or more TFs and/or scenes or feel free to do it yourself. If you DIY it would be nice, if you'd point me to your plans, before filing a PR for this.