### PR TITLE
Fix unclosed bold tag in PlayerInfo.as

### DIFF
--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -631,7 +631,7 @@ import flash.events.Event;
 			menu();
 			addButton(0, "Next", playerMenu);
 			if (player.statPoints > 0) {
-				outputText("\n\n<b>You have " + num2Text(player.statPoints) + " attribute point" + (player.statPoints == 1 ? "" : "s") + " to distribute.");
+				outputText("\n\n<b>You have " + num2Text(player.statPoints) + " attribute point" + (player.statPoints == 1 ? "" : "s") + " to distribute.</b>");
 				addButton(1, "Stat Up", attributeMenu);
 			}
 		}


### PR DESCRIPTION
When viewing the Stats-tab with attribute points left to be spent a missing `</b>`-tag resulted in all the following text being all bold until you reload the game. Fixed that by adding the missing tag.