### PR TITLE
Re-enable non-master branch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,4 @@ env:
 branches:
   except:
     VanillaPlus
-  only:
-    master
+


### PR DESCRIPTION
This line disabled all branch builds, so feature branches can
not be run on the CI.