### PR TITLE
Show lust damage

### DIFF
--- a/classes/classes/Scenes/Areas/Lake/FetishCultist.as
+++ b/classes/classes/Scenes/Areas/Lake/FetishCultist.as
@@ -80,7 +80,7 @@ package classes.Scenes.Areas.Lake
 			else {
 				outputText("She suddenly starts mauling her shapely breasts, her fingers nearly disappearing briefly in the soft, full flesh, while fingering herself eagerly, emitting a variety of lewd noises.  You are entranced by the scene, the sexual excitement she's experiencing penetrating your body in warm waves coming from your groin.");
 			}
-			game.dynStats("lus", (player.lib/10 + player.cor/20) +4);
+			player.takeLustDamage((player.lib/10 + player.cor/20) +4), true);
 			if (player.lust >= player.maxLust())
 				doNext(game.combat.endLustLoss);
 			else doNext(game.combat.combatMenu);
@@ -103,7 +103,7 @@ package classes.Scenes.Areas.Lake
 				else if (player.cockTotal() > 0) outputText("  A sudden influx of pre-cum blurts out and streams down your " + player.multiCockDescriptLight() + ", painfully hardened by a vast amount of blood rushing to your groin.");
 				if (player.gender == 0) outputText("  Your genderless body is suddenly filled by a perverted warmth.");
 				outputText("\n\nYou notice that the young woman seems to have calmed down some.");
-				game.dynStats("lus", (lust/3 * (1 + player.cor/300)));
+				player.takeLustDamage((lust/3 * (1 + player.cor/300)), true);
 				lust -= 50;
 				if (lust < 0) lust = 10;
 			}

--- a/classes/classes/Scenes/Areas/Lake/FetishCultist.as
+++ b/classes/classes/Scenes/Areas/Lake/FetishCultist.as
@@ -80,7 +80,7 @@ package classes.Scenes.Areas.Lake
 			else {
 				outputText("She suddenly starts mauling her shapely breasts, her fingers nearly disappearing briefly in the soft, full flesh, while fingering herself eagerly, emitting a variety of lewd noises.  You are entranced by the scene, the sexual excitement she's experiencing penetrating your body in warm waves coming from your groin.");
 			}
-			player.takeLustDamage((player.lib/10 + player.cor/20) +4), true);
+			player.takeLustDamage((player.lib/10 + player.cor/20) +4, true);
 			if (player.lust >= player.maxLust())
 				doNext(game.combat.endLustLoss);
 			else doNext(game.combat.combatMenu);

--- a/classes/classes/Scenes/Areas/Lake/FetishZealot.as
+++ b/classes/classes/Scenes/Areas/Lake/FetishZealot.as
@@ -100,7 +100,7 @@ package classes.Scenes.Areas.Lake
 			//The Zealot seems to have taken on the appearance of a young adult wearing a student uniform of sorts; of course, this isn't any less perverted than any of the other costumes this man wears.  This one includes a number of loose straps that you're certain would cause large sections of his clothes to fall off if somebody pulled on them.
 			outputText("The Zealot student looks at you a little shyly and sticks a pencil in his mouth while pushing a hand in front of his groin, trying to hide a rather obvious bulge.  The whole scene is rather cute, and you feel incredibly aroused afterwards.");
 		}
-		game.dynStats("lus", (7+rand(player.lib/20+player.cor/20)));
+		player.takeLustDamage((7+rand(player.lib/20+player.cor/20)), true);
 		combatRoundOver();
 	}
 	//Special2: Lust transfer spell, it becomes more and 
@@ -108,7 +108,7 @@ package classes.Scenes.Areas.Lake
 	//higher, but he can use it at any time (like the cultist).
 	private function zealotSpecial2():void {
 		outputText("The zealot suddenly cries out and extends his arms towards you; your mind is suddenly overwhelmed with a massive wave of arousal as images of every kind of fetish you can imagine wash over you, all blended together.  After a moment you are able to recover, but you notice that the Zealot doesn't seem to be as aroused as before.");
-		game.dynStats("lus", lust/2);
+		player.takeLustDamage(lust/2, true);
 		lust /= 2;
 		combatRoundOver();
 	}
@@ -119,7 +119,7 @@ package classes.Scenes.Areas.Lake
 				outputText("\nYou notice that some kind of unnatural heat is flowing into your body from the wound");
 				if (player.inte > 50) outputText(", was there some kind of aphrodisiac on the knife?");
 				else outputText(".");
-				game.dynStats("lus", (player.lib / 20 + 5));
+				player.takeLustDamage((player.lib / 20 + 5), true);
 			}
 			super.postAttack(damage);
 		}

--- a/classes/classes/Scenes/Areas/Lake/GooGirl.as
+++ b/classes/classes/Scenes/Areas/Lake/GooGirl.as
@@ -85,7 +85,7 @@ package classes.Scenes.Areas.Lake
 		private function gooPlay():void
 		{
 			outputText("The goo-girl lunges, wrapping her slimy arms around your waist in a happy hug, hot muck quivering excitedly against you. She looks up, empty eyes confused by your lack of enthusiasm and forms her mouth into a petulant pout before letting go.  You shiver in the cold air, regretting the loss of her embrace.");
-			game.dynStats("lus", 3 + rand(3) + player.sens / 10);
+			player.takeLustDamage(3 + rand(3) + player.sens / 10, true);
 			combatRoundOver();
 		}
 
@@ -95,7 +95,7 @@ package classes.Scenes.Areas.Lake
 			outputText("The girl reaches into her torso, pulls a large clump of goo out, and chucks it at you like a child throwing mud. The slime splatters on your chest and creeps under your " + player.armorName + ", tickling your skin like fingers dancing across your body. ");
 			var damage:Number = 1;
 			player.takeDamage(damage, true);
-			game.dynStats("lus", 5 + rand(3) + player.sens / 10);
+			player.takeLustDamage( 5 + rand(3) + player.sens / 10, true);
 			combatRoundOver();
 		}
 

--- a/classes/classes/Scenes/Areas/Lake/GreenSlime.as
+++ b/classes/classes/Scenes/Areas/Lake/GreenSlime.as
@@ -22,7 +22,7 @@
 		
 		private function lustAttack():void {
 			outputText("The creature surges forward slowly with a swing that you easily manage to avoid.  You notice traces of green liquid spurt from the creature as it does, forming a thin mist that makes your skin tingle with excitement when you inhale it.");
-			game.dynStats("lus", player.lib / 10 + 8);
+			player.takeLustDamage(player.lib / 10 + 8, true);
 			doNext(game.playerMenu);
 		}
 		

--- a/classes/classes/Scenes/Areas/Mountain/HellHound.as
+++ b/classes/classes/Scenes/Areas/Mountain/HellHound.as
@@ -33,7 +33,7 @@ package classes.Scenes.Areas.Mountain
 				var temp:Number = 15 + rand(10);
 				outputText("Both the hellhound's heads breathe in deeply before blasting a wave of dark fire at you. While the flames don't burn much, the unnatural heat fills your body with arousal. ");
 				player.takeDamage(temp, true);
-				game.dynStats("lus", 20+(player.sens/10));
+				player.takeLustDamage(20+(player.sens/10), true);
 				statScreenRefresh();
 				if(player.HP <= 0) {
 					doNext(game.combat.endHpLoss);

--- a/classes/classes/Scenes/Areas/Mountain/InfestedHellhound.as
+++ b/classes/classes/Scenes/Areas/Mountain/InfestedHellhound.as
@@ -24,11 +24,11 @@ package classes.Scenes.Areas.Mountain
 					outputText("  The worms inside you begin moving and squirming. A few of your cum-soaked parasites crawl out from your shivering " + player.multiCockDescriptLight() + " as if attempting to meet the new arrivals.  You desperately want to brush them away, but the pleasure in your crotch is too good to fight, and you find yourself staying your hand as each and every one of the new worms makes it way into your " + player.multiCockDescriptLight() + ".");
 					if (player.balls > 0) outputText("  Your " + player.ballsDescriptLight() + " grow weightier as the worms settle into their new home, arousing you beyond measure.");
 					else outputText("  You can feel them shifting around inside you as they adjust to their new home, arousing you beyond measure.");
-					game.dynStats("lus", 10);
+					player.takeLustDamage(10, true);
 				}
 				else if (player.totalCocks() > 0) {
 					outputText("  The worms wriggle and squirm all over you, working their way towards your groin.  It tickles pleasantly, but you brush them away before they can get inside you.  The thought of being turned into a worm-dispensing cum fountain is horrifying, but it leaves you hard.");
-					game.dynStats("lus", (5 + Math.round(player.cor / 20)));
+					player.takeLustDamage((5 + Math.round(player.cor / 20)), true);
 				}
 				else if (player.hasVagina()) outputText("  Thankfully, the worms don't seem to want anything to do with you, and rapidly drop down to the ground.");
 			}
@@ -44,16 +44,16 @@ package classes.Scenes.Areas.Mountain
 						outputText(" wriggle");
 						if (player.balls == 0 && player.cockTotal() == 1) outputText("s");
 						outputText(" hotly, expelling a few of your own worms in response along with a dribble of thick pre-cum.   You wonder what it would feel like to let his worms crawl inside you...");
-						game.dynStats("lus", 10);
+						player.takeLustDamage(10, true);
 					} else {
 						CoC_Settings.error("Infested but no cock!");
-						game.dynStats("lus", 5);
+						player.takeLustDamage(5, true);
 						outputText("  The idea of being covered in the beast's infested seed arouses you slightly, but you shake your head violently and clear away the unwelcome thought.");
 					}
 				}
 				//if aroused by worms +5 lust:
 				else if (player.hasStatusEffect(StatusEffects.WormsOn) && !player.hasStatusEffect(StatusEffects.WormsHalf)) {
-					game.dynStats("lus", 5);
+					player.takeLustDamage(5, true);
 					outputText("  The idea of being covered in the beast's infested seed arouses you slightly, but you shake your head violently and clear away the unwelcome thought.");
 				}
 			}

--- a/classes/classes/Scenes/Areas/Plains/Gnoll.as
+++ b/classes/classes/Scenes/Areas/Plains/Gnoll.as
@@ -119,7 +119,7 @@ package classes.Scenes.Areas.Plains
 				outputText("The gnoll dances forward, then back, her whole body alive with sensual movement.  She catches the way you watch her and smirks, throwing in a hip-shake just for you.");
 				bonus += 6;
 			}
-			game.dynStats("lus", (bonus + 10 + player.lib/20 + rand(player.cor/20)));
+			player.takeLustDamage((bonus + 10 + player.lib/20 + rand(player.cor/20)), true);
 			outputText("\n");
 		}
 

--- a/classes/classes/Scenes/Areas/Plains/GnollSpearThrower.as
+++ b/classes/classes/Scenes/Areas/Plains/GnollSpearThrower.as
@@ -85,7 +85,7 @@ package classes.Scenes.Areas.Plains
 					outputText("\nYou notice that some kind of unnatural heat is flowing into your body from the wound");
 					if (player.inte > 50) outputText(", was there some kind of aphrodisiac on the knife?");
 					else outputText(".");
-					game.dynStats("lus", (player.lib/20 + rand(4) +1));
+					player.takeLustDamage((player.lib/20 + rand(4) +1), true);
 				}
 				if (lustVuln > 0 && player.armorName == "barely-decent bondage straps") {
 					if (!plural) outputText("\n" + capitalA + short + " brushes against your exposed skin and jerks back in surprise, coloring slightly from seeing so much of you revealed.");
@@ -193,7 +193,7 @@ package classes.Scenes.Areas.Plains
 					outputText("A glint enters the dark eyes of the gnoll before she strides forward and pivots.  A long, spotted leg snaps up and out to slam against your " + player.chestDesc());
 					if (player.biggestTitSize() >= 1) outputText(", sending a wave of pain through the sensitive flesh");
 					outputText(".  A small, traitorous part of you can't help but notice a flash of long, dark flesh beneath her loincloth even as you stagger back from the impact. ");
-					game.dynStats("lus", 2);
+					player.takeLustDamage(2, true);
 					player.takeDamage(damage, true);
 				}
 			}
@@ -206,12 +206,12 @@ package classes.Scenes.Areas.Plains
 			//<Hyena Attack 4 – Arousal Attack – Highly Successful>
 			if (player.cor + player.lib > chance + 50) {
 				outputText("A wry grin spreads across the gnoll's face before she sprints towards you.  Too fast to follow, she flies forward, and you desperately brace for an impact that doesn't come.  Instead of striking you, two spotted paws clamp behind your neck and pull your head down, planting your face against her leather loincloth.  A powerful, musky smell burns in your nose and the feel of firm flesh behind the flimsy leather leaves a tingling sensation along your face.  She holds you there, pressed against her groin for several moments, desire growing deep within your body, before you find the strength and will to pull away.  The amazon grins, letting you stumble back as you try to fight off the feel of her body.\n\n");
-				game.dynStats("lus", (25 + player.lib/20 + player.sens/5));
+				player.takeLustDamage((25 + player.lib/20 + player.sens/5), true);
 			}
 			//<Hyena Attack 4 – Arousal Attack – Mildly Successful>
 			else if (20 + player.cor + player.lib > chance) {
 				outputText("A lazy grin spreads across the gnoll's face before she sprints towards you.  Too fast to follow, she flies forward, and you desperately brace for an impact that doesn't come.  Instead of striking you, two spotted paws clamp behind your neck and pull your head down, planting your face against her leather loincloth.  A powerful, musky smell burns in your nose and the feel of firm flesh behind the flimsy leather leaves a tingling sensation along your face.  Instinctively, you tear away from the hold, stumbling away from the sensations filling your mind, though some desire remains kindled within you.");
-				game.dynStats("lus", (15 + player.lib/20 + player.sens/5));
+				player.takeLustDamage((15 + player.lib/20 + player.sens/5), true);
 			}
 			//<Hyena Attack 4 – Arousal Attack – Unsuccessful>
 			else {

--- a/classes/classes/Scenes/Areas/Plains/Satyr.as
+++ b/classes/classes/Scenes/Areas/Plains/Satyr.as
@@ -30,7 +30,7 @@ package classes.Scenes.Areas.Plains
 		private function satyrBate():void {
 			outputText("He glares at you, panting while his tongue hangs out and begins to masturbate.  You can nearly see his lewd thoughts reflected in his eyes, as beads of pre form on his massive cock and begin sliding down the erect shaft.");
 			//(small Libido based Lust increase, and increase lust)
-			game.dynStats("lus", (player.lib/5) +4);
+			player.takeLustDamage((player.lib/5) +4, true);
 			lust += 5;
 			combatRoundOver();
 		}
@@ -79,7 +79,7 @@ package classes.Scenes.Areas.Plains
 		private function bottleChug():void {
 			outputText("He whips a bottle of wine seemingly from nowhere and begins chugging it down, then lets out a bellowing belch towards you.  The smell is so horrible you cover your nose in disgust, yet you feel hot as you inhale some of the fetid scent.");
 			//(damage PC lust very slightly and raise the satyr's lust.)
-			game.dynStats("lus", (player.lib/5));
+			player.takeLustDamage(player.lib/5, true);
 			lust += 5;
 			combatRoundOver();
 		}
@@ -97,7 +97,7 @@ package classes.Scenes.Areas.Plains
 				outputText("You fall with a <b>THUD</b> and the Satyr doesn't even bother to undress you before he begins rubbing his massive cock on your body until he comes, soiling your [armor] and " + player.skinFurScales() + " with slimy, hot cum.  As it rubs into your body, you shiver with unwanted arousal.");
 				//large-ish sensitivity based lust increase if hit.)(This also relieves him of some of his lust, though not completely.)
 				lust -= 50;
-				game.dynStats("lus", (player.sens/5+20));
+				player.takeLustDamage((player.sens/5+20), true);
 			}
 			combatRoundOver();
 		}

--- a/classes/classes/Scenes/Areas/Swamp/AbstractSpiderMorph.as
+++ b/classes/classes/Scenes/Areas/Swamp/AbstractSpiderMorph.as
@@ -96,7 +96,7 @@ package classes.Scenes.Areas.Swamp
 				outputText("While " + mf("his", "her") + " venom pours into you, the spider-" + mf("boy", "girl") + " reaches into your gear to play with your " + player.nippleDescript(0) + ", and you moan like a whore from the dual stimulation of " + mf("his", "her") + " venom and nipple-play.\n\n");
 				if (hasVagina()) outputText("The saucy dominatrix exhausts her supply of aphrodisiac toxin for the moment and finally steps back, admiring her work and giving you a lewd wink.  You ");
 				else outputText("The confident male exhausts his supply of aphrodisiac toxin for the moment and finally steps back, admiring his work and giving you a lewd wink.  You ");
-				game.dynStats("lus", 60);
+				player.takeLustDamage(60, true);
 				if (player.lust >= player.maxLust()) outputText("wobble, utterly defeated and about to cave in to your lust.");
 				else outputText("struggle not to fall down and start masturbating on the spot.");
 				outputText("\n");
@@ -129,11 +129,11 @@ package classes.Scenes.Areas.Swamp
 					outputText("You react far too slowly, and before you can even think to dodge, " + mf("he", "she") + "'s bitten deep into you, pumping large squirts of venom deep into your body.  Unnatural heat rolls through you, pooling in your groin until you're lewdly bucking your hips against the spider-morph's thigh.  " + mf("He", "She") + " pulls out and steps back, ");
 					if (hasVagina()) outputText("casually cupping her breasts while you watch with venom-dilated eyes, slowly touching yourself.  Once she stops, you shake your head and master yourself, remembering that you're supposed to be fighting this " + mf("boy", "girl") + "!\n");
 					else outputText("casually tugging on his relatively short, girthy dick as you watch with venom-dilated eyes, slowly touching yourself.  Once he stops, you shake your head and master yourself, remembering that you're supposed to be fighting this " + mf("boy", "girl") + "!\n");
-					game.dynStats("lus", 50);
+					player.takeLustDamage(50, true);
 				}
 				else {
 					outputText("You react too slowly, and before you can dodge, " + mf("he", "she") + "'s bitten you, leaving behind a burning venom that warms your blood and stokes your lust.\n");
-					game.dynStats("lus", 30);
+					player.takeLustDamage(30, true);
 				}
 			}
 			combatRoundOver();

--- a/classes/classes/Scenes/Areas/Swamp/CorruptedDrider.as
+++ b/classes/classes/Scenes/Areas/Swamp/CorruptedDrider.as
@@ -58,12 +58,12 @@ package classes.Scenes.Areas.Swamp
 			
 			else if (!player.hasStatusEffect(StatusEffects.DriderKiss)) {
 				//(HIT? + 10 lust)
-				game.dynStats("lus", 10);
 				outputText("Before you can move, she's right on top of you, leaning ");
 				if (player.tallness < 72) outputText("down");
 				else outputText("over");
 				outputText(" to plant a sloppy, wet kiss upon your lips.  Her glossy lip-venom oozes everywhere, dribbling down your collective chins and sliding into your mouth.  You shudder, trying to resist, but your tongue betrays you.  It slides between her moist, puffy entrance, lapping at her venom and making love to her tongue.");
 				if (player.lust100 <= 99) outputText("  Somehow, you work up the willpower to back away, but your body slowly begins to burn hotter and harder, afflicted with a slowly-building lust.");
+				player.takeLustDamage(10, true);
 				player.createStatusEffect(StatusEffects.DriderKiss,0,0,0,0);
 			}
 			//Get hit 2nd time) 
@@ -71,10 +71,10 @@ package classes.Scenes.Areas.Swamp
 				player.addStatusValue(StatusEffects.DriderKiss,1,1);
 				if (player.statusEffectv1(StatusEffects.DriderKiss) == 1) {
 					//(HIT? + 15 lust)
-					game.dynStats("lus", 15);
 					outputText("Again, the drider ties your mouth up in her syrupy lip-lock, seeming to bind your mouth as effectively as her webs bind your body.  Her sweet venom bubbles and froths at the corners of the oral embrace, dripping over her many-breasted bosom and your " + player.chestDesc() + ".");
 					if (player.hasCock()) outputText("  " + player.SMultiCockDesc() + " spews a rope of pre-cum into your " + player.armorName + ", desperate to get out and fuck.");
 					if (player.hasVagina()) outputText("  Fem-cum dribbles down your " + player.legs() + " while your " + player.clitDescript() + " gets so hard you think it'll explode.");
+					player.takeLustDamage(15, true);
 					outputText("  This time, the drider is the one to break the kiss.  She asks, \"<i>Are you ready, my horny little morsel?</i>\"\n");
 					if (player.lust100 <= 99) outputText("You shake your head 'no' and stand your ground!\n");
 				}
@@ -82,7 +82,6 @@ package classes.Scenes.Areas.Swamp
 				else {
 					outputText("This time you barely move.  Your body is too entranced by the idea of another venom-laced kiss to resist.  Glorious purple goo washes into your mouth as her lips meet yours, sealing tight but letting your tongue enter her mouth to swirl around and feel the venom drip from her fangs.  It's heavenly!  Your [skin] grows hot and tingly, and you ache to be touched so badly.  Your " + player.nippleDescript(0) + "s feel hard enough to cut glass, and a growing part of you admits that you'd love to feel the drider's chitinous fingers pulling on them.");
 					//(HIT? + 20 lust)
-					game.dynStats("lus", 20);
 					if (player.hasCock() || player.hasVagina()) {
 						outputText("  The moisture in your crotch only gets worse.  At this point, a ");
 						if (player.wetness() < 3 && player.cumQ() < 200) outputText("small");
@@ -90,6 +89,7 @@ package classes.Scenes.Areas.Swamp
 						else outputText("massive");
 						outputText(" wet stain that reeks of your sheer sexual ache has formed in your " + player.armorName + ".");
 						if (player.lust100 <= 99) outputText("  Amazingly, you resist her and pull back, panting for breath.");
+						player.takeLustDamage(20, true);
 					}
 				}
 			}
@@ -99,13 +99,14 @@ package classes.Scenes.Areas.Swamp
 		public function driderMasturbate():void {
 			//-Masturbate - (Lowers lust by 50, raises PC lust)
 			lust -= 30;
-			game.dynStats("lus", (10+player.lib/20));
 			outputText("The spider-woman skitters back and gives you a lusty, hungry expression.  She shudders and moans, \"<i>Mmm, just watch what you're missing out on...</i>\"\n\n");
 			outputText("As soon as she finishes, her large clit puffs up, balloon-like.  A second later, it slides forward, revealing nine inches of glossy, girl-spunk-soaked shaft.  Nodules ring the corrupted penis' surface, while the tiny cum-slit perched atop the tip dribbles heavy flows of pre-cum.  She pumps at the fleshy organ while her other hand paws at her jiggling breasts, tugging on the hard ");
 			if (nipplesPierced > 0) outputText("pierced ");
 			outputText("nipple-flesh.  Arching her back in a lurid pose, she cries out in high-pitched bliss, her cock pulsing in her hand and erupting out a stream of seed that lands in front of her.\n\n");
 			
-			outputText("The display utterly distracts you until it finishes, and as you adopt your combat pose once more, you find your own needs harder to ignore, while hers seem to be sated, for now.\n");
+			outputText("The display utterly distracts you until it finishes, and as you adopt your combat pose once more, you find your own needs harder to ignore, while hers seem to be sated, for now.");
+			player.takeLustDamage((10+player.lib/20), true);
+			outputText("\n");
 			combatRoundOver();
 		}
 

--- a/classes/classes/Scenes/Areas/VolcanicCrag/Behemoth.as
+++ b/classes/classes/Scenes/Areas/VolcanicCrag/Behemoth.as
@@ -26,7 +26,7 @@ package classes.Scenes.Areas.VolcanicCrag
 		
 		public function tease():void {
 			outputText("\"Want a piece of this?\" the behemoth says, and you avert your eyes as he flips up his loincloth, his huge cock alluring under the red silk and gold chains.");
-			game.dynStats("lus", 10 + (player.cor / 10) + (player.lib / 10));
+			player.takeLustDamage(10 + (player.cor / 10) + (player.lib / 10), true);
 			combatRoundOver();
 		}
 		

--- a/classes/classes/Scenes/Dungeons/D3/Doppleganger.as
+++ b/classes/classes/Scenes/Dungeons/D3/Doppleganger.as
@@ -59,7 +59,7 @@ package classes.Scenes.Dungeons.D3
 
 				outputText("\n\n“<i>What’s the matter, [name]?</i>” " + player.mf("he", "she") +" breathes, staring lustfully into your eyes ;as " + player.mf("he", "she") +" sinks both hands into " + player.mf("his", "her") +" crotch and bends forward, forcing you close to " + player.mf("his", "her") +" face. “<i>Never tried it in front of a mirror? You were missing out on the nasty little tramp you are.</i>”");
 				
-				game.dynStats("lus", damage + (rand(7) - 3));
+				player.takeLustDamage(damage + (rand(7) - 3), true);
 			}
 			addTalkShit();
 		}

--- a/classes/classes/Scenes/Dungeons/D3/DriderIncubus.as
+++ b/classes/classes/Scenes/Dungeons/D3/DriderIncubus.as
@@ -398,7 +398,7 @@ package classes.Scenes.Dungeons.D3
 					outputText(" [vagina]");
 				outputText(" ache to be touched");
 			}
-			game.dynStats("lus",player.lib / 10 + player.cor / 10 + 15);
+			player.takeLustDamage(player.lib / 10 + player.cor / 10 + 15, true);
 			outputText(". Your body rebels against you under the unholy influence");
 			if (player.lust100 < 100)
 				outputText(", but the effect is fleeting, thankfully. You try to ignore the residual tingles. You can’t afford to lose this close to your goal!");
@@ -417,7 +417,7 @@ package classes.Scenes.Dungeons.D3
 		public function taintedMindAttackAttempt():void
 		{
 			outputText("You ready an attack, but find your hands groping your own body instead. Somehow the demon’s magic has made it impossible to strike at him, crossing wires that weren’t meant to be crossed. Frowning, you look down at your more aroused form, determined not to fall for this a second time.");
-			game.dynStats("lus",15);
+			player.takeLustDamage(15, true);
 		}
 		
 		private function constrictingThoughts():void
@@ -432,7 +432,7 @@ package classes.Scenes.Dungeons.D3
 			else
 			{
 				outputText(" The intensity overwhelms your ability to act, arousing and stunning you.");
-				game.dynStats("lus",player.lib / 15 + player.cor / 15 + 15);
+				player.takeLustDamage(player.lib / 15 + player.cor / 15 + 15, true);
 				player.createStatusEffect(StatusEffects.Stunned,0,0,0,0);
 			}
 		}
@@ -451,7 +451,7 @@ package classes.Scenes.Dungeons.D3
 			else
 			{
 				outputText(" You concentrate to try and throw it off, but he overwhelms your mental defenses. Clouds of swirling pink filled with unsubtle erotic silhouettes fill your vision, effectively blinding you!");
-				game.dynStats("lus",25);
+				player.takeLustDamage(25, true);
 				player.createStatusEffect(StatusEffects.PurpleHaze,2 + rand(2),0,0,0);
 				player.createStatusEffect(StatusEffects.Blind,player.statusEffectv1(StatusEffects.PurpleHaze),0,0,0);
 			}
@@ -508,7 +508,7 @@ package classes.Scenes.Dungeons.D3
 			outputText("Darting into the crowd, the goblin comes back with a bottle of unusual shape and design. She pops the cork and upends it across her petite but all-too-stacked form, smearing it across her more-than-ample tits with one hand, making them shine in the flickering candlelight. Her eyes are bright and mischievous while she spreads it over the rest of her form, leaving the whole of her body slick and ready for love.");
 			outputText("\n\nShe dances and spins to the side, cooing, <i>“Don’t you want me anymore, baby? Look how ready I am”</i> Her nipples are taut and stiff, and the junction between her thighs absolutely drenched. Neither you nor your foe can keep from sparing lusty glances her way.");
 			lust += 7;
-			game.dynStats("lus", 7);
+			player.takeLustDamage(7, true);
 		}
 		
 		public function freeGoblin():void

--- a/classes/classes/Scenes/Dungeons/D3/HermCentaur.as
+++ b/classes/classes/Scenes/Dungeons/D3/HermCentaur.as
@@ -114,14 +114,14 @@ package classes.Scenes.Dungeons.D3
 				else outputText(" your anus until it puckers, craving something to fill it - anything.");
 			}
 			
-			game.dynStats("lus+", 8 + (player.lib / 10) + (player.sens / 10));
+			player.takeLustDamage(8 + (player.lib / 10) + (player.sens / 10), true);
 		}
 		
 		private function aphrodisiacSquirt():void
 		{
 			outputText("The centaur grabs her heavy tits and casually squeezes the prodding, hard nipples that cap them.  A trickle of rose moisture trickles out, dripping down the underside of her bust to glisten wetly in the light.  Spellbound for the moment, you look on in wonder at the display of demonic lactations.  A faint sweetness lingers in the air, and you lick your lips without meaning to.  Then, she squeezes down to spray a torrent of pink-tinged breastmilk directly at you, splitting into so many forks of fluid that you have no hope to dodge.");
 			
-			game.dynStats("lus+", 8 + (player.lib / 10) + (player.sens / 10));
+			player.takeLustDamage(8 + (player.lib / 10) + (player.sens / 10), true);
 
 	if (player.lust100 < 30) outputText("\n\nYou close your mouth tight and endure the shimmering shower, trying your damnedest to resist the effects of this insidious liquid.  Wherever it strikes you, it vanishes soon after, absorbed directly into your body.");
 	else if (player.lust100 < 40) outputText("\n\nYour heart beats faster.");
@@ -179,7 +179,7 @@ package classes.Scenes.Dungeons.D3
 				//(OH SHIT YOU GUNNA GET FUKKED)
 				outputText("The chanting reaches a crescendo before you can stop it, and as the nine-foot woman points at you, you barely have time to enunciate a single curse.  Her spell is upon you.  There's a flash of crimson light, seemingly as bright as the sun, and then you're hit with a wave of lust so strong it might as well be a physical force.  It slaps you hard enough to send you reeling, even while your heart pumps every spare drop of blood south.  You cry out at the forced arousal, blubbering wildly as the pleasure mounts and images of you and your foe locked together in every sexual position imaginable flood your consciousness.");
 				
-				game.dynStats("lus+", 20 + (player.lib / 6) + (player.sens / 6));
+				player.takeLustDamage(20 + (player.lib / 6) + (player.sens / 6), true);
 			}
 		}
 		
@@ -204,7 +204,7 @@ package classes.Scenes.Dungeons.D3
 			// Resistance-esque check, idk I threw this terrible shit together
 			if (player.inte * (2 / _hypnoCockUses) > rand((player.lib / 3) + (player.sens / 3) + (player.cor / 3)))
 			{
-				game.dynStats("lus+", 2 + rand((player.lib / 20) + (player.sens / 20)));
+				player.takeLustDamage(2 + rand((player.lib / 20) + (player.sens / 20)), true);
 				
 				if (player.lust100 <= 33) outputText("\n\nA warning thought jars you out of the cock-induced reverie with a start - this demon was going to hypnotize you, likely trying to seduce you into submission.  Not this time!  You tear yourself away and look her in the eye triumphantly.");
 				else if (player.lust100 <= 66) outputText("\n\nA quiet voice pipes up somewhere inside you and warns that something is amiss.  It's enough to stir you from your stupor, kindling your willpower to wrest your view from your foe's gently bobbing fuck-log.  You look her in the eye triumphantly.");
@@ -212,7 +212,7 @@ package classes.Scenes.Dungeons.D3
 			}
 			else
 			{
-				game.dynStats("lus+", 20 + 2 * _hypnoCockUses + 2 + rand((player.lib / 10) + (player.sens / 10)));
+				player.takeLustDamage(20 + 2 * _hypnoCockUses + 2 + rand((player.lib / 10) + (player.sens / 10)), true);
 				
 				outputText("Down it bobs, slowly hanging lower and lower... SMACK!  Up it goes, taking your bedazzled eyes along for the ride.  \"<i>That's a good " + player.mf("boy", "girl") + ",</i>\" the dick's director whispers, \"<i>Just follow the tempo and let it fill your mind, oozing inside you with each thump.</i>\"");
 				outputText("\n\nFuck!  She's right, it's getting awfully hard to think about anything else.  You fixate further on the cock, unwilling or unable to look away.");
@@ -244,7 +244,7 @@ package classes.Scenes.Dungeons.D3
 			outputText("\n\nFlushing, the demoness whimpers, \"<i>...don't think I can do that again, but I don't think you'll be able to turn me on like that twice!</i>\"");
 			
 			this.lust = 0;
-			game.dynStats("lus", 15);
+			player.takeLustDamage(15, true);
 		}
 		
 		private function healUp():void

--- a/classes/classes/Scenes/Dungeons/D3/JeanClaude.as
+++ b/classes/classes/Scenes/Dungeons/D3/JeanClaude.as
@@ -65,7 +65,7 @@ package classes.Scenes.Dungeons.D3
 					}
 					
 					applyTease(lustDelta);
-					game.dynStats("lus+", 20);
+					player.takeLustDamage(20, true);
 				}
 			}
 			else
@@ -73,7 +73,7 @@ package classes.Scenes.Dungeons.D3
 				outputText("\n\n“<i>Even when made the fool, still you try it, still you think you can entice me with things I have seen a thousand times before,</i>” Jean-Claude sighs. “<i>Why not give up, interloper? You do these things because they arouse YOU, not because you hope they arouse me. Give up, and embrace the life you were born to lead.</i>” Despite these words his hungry eyes remain on your body. Perhaps he can’t help it. You can only hope...");
 				
 				if (successful) applyTease(lustDelta);
-				game.dynStats("lus+", 20);
+				player.takeLustDamage(20, true);
 			}
 		}
 		

--- a/classes/classes/Scenes/Dungeons/D3/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/D3/Lethice.as
@@ -206,7 +206,7 @@ package classes.Scenes.Dungeons.D3
 			{
 				l = l * 1.25;
 			}
-			game.dynStats("lus",l);
+			player.takeLustDamage(l, true);
 			if (player.lust100 <= 30)
 			{
 				outputText("\n\nYou feel strangely warm.");
@@ -419,7 +419,7 @@ package classes.Scenes.Dungeons.D3
 				{
 					l = l * 1.25;
 				}
-				game.dynStats("lus",l);
+				player.takeLustDamage(l, true);
 			}
 			else if (player.lust100 <= 66)
 			{
@@ -429,7 +429,7 @@ package classes.Scenes.Dungeons.D3
 				{
 					l = l * 1.25;
 				}
-				game.dynStats("lus",l);
+				player.takeLustDamage(l, true);
 			}
 			else
 			{
@@ -439,7 +439,7 @@ package classes.Scenes.Dungeons.D3
 				{
 					l = l * 1.25;
 				}
-				game.dynStats("lus",l);
+				player.takeLustDamage(l, true);
 			}
 		}
 		
@@ -470,7 +470,7 @@ package classes.Scenes.Dungeons.D3
 				{
 					l = l * 1.25;
 				}
-				game.dynStats("lus",l);
+				player.takeLustDamage(l, true);
 			}
 		}
 		
@@ -539,12 +539,12 @@ package classes.Scenes.Dungeons.D3
 			else if (evade == EVASION_EVADE)
 			{
 				outputText(" You at least manage to close your eyes before the wave of spooge hits you, splattering all over your [armor].");
-				game.dynStats("lus",5);
+				player.takeLustDamage(5, true);
 			}
 			else
 			{
 				outputText(" You take a huge, fat, musky glob of spunk right to the eyes! You yelp in alarm, trying to wipe the salty, burning demonic cock-cream out, but it's simply too thick! Yuck!");
-				game.dynStats("lus",5);
+				player.takeLustDamage(5, true);
 				player.createStatusEffect(StatusEffects.Blind,2 + rand(2),0,0,0);
 			}
 		}
@@ -834,7 +834,7 @@ package classes.Scenes.Dungeons.D3
 				{
 					l = l * 1.25;
 				}
-				game.dynStats("lus",l);
+				player.takeLustDamage(l, true);
 				damage = str + weaponAttack - rand(player.tou);
 				outputText(" You can’t avoid them all! One clips you on its way past, ripping into your [skin] and leaving you feeling... flushed and hot in its wake.");
 				if (player.hasCock() && rand(player.tou + 50) < 25) {

--- a/classes/classes/Scenes/Dungeons/D3/MinotaurKing.as
+++ b/classes/classes/Scenes/Dungeons/D3/MinotaurKing.as
@@ -213,7 +213,7 @@ package classes.Scenes.Dungeons.D3
 				else
 					outputText(" Why did you do that? And why did it feel so good.");
 			}
-			game.dynStats("lus",15 + player.lib / 20);
+			player.takeLustDamage(15 + player.lib / 20, true);
 		}
 		
 		private function battleaxe():void
@@ -248,12 +248,12 @@ package classes.Scenes.Dungeons.D3
 				if (player.lust100 > 75)
 				{
 					outputText("swallowing it into your mouth without thinking.  ");
-					game.dynStats("lus",15 + player.lib / 10);
+					player.takeLustDamage(15 + player.lib / 10, true);
 				}
 				else
 				{
 					outputText("feeling your heart beat with desire as your tongue licks the residue from your lips.  ");
-					game.dynStats("lus",7.5 + player.lib / 20);
+					player.takeLustDamage(7.5 + player.lib / 20, true);
 				}
 			}
 			else
@@ -261,7 +261,7 @@ package classes.Scenes.Dungeons.D3
 				outputText("right past your head.  ");
 			}
 			outputText("The animalistic scent of it seems to get inside you, the musky aroma burning a path of liquid heat to your groin.");
-			game.dynStats("lus",15 + player.lib / 20);
+			player.takeLustDamage(15 + player.lib / 20, true);
 			if (player.findPerk(PerkLib.MinotaurCumAddict) >= 0 || flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] == 2)
 			{
 				if (rand(2) == 0)
@@ -272,7 +272,7 @@ package classes.Scenes.Dungeons.D3
 				{
 					outputText("\n<b>You groan and lick your lips over and over, craving the taste of him in your mouth.</b>");
 				}
-				game.dynStats("lus",5 + rand(5));
+				player.takeLustDamage(5 + rand(5), true);
 			}
 		}
 		
@@ -318,7 +318,7 @@ package classes.Scenes.Dungeons.D3
 				{
 					outputText("Excellia rises up onto her knees and arches her back to display her monumental mammaries, letting their chocolatey nipples jut accusingly in your direction. Her fingers travel to them, squeezing out thin flows of milk that she gathers and smears across each orb in turn, rubbing it into her skin like high-grade massage oil. When she’s finished, her tits are shining, and you’re a little hotter under the collar.");
 				}
-				game.dynStats("lus",5);
+				player.takeLustDamage(5, true);
 			}
 		}
 		

--- a/classes/classes/Scenes/Dungeons/D3/SuccubusGardener.as
+++ b/classes/classes/Scenes/Dungeons/D3/SuccubusGardener.as
@@ -237,8 +237,8 @@ this.HP = this.maxHP();
 				if (player.findPerk(PerkLib.Juggernaut) < 0 && armorPerk != "Heavy") {
 					player.takeDamage(75 + rand(15));
 				}
-				game.dynStats("lus+", 3 + rand(3));
-				if (flags[kFLAGS.PC_FETISH] >= 2) game.dynStats("lus+", 5);
+				player.takeLustDamage(3 + rand(3), true);
+				if (flags[kFLAGS.PC_FETISH] >= 2) player.takeLustDamage(7, true);
 				combatRoundOver();
 			}
 		}
@@ -265,7 +265,7 @@ this.HP = this.maxHP();
 			if (player.findPerk(PerkLib.Juggernaut) < 0 && armorPerk != "Heavy") {
 				player.takeDamage(75 + rand(15));
 			}
-			game.dynStats("lus+", 3 + rand(3));
+			player.takeLustDamage(3 + rand(3), true);
 			combatRoundOver();
 		}
 		
@@ -288,7 +288,7 @@ this.HP = this.maxHP();
 			if (damage >= 0)
 			{
 				var sL:Number = player.lust;
-				game.dynStats("lus+", damage);
+				player.takeLustDamage(damage, true);
 				sL = Math.round(player.lust - sL);
 				outputText(" The sinuous plant-based tentacles lash at you like a dozen tiny whips! Preparing for stinging pain, you're somewhat taken aback when they pull back at the last moment, sensually caressing your most sensitive places! (" + sL + ")");
 			}
@@ -321,7 +321,7 @@ this.HP = this.maxHP();
 		
 		private function showerDotEffect():void
 		{
-			game.dynStats("lus+", 2 + rand(2));
+			player.takeLustDamage(2 + rand(2), true);
 			
 			player.addStatusValue(StatusEffects.ShowerDotEffect, 1, -1);
 			
@@ -413,7 +413,7 @@ this.HP = this.maxHP();
 			if (this.hasStatusEffect(StatusEffects.LustAura))
 			{
 				outputText("  Your eyes cross with unexpected feelings as the taste of desire in the air worms its way into you.  The intense aura quickly subsides, but it's already done its job.");
-				game.dynStats("lus", (8+int(player.lib/20 + player.cor/25)));
+				player.takeLustDamage((8+int(player.lib/20 + player.cor/25)), true);
 			}
 			else 
 			{
@@ -434,7 +434,8 @@ this.HP = this.maxHP();
 				outputText("\n\nIt hangs there for a moment while the succubus yanks your mouth open, just in time to receive the undoubtedly drugged jism. It practically sizzles on your tongue, tasting of almonds and walnuts with a distinctly fruity aftertaste. Your mouth gulps it down automatically, and with slow-dawning comprehension, you understand how the succubus could be so obsessed with these plants. Your groin heats eagerly as the plant spunk absorbs into your system. Your pupils dilate. Gods, it feels good!");
 				
 				outputText("\n\nYou barely even realize that the temptress has stepped away. How can you fight this?");
-				game.dynStats("lus", (8 + int(player.lib / 20 + player.cor / 25)), "cor+", 5);
+				player.takeLustDamage(8 + int(player.lib / 20 + player.cor / 25), true);
+				game.dynStats("cor+", 5);
 			}
 			else
 			{

--- a/classes/classes/Scenes/Dungeons/DeepCave/EncapsulationPod.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/EncapsulationPod.as
@@ -25,12 +25,13 @@ package classes.Scenes.Dungeons.DeepCave
 				}
 				if (player.hasVagina()) outputText(player.vaginaDescript() + " ");
 				else if (player.balls == 0) outputText("taint ");
-				outputText("as they climb ever-further up your body.  In spite of yourself, you feel the touch of arousal licking at your thoughts.\n");
+				outputText("as they climb ever-further up your body.  In spite of yourself, you feel the touch of arousal licking at your thoughts.");
 				if (player.lust < 35) {
-					game.dynStats("lus", 1);
+					player.takeLustDamage(1, true);
 					player.lust = 35;
 					statScreenRefresh();
 				}
+				outputText("\n");
 			}
 			//[Round 2 Action]
 			else if (statusEffectv1(StatusEffects.Round) == 2) {
@@ -69,12 +70,13 @@ package classes.Scenes.Dungeons.DeepCave
 				outputText("belly as they get closer and closer to ");
 				if (player.biggestTitSize() < 1) outputText("your chest");
 				else outputText("the underside of your " + player.allBreastsDescript());
-				outputText(".  Gods above, this is turning you on!  Your lower body is being violated in every conceivable way and it's only arousing you more.  Between the mind-numbing smell and the sexual assault you're having a hard time focusing.\n");
+				outputText(".  Gods above, this is turning you on!  Your lower body is being violated in every conceivable way and it's only arousing you more.  Between the mind-numbing smell and the sexual assault you're having a hard time focusing.");
 				if (player.lust < 65) {
-					game.dynStats("lus", 1);
+					player.takeLustDamage(1, true);
 					player.lust = 65;
 					statScreenRefresh();
 				}
+				outputText("\n");
 			}
 			//[Round 3 Action]
 			else if (statusEffectv1(StatusEffects.Round) == 3) {
@@ -82,12 +84,13 @@ package classes.Scenes.Dungeons.DeepCave
 				if (player.hasFuckableNipples()) outputText("  Proof of your arousal leaks from each " + player.nippleDescript(0) + " as their entrances part for the probing tentacles.  They happily dive inside to begin fucking your breasts, doubling your pleasure.");
 				outputText("  Moans escape your mouth as your hips begin to rock in time with the tentacles and the pulsing luminance of your fungus-pod.  It would be easy to lose yourself here.  You groan loudly enough to startle yourself back to attention.  You've got to get out!\n\n");
 				
-				outputText("The tentacles that aren't busy with your " + player.allBreastsDescript() + " are already climbing higher, and the slime has reached your waist.  If anything it actually makes the constant violation more intense and relaxing.  You start to sink down into it, but catch yourself and pull yourself back up.  No! You've got to fight!\n");
+				outputText("The tentacles that aren't busy with your " + player.allBreastsDescript() + " are already climbing higher, and the slime has reached your waist.  If anything it actually makes the constant violation more intense and relaxing.  You start to sink down into it, but catch yourself and pull yourself back up.  No! You've got to fight!");
 				if (player.lust < 85) {
-					game.dynStats("lus", 1);
+					player.takeLustDamage(1, true);
 					player.lust = 85;
 					statScreenRefresh();
 				}
+				outputText("\n");
 			}
 			//[Round 4 Action]
 			else {

--- a/classes/classes/Scenes/Dungeons/DeepCave/ImpHorde.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/ImpHorde.as
@@ -16,7 +16,7 @@ package classes.Scenes.Dungeons.DeepCave
 			//(½ chance during any round):
 			if (rand(2) == 0) {
 				outputText("\nOne of the tiny demons latches onto one of your " + player.legs() + " and starts humping it.  You shake the little bastard off and keep fighting!");
-				game.dynStats("lus", 1);
+				player.takeLustDamage(1, true);
 			}
 			combatRoundOver();
 		}
@@ -29,7 +29,6 @@ package classes.Scenes.Dungeons.DeepCave
 			else {
 				//(OH SHIT IT GOES OFF) 
 				//+50 lust!
-				game.dynStats("lus", 50);
 				outputText("The imps in the back finish their spell-casting, and point at you in unison.  A wave of pure arousal hits you with the force of a freight train.   Your equipment rubs across your suddenly violently sensitive " + player.nippleDescript(0));
 				if (player.biggestLactation() > 1) outputText(" as they begin to drip milk");
 				outputText(".  The lower portions of your coverings ");
@@ -44,6 +43,7 @@ package classes.Scenes.Dungeons.DeepCave
 					if (player.getClitLength() > 3) outputText(" as your clit swells up in a more sensitive imitation of a cock");
 				}
 				if (player.gender == 0) outputText("rub the sensitive skin of your thighs and featureless groin in a way that makes you wish you had a sex of some sort");
+				player.takeLustDamage(50, true);
 				outputText(".\n");
 				removeStatusEffect(StatusEffects.ImpUber);
 			}
@@ -107,7 +107,7 @@ package classes.Scenes.Dungeons.DeepCave
 					if (damage == 3) outputText("Seed lands in your " + player.hairDescript() + ", slicking you with demonic fluid.\n");
 					if (damage == 4) outputText("Another blast of jizz splatters against your face, coating your lips and forcing a slight taste of it into your mouth.\n");
 					if (damage == 5) outputText("The last eruption of cum soaks your thighs and the lower portions of your " + player.armorName + ", turning it a sticky white.\n");
-					game.dynStats("lus", (7+int(player.lib/40+player.cor/40)));
+					player.takeLustDamage((7+int(player.lib/40+player.cor/40)), true);
 				}
 				lust -= 5;
 				hits--;

--- a/classes/classes/Scenes/Dungeons/DeepCave/Vala.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/Vala.as
@@ -14,15 +14,15 @@ package classes.Scenes.Dungeons.DeepCave
 			//Lightly wounded.
 			if (HPRatio() > .7) {
 				outputText("  The sweet-smelling cloud rapidly fills the room, but the volume of mist is low enough that you don't end up breathing in that much of it.  It does make your pulse quicken in the most pleasant way though...");
-				game.dynStats("lus", 5 + player.lib/20);
+				player.takeLustDamage(5 + player.lib/20, true);
 			}
 			else if (HPRatio() > .4) {
 				outputText("  The rose-colored vapor spreads throughout the room, forcing you to breathe it in or pass out from lack of air.  It smells sweet and makes your head swim with sensual promises and your crotch tingle with desire.  Panicked by the knowledge that you're being drugged, you gasp, but it only draws more of the rapidly dissipating cloud into your lungs, fueling your lust.");
-				game.dynStats("lus", 10 + player.lib/20);
+				player.takeLustDamage(10 + player.lib/20, true);
 			}
 			else {
 				outputText("  The cloying, thick cloud of pink spools out from her mouth and fills the room with a haze of bubblegum-pink sweetness.  Even the shallowest, most experimental breath makes your heart pound and your crotch thrum with excitement.  You gasp in another quick breath and sway back and forth on your feet, already on the edge of giving in to the faerie.");
-				game.dynStats("lus", 30 + player.lib/10);
+				player.takeLustDamage(30 + player.lib/10, true);
 			}
 			combatRoundOver();
 		}
@@ -40,13 +40,13 @@ package classes.Scenes.Dungeons.DeepCave
 				createStatusEffect(StatusEffects.Milk,5,0,0,0);
 				outputText("You aren't sure if there's something in her milk, the dust, or just watching her squirt and shake for you, but it's turning you on.");
 			}
-			game.dynStats("lus", statusEffectv1(StatusEffects.Milk) + player.lib/20);
+			player.takeLustDamage(statusEffectv1(StatusEffects.Milk) + player.lib/20, true);
 			combatRoundOver();
 		}
 		//Masturbation
 		public function valaMasturbate():void {
 			outputText("The mind-fucked faerie spreads her alabaster thighs and dips a finger into the glistening slit between her legs, sliding in and out, only pausing to circle her clit.  She brazenly masturbates, putting on quite the show.  Vala slides another two fingers inside herself and finger-fucks herself hard, moaning and panting lewdly.  Then she pulls them out and asks, \"<i>Did you like that?  Will you fuck Vala now?</i>\"");
-			game.dynStats("lus", 4 + player.cor/10);
+			player.takeLustDamage(4 + player.cor/10, true);
 			combatRoundOver();
 		}
 

--- a/classes/classes/Scenes/Dungeons/DeepCave/Zetaz.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/Zetaz.as
@@ -51,7 +51,7 @@ package classes.Scenes.Dungeons.DeepCave
 				outputText("The imp lord shudders from his wounds and the pulsing member that's risen from under his tattered loincloth.  He strokes it and murmurs under his breath for a few moments.  You're so busy watching the spectacle of his masturbation that you nearly miss the sight of his bruises and wounds closing!  Zetaz releases his swollen member, and it deflates slightly.  He's used some kind of black magic to convert some of his lust into health!");
 				addHP(0.25 * maxHP());
 				lust -= 20;
-				game.dynStats("lus", 2);
+				player.takeLustDamage(2, true);
 			}
 			else {
 				var attackChoice:Number = rand(3);

--- a/classes/classes/Scenes/Dungeons/DesertCave/SandMother.as
+++ b/classes/classes/Scenes/Dungeons/DesertCave/SandMother.as
@@ -91,7 +91,7 @@ package classes.Scenes.Dungeons.DesertCave
 		public function getWhispered():void {
 			outputText("Mouthing, \"<i>Can you hear me?</i>\" the witch's voice intrudes into your mind, matching her mouth word for word.  She floods your psyche with words and thoughts, all of your defeat or submission, each more degrading and more humiliating than the last.  Perhaps the worst are the ones where she turns you over to Lethice after you're broken...  The tumultuous thoughts and emotions both stun and arouse you, preventing you from attacking while you try to clear your beleaguered consciousness.");
 			player.createStatusEffect(StatusEffects.Whispered,0,0,0,0);
-			game.dynStats("lus", 15);
+			player.takeLustDamage(15, true);
 			combatRoundOver();
 		}
 		public function sandStormAttack():void {

--- a/classes/classes/Scenes/Dungeons/DesertCave/SandWitchMob.as
+++ b/classes/classes/Scenes/Dungeons/DesertCave/SandWitchMob.as
@@ -103,7 +103,7 @@ package classes.Scenes.Dungeons.DesertCave
 					
 				}
 				player.createStatusEffect(StatusEffects.LustStones,bonus,0,0,0);
-				game.dynStats("lus", bonus * 2 + 5 + player.sens/7);
+				player.takeLustDamage(bonus * 2 + 5 + player.sens/7, true);
 			}
 			//[If attack misses]
 			else {
@@ -118,7 +118,7 @@ package classes.Scenes.Dungeons.DesertCave
 		public function drankSomeMialk():void {
 			outputText("One of the blonde beauties turns to another and asks, \"<i>A drink, sister?  Fighting this intruder has given me a powerful thirst.</i>\"  The other woman wordlessly opens her robe, baring her breasts, exposing four heaving, milk-fueled mounds to the air before the other woman claims a nipple for herself.  Three others crowd in on the exposed teats, their rumps shaking contentedly as they grab a quick snack.");
 			outputText("\n\nAfter wiping the excess from their lips, they close their robes and resume a fighting stance, seeming healthier than before.");
-			game.dynStats("lus", 4 + player.lib/10);
+			player.takeLustDamage(4 + player.lib/10, true);
 			//+ 30 HP, +light lust damage to PC and mob
 			addHP(30);
 			combatRoundOver();

--- a/classes/classes/Scenes/Dungeons/Factory/IncubusMechanic.as
+++ b/classes/classes/Scenes/Dungeons/Factory/IncubusMechanic.as
@@ -90,15 +90,16 @@ package classes.Scenes.Dungeons.Factory
 				outputText("  You land hard on your ass, momentarily stunned as the demonic cock-tentacle curls around your " + player.legs() + ", smearing them with oozing demonic fluids.");
 				if (player.lust100 >= 80 || player.cor >= 80) {
 					outputText("  Moaning with desire, you lick your lips as you slide your well-lubricated " + player.legs() + " free.  You gather a dollop of cum and lick it seductively, winking at the incubus and hoping to make him cave into his desire.");
-					game.dynStats("lus", 13, "cor", 1);
+					player.takeLustDamage(13, true);
+					game.dynStats("cor", 1);
 				}
 				else if (player.lust100 >= 50 || player.cor >= 50) {
 					outputText("  Blushing at the scent and feel of cum on your " + player.legs() + ", you twist and pull free.  You find yourself wondering what this demon's dick would taste like.");
-					game.dynStats("lus", 8 + player.cor / 20);
+					player.takeLustDamage(8 + player.cor / 20, true);
 				}
 				else {
 					outputText("  Disgusted, you pull away from the purplish monstrosity, the act made easier by your well-slimed " + player.legs() + ".");
-					game.dynStats("lus", 5 + player.cor / 20);
+					player.takeLustDamage(5 + player.cor / 20, true);
 				}
 				player.takeDamage(5);
 			}

--- a/classes/classes/Scenes/Dungeons/Factory/OmnibusOverseer.as
+++ b/classes/classes/Scenes/Dungeons/Factory/OmnibusOverseer.as
@@ -59,7 +59,7 @@ package classes.Scenes.Dungeons.Factory
 						game.dynStats("lus", 5);
 					}
 				}
-				game.dynStats("lus", 7 + player.sens / 20);
+				player.takeLustDamage(7 + player.sens / 20, true);
 				if (player.biggestLactation() > 1) outputText("Milk dribbles from your " + player.allBreastsDescript() + " in sympathy.");
 			}
 			game.combat.combatRoundOver();

--- a/classes/classes/Scenes/Dungeons/Factory/SecretarialSuccubus.as
+++ b/classes/classes/Scenes/Dungeons/Factory/SecretarialSuccubus.as
@@ -15,12 +15,12 @@ package classes.Scenes.Dungeons.Factory
 				clearOutput();
 				if (hpVictory) {
 					outputText("You smile in satisfaction as the " + short + " collapses, unable to continue fighting.  Now would be the perfect opportunity to taste the fruits of her sex-ready form...\n\nDo you rape her?");
-					game.dynStats("lus", 1);
+					player.takeLustDamage(1, true);
 					game.doYesNo(factory.secretarialSuccubus.doRapeSuccubus, factory.secretarialSuccubus.doLeaveSuccubus)
 					if (player.hasKeyItem("Deluxe Dildo") >= 0) game.addButton(2, "Dildo Rape", factory.secretarialSuccubus.dildoSuccubus);
 				} else if (player.lust >= 33) {	
 					outputText("You smile in satisfaction as the " + short + " gives up on fighting you and starts masturbating, begging for you to fuck her.  Now would be the perfect opportunity to taste the fruits of her sex-ready form...\n\nDo you fuck her?");
-					game.dynStats("lus", 1);
+					player.takeLustDamage(1, true);
 					game.doYesNo(factory.secretarialSuccubus.doRapeSuccubus, factory.secretarialSuccubus.doLeaveSuccubus)
 					if (player.hasKeyItem("Deluxe Dildo") >= 0) game.addButton(2, "Dildo Rape", factory.secretarialSuccubus.dildoSuccubus);
 				} else {

--- a/classes/classes/Scenes/Dungeons/HelDungeon/Brigid.as
+++ b/classes/classes/Scenes/Dungeons/HelDungeon/Brigid.as
@@ -29,7 +29,7 @@ package classes.Scenes.Dungeons.HelDungeon
 		//Attack Three: Harpy Ass Grind GO!
 		private function BrigidAssGrind():void {
 			outputText("Brigid grins as she approaches you.  She handily deflects a few defensive blows and grabs you by the shoulders.  She forces you onto your knees and before you can blink, has turned around and smashed your face into her ass!  \"<i>Mmm, you like that, don'tcha?</i>\" she growls, grinding her huge, soft ass across your face, giving you an up-close and personal feel of her egg-laying hips.");
-			game.dynStats("lus", 30);
+			player.takeLustDamage(30, true);
 			game.combat.combatRoundOver();
 		}
 		override protected function performCombatAction():void

--- a/classes/classes/Scenes/Dungeons/HelDungeon/HarpyMob.as
+++ b/classes/classes/Scenes/Dungeons/HelDungeon/HarpyMob.as
@@ -46,15 +46,16 @@ package classes.Scenes.Dungeons.HelDungeon
 		
 		//ATTACK THREE: LUSTY HARPIES!
 		public function harpyHordeLustAttack():void {
+			var lustDmg:int = 10;
 			outputText("The harpies back off for a moment, giving you room to breathe - only to begin a mini strip-tease, pulling off bits of clothing to reveal their massive asses and hips or bearing their small, perky tits.  They caress themselves and each other, moaning lewdly.  Distracted by the burlesque, you don't notice a lipstick-wearing harpy approach you until it's too late!  She plants a kiss right on your lips, ");
 			if (player.findPerk(PerkLib.LuststickAdapted) >= 0) outputText("doing relatively little thanks to your adaptation");
 			else {
 				outputText("sending shivers of lust up your spine");
-				game.dynStats("lus", 5);
-				if (player.hasCock()) game.dynStats("lus", 15);
+				lustDmg += 5;
+				if (player.hasCock()) lustDmg += 15;
 			}
 			outputText(".");
-			game.dynStats("lus", 10);
+			player.takeLustDamage(lustDmg, true);
 			combatRoundOver();
 		}
 		

--- a/classes/classes/Scenes/Dungeons/HelDungeon/HarpyQueen.as
+++ b/classes/classes/Scenes/Dungeons/HelDungeon/HarpyQueen.as
@@ -39,7 +39,7 @@ package classes.Scenes.Dungeons.HelDungeon
 		public function lustSpikeAttack():void {
 			outputText("The Harpy Queen draws a strange arcane circle in the air, lines of magic remaining wherever the tip of her staff goes.  You try to rush her, but the circle seems to have created some kind of barrier around her.  You can only try to force it open - but too late!  A great pink bolt shoots out of the circle, slamming into your chest.  You suddenly feel light-headed and so very, very horny...");
 			//(Effect: Heavy Lust Damage)
-			game.dynStats("lus", 40);
+			player.takeLustDamage(40, true);
 			combatRoundOver();
 		}
 

--- a/classes/classes/Scenes/Dungeons/HelDungeon/PhoenixPlatoon.as
+++ b/classes/classes/Scenes/Dungeons/HelDungeon/PhoenixPlatoon.as
@@ -26,7 +26,7 @@ package classes.Scenes.Dungeons.HelDungeon
 		public function phoenixPlatoonLustbang():void {
 			outputText("\"<i>LUSTBANG OUT!</i>\" one of the rear-most phoenixes shouts, causing all the other warriors to duck down behind their shields.  Oh, shit!  A large glass sphere rolls out from the shield wall, and immediately explodes in a great pink cloud.  You cough and wave your arms, but by the time the cloud has dissipated, you feel lightheaded and lusty, barely able to resist the urge to throw yourself at the phoenixes and beg for their cocks and cunts.");
 			//(Effect: Large lust increase)
-			game.dynStats("lus", 40);
+			player.takeLustDamage(40, true);
 			combatRoundOver();
 		}
 

--- a/classes/classes/Scenes/Places/Boat/Marae.as
+++ b/classes/classes/Scenes/Places/Boat/Marae.as
@@ -23,7 +23,7 @@ package classes.Scenes.Places.Boat
 			{
 				outputText("but you fail and get hit instead! The feel of the tentacles left your groin slightly warmer. ");
 				var damage:int = ((str + 100) + rand(50))
-				game.dynStats("lust", rand(5) + 5);
+				player.takeLustDamage(rand(5) + 5, true);
 				damage = player.reduceDamage(damage);
 				player.takeDamage(damage, true);
 			}
@@ -46,8 +46,7 @@ package classes.Scenes.Places.Boat
 			{
 				outputText("You attempt to slap away the tentacles but it's too late! The tentacles tickle your groin and you can feel your [ass] being teased! \"<i>You know you want me!</i>\" Marae giggles. ");
 				var lustDmg:int = (20 + rand(player.cor / 10) + rand(player.sens / 5) + rand(player.lib / 10) + rand(10)) * (player.lustPercent() / 100);
-				game.dynStats("lust", lustDmg, "resisted", false);
-				outputText("<b>(<font color=\"#ff00ff\">" + lustDmg + "</font> lust)</b>");
+				player.takeLustDamage(lustDmg, true, false);
 				
 			}
 			combatRoundOver();

--- a/classes/classes/Scenes/Places/Boat/SharkGirl.as
+++ b/classes/classes/Scenes/Places/Boat/SharkGirl.as
@@ -13,13 +13,13 @@ package classes.Scenes.Places.Boat
 				outputText("You charge at the shark girl, prepared to strike again, but stop dead in your tracks when she bends over and wiggles her toned ass towards you. It distracts you long enough for her tail to swing out and smack you to the ground. She coos, \"<i>Aw... You really do like me!</i>\" ");
 				//(Small health damage, medium lust build).
 				player.takeDamage(4+rand(4), true);
-				game.dynStats("lus", (10+(player.lib/20)));
+				player.takeLustDamage(10+(player.lib/20), true);
 			}
 			else {
 				outputText("You pull your " + player.weaponName + " back, getting a running start to land another attack. The Shark girl smirks and pulls up her bikini top, shaking her perky breasts in your direction. You stop abruptly, aroused by the sight just long enough for the shark girl to kick you across the face and knock you to the ground.  She teases, \"<i>Aw, don't worry baby, you're gonna get the full package in a moment!</i>\" ");
 				//(Small health damage, medium lust build)
 				player.takeDamage(4+rand(4), true);
-				game.dynStats("lus", (5+(player.lib/10)));
+				player.takeLustDamage(5+(player.lib/10), true);
 			}
 			combatRoundOver();
 		}

--- a/classes/classes/Scenes/Places/Farm/Kelt.as
+++ b/classes/classes/Scenes/Places/Farm/Kelt.as
@@ -71,7 +71,7 @@ package classes.Scenes.Places.Farm
 				if (player.lust100 >= 80) outputText("Your hand moves towards your groin seemingly of its own volition.");
 				else outputText("Your hands twitch towards your groin but you arrest them.  Still, the idea seems to buzz at the back of your brain, exciting you.");
 			}
-			game.dynStats("lus", player.lib/5 + rand(10));
+			player.takeLustDamage(player.lib/5 + rand(10), true);
 			combatRoundOver();
 		}
 


### PR DESCRIPTION
Refactors player.takeLustDamage() function to all monsters in Lake, Mountain, Plain, Swamp, VulcanicCrag, Dungeons and Places.

Only NPC´s are left ... 
and hopefully no text bugs