### PR TITLE
Restore black borders around game.

### DIFF
--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -133,7 +133,7 @@ the text from being too boring.
 	// Add in descriptions for the include statements. Many of the description text code is inside of these.
 	// Suggest moving or removing old comments referencing things that aren't needed anymore.
 		
-	[SWF( width="1000", height="800", pageTitle="Corruption of Champions" )]
+	[SWF( width="1000", height="800", backgroundColor="0x000000", pageTitle="Corruption of Champions" )]
 
 	public class CoC extends MovieClip
 	{

--- a/classes/coc/view/MainView.as
+++ b/classes/coc/view/MainView.as
@@ -157,10 +157,10 @@ public class MainView extends Block {
 		super();
 		addElement(blackBackground = new BitmapDataSprite({
 			bitmapClass: ButtonBackground2,
-			x          : -SCREEN_W / 2,
-			width      : SCREEN_W * 2,
-			height     : SCREEN_H * 2,
-			y          : -SCREEN_H / 2,
+			x          : -SCREEN_W,
+			width      : SCREEN_W,
+			height     : SCREEN_H,
+			y          : -SCREEN_H,
 			fillColor  : '#000000'
 		}), {});
 		addElement(background = new BitmapDataSprite({


### PR DESCRIPTION
Recently, CoC-Mod builds have had white or tan colored borders around the game window. In addition to unnecessarily burning in OLED/plasma/CRT displays, this is uncomfortable for the eyes and really ugly in mobile builds of the game that I make.

This patch restores the black borders around the game window, and appears to have no negative side-effects.