### PR TITLE
BodyParts.Neck

### DIFF
--- a/classes/classes/Appearance.as
+++ b/classes/classes/Appearance.as
@@ -2044,6 +2044,11 @@ package classes
 			}
 			return description;
 		}
+
+		public static function neckDescript(i_creature:Creature):String
+		{
+			return DEFAULT_NECK_NAMES[i_creature.neck.type] + " neck";
+		}
 		
 		public static function wingsDescript(i_creature:Creature):String
 		{
@@ -2348,6 +2353,13 @@ package classes
 					[TAIL_TYPE_SHEEP, "sheep"],
 					[TAIL_TYPE_IMP, "imp"],
 					[TAIL_TYPE_COCKATRICE, "cockatrice"],
+				]
+		);
+		public static const DEFAULT_NECK_NAMES:Object = createMapFromPairs(
+				[
+					[NECK_TYPE_NORMAL, "normal"],
+					[NECK_TYPE_DRACONIC, "long draconic"],
+					[NECK_TYPE_COCKATRICE, "feathery cockatrice"],
 				]
 		);
 		public static const DEFAULT_WING_NAMES:Object = createMapFromPairs(

--- a/classes/classes/BodyParts/BaseBodyPart.as
+++ b/classes/classes/BodyParts/BaseBodyPart.as
@@ -1,0 +1,36 @@
+package classes.BodyParts 
+{
+	/**
+	 * ...
+	 * @since August 06, 2017
+	 * @author Stadler76
+	 */
+	public class BaseBodyPart 
+	{
+		public function BaseBodyPart() {}
+
+		public function canDye():Boolean
+		{
+			return false;
+		}
+
+		public function hasDyeColor(_color:String):Boolean
+		{
+			return true;
+		}
+
+		public function applyDye(_color:String):void {}
+
+		public function canOil():Boolean
+		{
+			return false;
+		}
+
+		public function hasOilColor(_color:String):Boolean
+		{
+			return true;
+		}
+
+		public function applyOil(_color:String):void {}
+	}
+}

--- a/classes/classes/BodyParts/Neck.as
+++ b/classes/classes/BodyParts/Neck.as
@@ -1,0 +1,64 @@
+package classes.BodyParts 
+{
+	/**
+	 * Container class for the players neck
+	 * @since December 19, 2016
+	 * @author Stadler76
+	 */
+	public class Neck 
+	{
+		include "../../../includes/appearanceDefs.as";
+
+		public var type:Number = NECK_TYPE_NORMAL;
+		public var len:Number  = 2;
+		public var pos:Boolean = false;
+
+		private var _nlMax:Array = [];
+
+		public function Neck()
+		{
+			_nlMax[NECK_TYPE_NORMAL]   =  2;
+			_nlMax[NECK_TYPE_DRACONIC] = 30;
+		}
+
+		public function restore():void
+		{
+			type = NECK_TYPE_NORMAL;
+			len  = 2;
+			pos  = false;
+		}
+
+		public function setProps(p:Object):void
+		{
+			if (p.hasOwnProperty('type')) type = p.type;
+			if (p.hasOwnProperty('len'))  len  = p.len;
+			if (p.hasOwnProperty('pos'))  pos  = p.pos;
+		}
+
+		public function setAllProps(p:Object):void
+		{
+			restore();
+			setProps(p);
+		}
+
+		public function modify(diff:Number, newType:Number = -1):void
+		{
+			if (newType != -1) type = newType;
+
+			if (_nlMax[type] == undefined) { // Restore length and pos, if the type is not associated with a certain max length
+				pos = false;
+				len = 2;
+				return;
+			}
+
+			len += diff;
+			if (len < 2)  len = 2;
+			if (len > _nlMax[type]) len = _nlMax[type];
+		}
+
+		public function isFullyGrown():Boolean
+		{
+			return len >= _nlMax[type];
+		}
+	}
+}

--- a/classes/classes/BodyParts/Neck.as
+++ b/classes/classes/BodyParts/Neck.as
@@ -68,5 +68,15 @@ package classes.BodyParts
 		{
 			return type == NECK_TYPE_COCKATRICE;
 		}
+
+		public function hasDyeColor(_color:String):Boolean
+		{
+			return color == _color;
+		}
+
+		public function applyDye(_color:String):void
+		{
+			color = _color;
+		}
 	}
 }

--- a/classes/classes/BodyParts/Neck.as
+++ b/classes/classes/BodyParts/Neck.as
@@ -9,9 +9,10 @@ package classes.BodyParts
 	{
 		include "../../../includes/appearanceDefs.as";
 
-		public var type:Number = NECK_TYPE_NORMAL;
-		public var len:Number  = 2;
-		public var pos:Boolean = false;
+		public var type:Number  = NECK_TYPE_NORMAL;
+		public var len:Number   = 2;
+		public var pos:Boolean  = false;
+		public var color:String = "no";
 
 		private var _nlMax:Array = [];
 
@@ -23,16 +24,18 @@ package classes.BodyParts
 
 		public function restore():void
 		{
-			type = NECK_TYPE_NORMAL;
-			len  = 2;
-			pos  = false;
+			type  = NECK_TYPE_NORMAL;
+			len   = 2;
+			pos   = false;
+			color = "no";
 		}
 
 		public function setProps(p:Object):void
 		{
-			if (p.hasOwnProperty('type')) type = p.type;
-			if (p.hasOwnProperty('len'))  len  = p.len;
-			if (p.hasOwnProperty('pos'))  pos  = p.pos;
+			if (p.hasOwnProperty('type'))  type  = p.type;
+			if (p.hasOwnProperty('len'))   len   = p.len;
+			if (p.hasOwnProperty('pos'))   pos   = p.pos;
+			if (p.hasOwnProperty('color')) color = p.color;
 		}
 
 		public function setAllProps(p:Object):void
@@ -59,6 +62,11 @@ package classes.BodyParts
 		public function isFullyGrown():Boolean
 		{
 			return len >= _nlMax[type];
+		}
+
+		public function canDye():Boolean
+		{
+			return type == NECK_TYPE_COCKATRICE;
 		}
 	}
 }

--- a/classes/classes/BodyParts/Neck.as
+++ b/classes/classes/BodyParts/Neck.as
@@ -5,7 +5,7 @@ package classes.BodyParts
 	 * @since December 19, 2016
 	 * @author Stadler76
 	 */
-	public class Neck 
+	public class Neck extends BaseBodyPart
 	{
 		include "../../../includes/appearanceDefs.as";
 
@@ -64,17 +64,17 @@ package classes.BodyParts
 			return len >= _nlMax[type];
 		}
 
-		public function canDye():Boolean
+		override public function canDye():Boolean
 		{
 			return type == NECK_TYPE_COCKATRICE;
 		}
 
-		public function hasDyeColor(_color:String):Boolean
+		override public function hasDyeColor(_color:String):Boolean
 		{
 			return color == _color;
 		}
 
-		public function applyDye(_color:String):void
+		override public function applyDye(_color:String):void
 		{
 			color = _color;
 		}

--- a/classes/classes/BodyParts/Readme.md
+++ b/classes/classes/BodyParts/Readme.md
@@ -58,6 +58,15 @@ player.rearBody.setProps({
 ### setAllProps(p:Object)
 same as above, but skipped propertys are being reset to their default values
 
+### canDye() / canOil()
+Returns `true` if you can apply hair dye, respectively skin oil to that bodypart
+
+### hasDyeColor(_color:String) / hasOilColor(_color:String)
+Returns `true` if the bodypart already has the color to be applied
+
+### applyDye(_color:String) / applyOil(_color:String)
+Applies the color to the bodypart
+
 BodyParts
 ---------
 
@@ -108,8 +117,24 @@ Assuming that:
 - `desc` is set to "fur"
 
 ##### public function hasFur():Boolean
-Moved from and aliased to `Creature.hasFur()`<br>
+Moved from and alias of `Creature.hasFur()`<br>
 Returns true if the player has fur (aka `player.skin.type == SKIN_TYPE_FUR`). Nuff said.
+
+##### public function hasWool():Boolean
+Alias of `Creature.hasWool()`<br>
+Returns true if the player has wool (aka `player.skin.type == SKIN_TYPE_WOOL`).
+
+##### public function hasFeathers():Boolean
+Alias of `Creature.hasFeathers()`<br>
+Returns true if the player has feathers (aka `player.skin.type == SKIN_TYPE_FEATHERED`).
+
+##### public function isFurry():Boolean
+Alias of `Creature.isFurry()`<br>
+Returns true if the player has fur or wool.
+
+##### public function isFluffy():Boolean
+Alias of `Creature.isFluffy()`<br>
+Returns true if the player has fur, wool or feathers.
 
 #### Note
 I've added the optional param `keepTone` to the methods `restore()` and `setAllProps()` which defaults to true.
@@ -142,13 +167,6 @@ Alias of `skin.skinFurScales()` (Same as above, but for the skin on the underbod
 
 Parser tag: `[underbody.skinfurscales]` (case insensitive)
 
-##### copySkin(p:Object = null)
-This is mainly a wrapper around
-```as3
-player.underBody.skin.setProps(player.skin);
-```
-The param `p:Object = null` can optionally be used to override certain skin propertys after copying them (See in the examples below)
-
 #### Examples
 ##### From lizard scales TF:
 ```as3
@@ -158,7 +176,7 @@ player.skin.setProps({
 	desc: "scales"
 });
 player.underBody.type = UNDER_BODY_TYPE_REPTILE;
-player.underBody.copySkin({ // copy the main skin props to the underBody skin ...
+player.copySkinToUnderBody({    // copy the main skin props to the underBody skin ...
 	desc: "ventral scales"  // ... and only override the desc
 });
 ```
@@ -171,7 +189,7 @@ player.skin.setProps({
 	desc: "scales"
 });
 player.underBody.type = UNDER_BODY_TYPE_REPTILE;
-player.underBody.copySkin();                     // copy the main skin props to the underBody skin ...
+player.copySkinToUnderBody();                    // copy the main skin props to the underBody skin ...
 player.underBody.skin.desc = "ventral scales";   // ... and only override the desc
 ```
 
@@ -188,7 +206,7 @@ if ((!player.hasLizardScales() || [UNDER_BODY_TYPE_REPTILE, UNDER_BODY_TYPE_TURT
 		desc: "scales"
 	});
 	player.underBody.type = UNDER_BODY_TYPE_REPTILE;
-	player.underBody.copySkin({ // copy the main skin props to the underBody skin ...
+	player.copySkinToUnderBody({    // copy the main skin props to the underBody skin ...
 		desc: "ventral scales"  // ... and only override the desc
 	});
 	changes++;
@@ -202,17 +220,47 @@ if (player.hasLizardScales() && player.underBody.type == UNDER_BODY_TYPE_REPTILE
 }
 ```
 
+### Wings
+#### Property table
+| Property | Access example       | Description / Examples                                           |
+|----------|----------------------|------------------------------------------------------------------|
+| `type`   | `player.wings.type`  | **The type**<br>`player.wings.type = WING_TYPE_FEATHERED_LARGE;` |
+| `color`  | `player.wings.color` | **The color**<br>`player.wings.color = "green";`                 |
+
+### Neck
+#### Property table
+| Property | Access example      | Description / Examples                                                                         |
+|----------|---------------------|------------------------------------------------------------------------------------------------|
+| `type`   | `player.neck.type`  | **The type**<br>`player.neck.type = NECK_TYPE_DRACONIC;`                                       |
+| `len`    | `player.neck.len`   | **The length**<br>`player.neck.len = 30;`                                                      |
+| `pos`    | `player.neck.pos`   | **The position related to the head, true if its behind the face**<br>`player.neck.pos = true;` |
+| `color`  | `player.neck.color` | **The color (e. g. the feathers of a cockatrice neck**<br>`player.neck.color = "green";`       |
+
+#### Additional methods
+##### modify(diff:Number, newType:Number = -1)
+Modify the length of the neck by `diff`. Optinally set the type to `newType` before modifying the length
+
+##### isFullyGrown()
+Checks, if the neck has reached its max length for the type
+
+##### Notes
+Currently only the dragon neck (`NECK_TYPE_DRACONIC`) uses the methods `modify` and `isFullyGrown` and the propertys `len` and `pos`. Ideas for more races with inhuman necks would be appreciated.
 
 ### RearBody
 placeholder
 
-### Neck
-placeholder
 
 Changed or new related methods
 ------------------------------
 
 Syntax: ClassName.methodName
+
+##### Creature.copySkinToUnderBody(p:Object = null)
+This is mainly a wrapper around
+```as3
+player.underBody.skin.setProps(player.skin);
+```
+The param `p:Object = null` can optionally be used to override certain skin propertys after copying them (See in the examples for UnderBody)
 
 ### Player.setFurColor
 Set the new furColor or furColors randomly and, if wanted: set the new underBody as well.

--- a/classes/classes/BodyParts/Wings.as
+++ b/classes/classes/BodyParts/Wings.as
@@ -5,7 +5,7 @@ package classes.BodyParts
 	 * @since May 01, 2017
 	 * @author Stadler76
 	 */
-	public class Wings
+	public class Wings extends BaseBodyPart
 	{
 		include "../../../includes/appearanceDefs.as";
 
@@ -32,9 +32,19 @@ package classes.BodyParts
 			setProps(p);
 		}
 
-		public function canDye():Boolean
+		override public function canDye():Boolean
 		{
 			return [WING_TYPE_HARPY, WING_TYPE_FEATHERED_LARGE].indexOf(type) != -1;
+		}
+
+		override public function hasDyeColor(_color:String):Boolean
+		{
+			return color == _color;
+		}
+
+		override public function applyDye(_color:String):void
+		{
+			color = _color;
 		}
 	}
 }

--- a/classes/classes/Character.as
+++ b/classes/classes/Character.as
@@ -885,6 +885,11 @@ import classes.GlobalFlags.kFLAGS;
 		{
 			return Appearance.oneTailDescript(this);
 		}
+
+		public function neckDescript():String
+		{
+			return Appearance.neckDescript(this);
+		}
 		
 		public function wingsDescript():String
 		{

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -54,6 +54,7 @@ the text from being too boring.
 
 	import classes.AssClass; // Creates the class that holds ass-related variables as described above. 
 	import classes.BreastRowClass; // Creates the class that holds breast-related variables.
+	import classes.BodyParts.Neck;
 	import classes.BodyParts.Skin;
 	import classes.BodyParts.UnderBody;
 	import classes.Items.*; // This pulls in all the files in the Items folder. Basically any inventory item in the game
@@ -582,6 +583,7 @@ the text from being too boring.
 			registerClassAlias("Player", Player);
 			registerClassAlias("StatusEffectClass", StatusEffectClass);
 			registerClassAlias("VaginaClass", VaginaClass);
+			registerClassAlias("Neck", Neck);
 			registerClassAlias("Skin", Skin);
 			registerClassAlias("UnderBody", UnderBody);
 			//registerClassAlias("Enum", Enum);

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1,6 +1,7 @@
 ﻿//CoC Creature.as
 package classes
 {
+	import classes.BodyParts.Neck;
 	import classes.BodyParts.Skin;
 	import classes.BodyParts.UnderBody;
 	import classes.BodyParts.Wings;
@@ -231,6 +232,7 @@ package classes
 		public var clawTone:String = "";
 		public var clawType:Number = CLAW_TYPE_NORMAL;
 		// </mod>
+		public var neck:Neck = new Neck();
 		public var underBody:UnderBody = new UnderBody();
 
 		/*EarType

--- a/classes/classes/Items/Consumables/BeeHoney.as
+++ b/classes/classes/Items/Consumables/BeeHoney.as
@@ -179,8 +179,10 @@ package classes.Items.Consumables
 					player.breastRows[temp].nipplesPerBreast = 1;
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
 			//Lose reptile oviposition!
-			if (Utils.rand(4) == 0) mutations.updateOvipositionPerk(tfSource);
+			if (rand(4) == 0) mutations.updateOvipositionPerk(tfSource);
 			//Gain bee oviposition!
 			if (changes < changeLimit && player.findPerk(PerkLib.BeeOvipositor) < 0 && player.tailType == CoC.TAIL_TYPE_BEE_ABDOMEN && Utils.rand(2) == 0) {
 				outputText("\n\nAn odd swelling starts in your insectile abdomen, somewhere along the underside.  Curling around, you reach back to your extended, bulbous bee part and run your fingers along the underside.  You gasp when you feel a tender, yielding slit near the stinger.  As you probe this new orifice, a shock of pleasure runs through you, and a tubular, black, semi-hard appendage drops out, pulsating as heavily as any sexual organ.  <b>The new organ is clearly an ovipositor!</b>  A few gentle prods confirm that it's just as sensitive; you can already feel your internals changing, adjusting to begin the production of unfertilized eggs.  You idly wonder what laying them with your new bee ovipositor will feel like...");

--- a/classes/classes/Items/Consumables/Clovis.as
+++ b/classes/classes/Items/Consumables/Clovis.as
@@ -66,6 +66,9 @@ package classes.Items.Consumables
 				}
 				outputText("\n\nYou feel your clothes tighten around your [butt], your behind expanding. Thankfully, it stops before your clothes can't handle it. As you run your hand over the tight fabric, you can't help but grope the now plumper flesh.");
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0)
+				mutations.restoreNeck(tfSource);
 			if (player.earType !== EARS_SHEEP && rand(3) === 0 && changes < changeLimit) {
 				if (player.earType === -1) { outputText("\n\nTwo painful nubs begin sprouting from your head, growing out in a tear-drop shape and flopping over. To top it off, wool coats them."); } else { outputText("\n\nYou feel your ears shift and elongate, becoming much floppier. They take on a more tear drop shape, flopping at the side of your head cutely as a light coat of downy wool forms on them.");	}		
 				player.earType = EARS_SHEEP;

--- a/classes/classes/Items/Consumables/Ectoplasm.as
+++ b/classes/classes/Items/Consumables/Ectoplasm.as
@@ -60,6 +60,9 @@ package classes.Items.Consumables
 					changes++;
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/EmberTFs.as
+++ b/classes/classes/Items/Consumables/EmberTFs.as
@@ -207,10 +207,14 @@ package classes.Items.Consumables
 				}
 				changes++;
 			}
+			//Restore non dragon neck
+			if (player.neck.type != NECK_TYPE_DRACONIC && changes < changeLimit && rand(4) == 0)
+				mutations.restoreNeck(tfSource);
 			//Gain Dragon Neck
 			//public function hasDraconicBackSide():Boolean { return hasDragonWings(true) && skinType == SKIN_TYPE_DRACONIC && hasReptileTail() && hasReptileArms() && hasReptileLegs(); }
 			//If you are considered a dragon-morph and if your backside is dragon-ish enough, your neck is eager to allow you to take a look at it, right? ;-)
-			if (!drakesHeart && !player.hasDragonNeck() && player.dragonScore() >= 6 && player.hasDraconicBackSide() && changes < changeLimit) {
+			if (!drakesHeart && !player.hasDragonNeck() && player.dragonScore() >= 6 && player.hasDraconicBackSide() && player.faceType == FACE_DRAGON && changes < changeLimit) {
+				mutations.restoreNeck(tfSource);
 				var nlChange:int = 4 + rand(5);
 				if (!player.hasNormalNeck()) { // Note: hasNormalNeck checks the length, not the type!
 					player.neck.modify(nlChange);

--- a/classes/classes/Items/Consumables/EmberTFs.as
+++ b/classes/classes/Items/Consumables/EmberTFs.as
@@ -214,7 +214,7 @@ package classes.Items.Consumables
 			//public function hasDraconicBackSide():Boolean { return hasDragonWings(true) && skinType == SKIN_TYPE_DRACONIC && hasReptileTail() && hasReptileArms() && hasReptileLegs(); }
 			//If you are considered a dragon-morph and if your backside is dragon-ish enough, your neck is eager to allow you to take a look at it, right? ;-)
 			if (!drakesHeart && !player.hasDragonNeck() && player.dragonScore() >= 6 && player.hasDraconicBackSide() && player.faceType == FACE_DRAGON && changes < changeLimit) {
-				mutations.restoreNeck(tfSource);
+				mutations.restoreNeck(tfSource + "-forceRestoreNeck");
 				var nlChange:int = 4 + rand(5);
 				if (!player.hasNormalNeck()) { // Note: hasNormalNeck checks the length, not the type!
 					player.neck.modify(nlChange);

--- a/classes/classes/Items/Consumables/EmberTFs.as
+++ b/classes/classes/Items/Consumables/EmberTFs.as
@@ -207,6 +207,26 @@ package classes.Items.Consumables
 				}
 				changes++;
 			}
+			//Gain Dragon Neck
+			//public function hasDraconicBackSide():Boolean { return hasDragonWings(true) && skinType == SKIN_TYPE_DRACONIC && hasReptileTail() && hasReptileArms() && hasReptileLegs(); }
+			//If you are considered a dragon-morph and if your backside is dragon-ish enough, your neck is eager to allow you to take a look at it, right? ;-)
+			if (!drakesHeart && !player.hasDragonNeck() && player.dragonScore() >= 6 && player.hasDraconicBackSide() && changes < changeLimit) {
+				var nlChange:int = 4 + rand(5);
+				if (!player.hasNormalNeck()) { // Note: hasNormalNeck checks the length, not the type!
+					player.neck.modify(nlChange);
+					outputText("\n\nWith less pain than the last time your neck grows a few more inches reaching " + player.neck.len + " inches.");
+				} else {
+					player.neck.modify(nlChange, NECK_TYPE_DRACONIC);
+					// Growing a dragon neck may be limited to Ember's blood only in the future.
+					outputText("\n\nAfter you have finished " + (drakesHeart ? "eating the flower" : "drinking Ember's dragon blood") + " you start feeling a sudden pain in your neck. Your skin stretches and your spine grows a bit. Your neck has grown a few inches longer than that of a normal human reaching " + player.neck.len + " inches.");
+				}
+				if (player.hasDragonNeck() && !player.neck.pos) {
+					outputText("\n\nAfter the enlongation has finally ceased, your spine begins to readjust its position on your head until its settled at the backside of your head. After that you want to try out your new draconic neck and begin to bend your neck finding that you can bend it at ease like a snake can bend its tail. Eager to see, how you look from behind you quickly turn your head around. Staring at your magnificent draconic rear your mouth and eyes open wide in astonishment. You muster your tail, your backside fully covered in scales and finally, you unfold your wings. This is the first time, you can see every single scale of them. You look at them from all sides, flapping them slowly, just to watch them moving.");
+					outputText("  <b>You now have a fully grown dragon neck.</b>");
+					player.neck.pos = true;
+				}
+				changes++;
+			}
 			// <mod name="Predator arms" author="Stadler76">
 			//Gain Dragon Arms (Derived from ARM_TYPE_SALAMANDER)
 			if (player.armType != ARM_TYPE_PREDATOR && player.hasDragonScales() && player.lowerBody == LOWER_BODY_TYPE_DRAGON && changes < changeLimit && rand(3) == 0) {

--- a/classes/classes/Items/Consumables/Equinum.as
+++ b/classes/classes/Items/Consumables/Equinum.as
@@ -159,6 +159,9 @@ package classes.Items.Consumables
 					changes++;
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/FerretFruit.as
+++ b/classes/classes/Items/Consumables/FerretFruit.as
@@ -183,6 +183,9 @@ package classes.Items.Consumables
 						changes++;
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/GoblinAle.as
+++ b/classes/classes/Items/Consumables/GoblinAle.as
@@ -65,6 +65,9 @@ package classes.Items.Consumables
 				outputText("\n\nYou feel like dancing, and stumble as your legs react more quickly than you'd think.  Is the alcohol slowing you down or are you really faster?  You take a step and nearly faceplant as you go off balance.  It's definitely both.");
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/HairDye.as
+++ b/classes/classes/Items/Consumables/HairDye.as
@@ -74,7 +74,7 @@ package classes.Items.Consumables
 
 			if (game.player.neck.canDye()) {
 				outputText("\n\nYou have a [neckColor] neck.");
-				if (game.player.neck.color != _color) game.addButton(5, "Neck", dyeNeck);
+				if (!game.player.neck.hasDyeColor(_color)) game.addButton(5, "Neck", dyeNeck);
 				else game.addButtonDisabled(5, "Neck", "Your already have a " + _color + " neck!");
 			} else {
 				outputText("\n\nYour neck can't be dyed.");
@@ -153,7 +153,7 @@ package classes.Items.Consumables
 		{
 			clearOutput();
 			outputText("You rub the dye onto your [neck], then use a bucket of cool lakewater to rinse clean a few minutes later.  ");
-			game.player.neck.color = _color;
+			game.player.neck.applyDye(_color);
 			outputText("You now have a [neckColor] neck.");
 			finalize();
 		}

--- a/classes/classes/Items/Consumables/HairDye.as
+++ b/classes/classes/Items/Consumables/HairDye.as
@@ -65,7 +65,7 @@ package classes.Items.Consumables
 
 			if (game.player.wings.canDye()) {
 				outputText("\n\nYou have " + game.player.wingColor + " wings.");
-				if (game.player.wingColor != _color) game.addButton(3, "Wings", dyeWings);
+				if (!game.player.wings.hasDyeColor(_color)) game.addButton(3, "Wings", dyeWings);
 				else game.addButtonDisabled(3, "Wings", "Your already have " + _color + " wings!");
 			} else {
 				outputText("\n\nYour wings can't be dyed.");
@@ -144,8 +144,8 @@ package classes.Items.Consumables
 		{
 			clearOutput();
 			outputText("You rub the dye into your [wings], then use a bucket of cool lakewater to rinse clean a few minutes later.  ");
-			game.player.wingColor = _color;
-			outputText("You now have " + game.player.wingColor + " wings.");
+			game.player.wings.applyDye(_color);
+			outputText("You now have [wingColor] wings.");
 			finalize();
 		}
 

--- a/classes/classes/Items/Consumables/HairDye.as
+++ b/classes/classes/Items/Consumables/HairDye.as
@@ -72,6 +72,15 @@ package classes.Items.Consumables
 				game.addButtonDisabled(3, "Wings", "Your wings can't be dyed!");
 			}
 
+			if (game.player.neck.canDye()) {
+				outputText("\n\nYou have a [neckColor] neck.");
+				if (game.player.neck.color != _color) game.addButton(5, "Neck", dyeNeck);
+				else game.addButtonDisabled(5, "Neck", "Your already have a " + _color + " neck!");
+			} else {
+				outputText("\n\nYour neck can't be dyed.");
+				game.addButtonDisabled(5, "Neck", "Your neck can't be dyed!");
+			}
+
 			game.addButton(4, "Nevermind", dyeCancel);
 			return true;
 		}
@@ -137,6 +146,15 @@ package classes.Items.Consumables
 			outputText("You rub the dye into your [wings], then use a bucket of cool lakewater to rinse clean a few minutes later.  ");
 			game.player.wingColor = _color;
 			outputText("You now have " + game.player.wingColor + " wings.");
+			finalize();
+		}
+
+		private function dyeNeck():void
+		{
+			clearOutput();
+			outputText("You rub the dye onto your [neck], then use a bucket of cool lakewater to rinse clean a few minutes later.  ");
+			game.player.neck.color = _color;
+			outputText("You now have a [neckColor] neck.");
 			finalize();
 		}
 

--- a/classes/classes/Items/Consumables/ImpFood.as
+++ b/classes/classes/Items/Consumables/ImpFood.as
@@ -255,6 +255,9 @@ package classes.Items.Consumables
 				changes++;
 			}
 			
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0 && changes < changeLimit) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/MinotaurBlood.as
+++ b/classes/classes/Items/Consumables/MinotaurBlood.as
@@ -116,6 +116,9 @@ package classes.Items.Consumables
 				}
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/MouseCocoa.as
+++ b/classes/classes/Items/Consumables/MouseCocoa.as
@@ -127,6 +127,9 @@ package classes.Items.Consumables
           changes++;
         }
       }
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/RegularHummus.as
+++ b/classes/classes/Items/Consumables/RegularHummus.as
@@ -57,6 +57,9 @@ package classes.Items.Consumables
 				player.removePerk(PerkLib.Incorporeality);
 				changes++;
 			}
+			//Restore neck
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(5) == 0)
+				mutations.restoreNeck(tfSource);
 			//-Skin color change – light, fair, olive, dark, ebony, mahogany, russet
 			if ((player.skinTone !== "light" && player.skinTone !== "fair" && player.skinTone !== "olive" && player.skinTone !== "dark" && player.skinTone !== "ebony" && player.skinTone !== "mahogany" && player.skinTone !== "russet") && changes < changeLimit && rand(5) === 0) {
 				changes++;

--- a/classes/classes/Items/Consumables/Reptilum.as
+++ b/classes/classes/Items/Consumables/Reptilum.as
@@ -233,7 +233,9 @@ package classes.Items.Consumables
 			if (!player.hasDragonHorns(true) && changes < changeLimit && rand(5) === 0){
 				mutations.gainDraconicHorns(tfSource);
 			}
-			
+
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
 			//-Hair changes
 			if (changes < changeLimit && rand(4) === 0) {
 				mutations.lizardHairChange(tfSource);

--- a/classes/classes/Items/Consumables/RingtailFig.as
+++ b/classes/classes/Items/Consumables/RingtailFig.as
@@ -74,6 +74,9 @@ package classes.Items.Consumables
 				outputText(player.modThickness(80, 2));
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/Salamanderfirewater.as
+++ b/classes/classes/Items/Consumables/Salamanderfirewater.as
@@ -180,6 +180,9 @@ package classes.Items.Consumables
 				player.breastRows[player.smallestTitRow()].breastRating++;
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/ShriveledTentacle.as
+++ b/classes/classes/Items/Consumables/ShriveledTentacle.as
@@ -52,6 +52,9 @@ package classes.Items.Consumables
 			//-always increases lust by a function of sensitivity
 			//"The tingling of the tentacle
 
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/SnakeOil.as
+++ b/classes/classes/Items/Consumables/SnakeOil.as
@@ -59,6 +59,9 @@ package classes.Items.Consumables
 				if (player.spe100 < 40) outputText("  Of course, you're nowhere near as fast as that.");
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/SuperHummus.as
+++ b/classes/classes/Items/Consumables/SuperHummus.as
@@ -59,6 +59,7 @@ package classes.Items.Consumables
 			player.skinDesc = "skin";
 			player.skinAdj = "";
 			player.underBody.restore();
+			player.neck.restore();
 			player.tongueType = TONGUE_HUMAN;
 			player.eyeType = EYES_HUMAN;
 			if (player.fertility > 15) player.fertility = 15;

--- a/classes/classes/Items/Consumables/TonOTrice.as
+++ b/classes/classes/Items/Consumables/TonOTrice.as
@@ -498,8 +498,12 @@ package classes.Items.Consumables
 				mutations.updateClaws(CLAW_TYPE_COCKATRICE);
 				changes++;
 			}
+			//Neck loss, if not cockatrice neck
+			if (player.neck.type != NECK_TYPE_COCKATRICE && changes < changeLimit && rand(4) == 0)
+				mutations.restoreNeck(tfSource);
 			//Body TF
 			if (!player.hasCockatriceSkin() && player.faceType == FACE_COCKATRICE && changes < changeLimit && rand(3) == 0) {
+				mutations.restoreNeck(tfSource);
 				var colorChoice:Array = mutations.newCockatriceColors();
 				outputText("\n\nYour body feels hot and your skin feels tight, making you fall to your knees in a bout of lightheadedness."
 				          +" You kneel there panting as the pressure increases, sweat dripping from your brow. You don’t know how long you can take"
@@ -507,7 +511,7 @@ package classes.Items.Consumables
 				outputText("\nWhen you awaken you check yourself to see what has changed now that the overwhelming pressure has left your body."
 				          +" The first thing you notice is feathers, lots and lots of feathers that now cover your body in a downy layer."
 				          +" Around your neck a ruff of soft fluffy feathers has formed like that of an exotic bird. As you look down to your [chest]"
-				          +" you see that from your chest to your groin you are covered in a layer of cream scales.");
+				          +" you see that from your chest to your groin you are covered in a layer of " + colorChoice[2] + " scales.");
 				outputText("\n<b>Your body is now covered in scales and feathers!</b>");
 
 				player.skin.setAllProps({
@@ -524,6 +528,22 @@ package classes.Items.Consumables
 						tone:     colorChoice[2],
 						desc:     "feathers"
 					}
+				});
+				player.neck.setAllProps({
+					type: NECK_TYPE_COCKATRICE,
+					color: colorChoice[1]
+				});
+				changes++;
+			}
+			//Neck TF, if not already TFed from Body TF above
+			if (player.neck.type != NECK_TYPE_COCKATRICE && player.hasCockatriceSkin() && player.faceType == FACE_COCKATRICE && changes < changeLimit && rand(3) == 0) {
+				mutations.restoreNeck(tfSource);
+				outputText("\n\nYour neck starts to tingle and [secondary furcolor] feathers begin to grow out of it one after another until a ruff"
+				          +" of soft fluffy feathers has formed like that of an exotic bird.");
+				outputText("\n<b>You now have a cockatrice neck!</b>");
+				player.neck.setAllProps({
+					type: NECK_TYPE_COCKATRICE,
+					color: colorChoice[1]
 				});
 				changes++;
 			}

--- a/classes/classes/Items/Consumables/TonOTrice.as
+++ b/classes/classes/Items/Consumables/TonOTrice.as
@@ -503,7 +503,7 @@ package classes.Items.Consumables
 				mutations.restoreNeck(tfSource);
 			//Body TF
 			if (!player.hasCockatriceSkin() && player.faceType == FACE_COCKATRICE && changes < changeLimit && rand(3) == 0) {
-				mutations.restoreNeck(tfSource);
+				mutations.restoreNeck(tfSource + "-forceRestoreNeck");
 				var colorChoice:Array = mutations.newCockatriceColors();
 				outputText("\n\nYour body feels hot and your skin feels tight, making you fall to your knees in a bout of lightheadedness."
 				          +" You kneel there panting as the pressure increases, sweat dripping from your brow. You don’t know how long you can take"

--- a/classes/classes/Items/Consumables/TrapOil.as
+++ b/classes/classes/Items/Consumables/TrapOil.as
@@ -242,6 +242,9 @@ package classes.Items.Consumables
 					changes++;
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/WetCloth.as
+++ b/classes/classes/Items/Consumables/WetCloth.as
@@ -36,6 +36,9 @@ package classes.Items.Consumables
 			}
 
 			//Cosmetic changes based on 'goopyness'
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/WhiskerFruit.as
+++ b/classes/classes/Items/Consumables/WhiskerFruit.as
@@ -238,6 +238,9 @@ package classes.Items.Consumables
 					changes++;
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Consumables/WolfPepper.as
+++ b/classes/classes/Items/Consumables/WolfPepper.as
@@ -385,6 +385,9 @@ package classes.Items.Consumables
 				changes++;
 			}
 			//MISC CRAP
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) === 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -188,6 +188,9 @@ package classes.Items
 					player.shrinkTits();
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Demonic changes - higher chance with higher corruption.
 			if (rand(40) + player.cor / 3 > 35 && tainted) demonChanges(player);
@@ -487,6 +490,9 @@ package classes.Items
 					kGAMECLASS.rathazul.addMixologyXP(20);
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Demonic changes - higher chance with higher corruption.
 			if (rand(40) + player.cor / 3 > 35 && tainted) demonChanges(player);
@@ -607,6 +613,9 @@ package classes.Items
 				outputText("dumber.");
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Restore arms to become human arms again
 			if (rand(4) == 0) restoreArms(tfSource);
@@ -1940,6 +1949,9 @@ package classes.Items
 					dynStats("lus", 10);
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (tainted && rand(5) == 0) updateOvipositionPerk(tfSource);
 			//General Appearance (Tail -> Ears -> Paws(fur stripper) -> Face -> Horns
 			//Give the player a bovine tail, same as the minotaur
@@ -2217,6 +2229,9 @@ package classes.Items
 				dynStats("lib", 2, "sen", 3, "lus", 10);
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//Transformations:
 			//Mouth TF
@@ -2457,6 +2472,9 @@ package classes.Items
 				outputText("\n\nYou feel strange.  Fertile... somehow.  You don't know how else to think of it, but you know your body is just aching to be pregnant and give birth.");
 			}
 			//-VAGs
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(4) == 0) updateOvipositionPerk(tfSource);
 			if (player.hasVagina() && player.findPerk(PerkLib.BunnyEggs) < 0 && changes < changeLimit && rand(4) == 0 && player.bunnyScore() > 3) {
 				outputText("\n\nDeep inside yourself there is a change.  It makes you feel a little woozy, but passes quickly.  Beyond that, you aren't sure exactly what just happened, but you are sure it originated from your womb.\n\n");
@@ -2812,6 +2830,9 @@ package classes.Items
 					}
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//****************
 			//General Appearance:
@@ -3122,6 +3143,9 @@ package classes.Items
 					changes++;
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//****************
 			//Big Kanga Morphs
@@ -3325,6 +3349,9 @@ package classes.Items
 				player.buttRating++;
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//***************
 			//Appearance Changes
@@ -3714,6 +3741,9 @@ package classes.Items
 						changes++;
 				}
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//[Grow Fur]
 			//FOURTH
@@ -3954,6 +3984,9 @@ package classes.Items
 			//**********************
 			//BIG APPEARANCE CHANGES
 			//**********************
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//[Grow Fox Tail]
 			if (player.tailType != TAIL_TYPE_FOX && changes < changeLimit && ((mystic && rand(2) == 0) || (!mystic && rand(4) == 0))) {
@@ -4264,6 +4297,9 @@ package classes.Items
 				player.ballSize++;
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) updateOvipositionPerk(tfSource);
 			//-----------------------
 			// TRANSFORMATIONS

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -155,11 +155,11 @@ package classes.Items
 			if (tsParts.length > 1 && tsParts[0] != "reptilum") // probably later dracolisks would get an elongated neck, too (shorter than the dragon version)
 				tfSource = tsParts[0];
 
-			if (changes >= changeLimit) return false;
+			var forceRestore:Boolean = tsParts.indexOf("forceRestoreNeck") != -1;
 
 			switch (player.neck.type) {
 				case NECK_TYPE_DRACONIC:
-					if (tfSource == "EmberTFs" || player.dragonScore() >= 9)
+					if (tfSource == "EmberTFs" || (!forceRestore && player.dragonScore() >= 9))
 						return false;
 
 					outputText("\n\n<b>Your draconic neck[if (neckPos) and its position on your head revert|reverts] to its normal"
@@ -167,15 +167,15 @@ package classes.Items
 					break;
 
 				case NECK_TYPE_COCKATRICE:
-					if (tfSource == "TonOTrice" || player.cockatriceScore() >= 7)
+					if (tfSource == "TonOTrice" || (!forceRestore && player.cockatriceScore() >= 7))
 						return false;
 
-					outputText("\n\nYou neck starts to tingle and the feathers that decorate your neck begin fall out until"
+					outputText("\n\nYou neck starts to tingle and the feathers that decorate your neck begin to fall out until"
 					          +" <b>you're left with a normal neck!</b>");
 					break;
 			}
 
-			changes++;
+			if (!forceRestore) changes++;
 			player.neck.restore();
 			return true;
 		}

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -148,6 +148,38 @@ package classes.Items
 			return false;
 		}
 
+		public function restoreNeck(tfSource:String):Boolean
+		{
+			trace('called restoreNeck("' + tfSource + '")');
+			var tsParts:Array = tfSource.split("-");
+			if (tsParts.length > 1 && tsParts[0] != "reptilum") // probably later dracolisks would get an elongated neck, too (shorter than the dragon version)
+				tfSource = tsParts[0];
+
+			if (changes >= changeLimit) return false;
+
+			switch (player.neck.type) {
+				case NECK_TYPE_DRACONIC:
+					if (tfSource == "EmberTFs" || player.dragonScore() >= 9)
+						return false;
+
+					outputText("\n\n<b>Your draconic neck[if (neckPos) and its position on your head revert|reverts] to its normal"
+					          +" [if (neckPos)position and] length.</b> ");
+					break;
+
+				case NECK_TYPE_COCKATRICE:
+					if (tfSource == "TonOTrice" || player.cockatriceScore() >= 7)
+						return false;
+
+					outputText("\n\nYou neck starts to tingle and the feathers that decorate your neck begin fall out until"
+					          +" <b>you're left with a normal neck!</b>");
+					break;
+			}
+
+			changes++;
+			player.neck.restore();
+			return true;
+		}
+
 		public function removeFeatheryHair():Boolean
 		{
 			if (changes < changeLimit && player.hairType == HAIR_FEATHER && rand(4) == 0) {

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -173,6 +173,10 @@ package classes.Items
 					outputText("\n\nYou neck starts to tingle and the feathers that decorate your neck begin to fall out until"
 					          +" <b>you're left with a normal neck!</b>");
 					break;
+
+				default:
+					player.neck.restore(); // Restore leftovers. Failsafe!
+					return false;
 			}
 
 			if (!forceRestore) changes++;

--- a/classes/classes/Parser/conditionalConverters.as
+++ b/classes/classes/Parser/conditionalConverters.as
@@ -51,6 +51,7 @@
 				"hascock"			: function(thisPtr:*):* {return  kGAMECLASS.player.hasCock();},
 				"hassheath"			: function(thisPtr:*):* {return  kGAMECLASS.player.hasSheath();},
 				"hasbeak"			: function(thisPtr:*):* {return  kGAMECLASS.player.hasBeak();},
+				"neckpos"			: function(thisPtr:*):* {return  kGAMECLASS.player.neck.pos;},
 				"isherm"			: function(thisPtr:*):* {return  (kGAMECLASS.player.gender == 3);},
 				"cumnormal"			: function(thisPtr:*):* {return  (kGAMECLASS.player.cumQ() <= 150);},
 				"cummedium"			: function(thisPtr:*):* {return  (kGAMECLASS.player.cumQ() > 150 && kGAMECLASS.player.cumQ() <= 350);},

--- a/classes/classes/Parser/singleArgLookups.as
+++ b/classes/classes/Parser/singleArgLookups.as
@@ -72,6 +72,7 @@
 				"multicock"					: function(thisPtr:*):* { return kGAMECLASS.player.multiCockDescriptLight(); },
 				"multicockdescriptlight"	: function(thisPtr:*):* { return kGAMECLASS.player.multiCockDescriptLight(); },
 				"name"						: function(thisPtr:*):* { return kGAMECLASS.player.short;},
+				"neckcolor"					: function(thisPtr:*):* { return kGAMECLASS.player.neck.color;},
 				"nipple"					: function(thisPtr:*):* { return kGAMECLASS.player.nippleDescript(0);},
 				"nipples"					: function(thisPtr:*):* { return kGAMECLASS.player.nippleDescript(0) + "s";},
 				"onecock"					: function(thisPtr:*):* { return kGAMECLASS.player.oMultiCockDesc();},

--- a/classes/classes/Parser/singleArgLookups.as
+++ b/classes/classes/Parser/singleArgLookups.as
@@ -108,6 +108,7 @@
 				"boy"						: function(thisPtr:*):* { return kGAMECLASS.player.mf("boy", "girl"); },
 				"guy"						: function(thisPtr:*):* { return kGAMECLASS.player.mf("guy", "girl"); },
 				"wings"						: function(thisPtr:*):* { return kGAMECLASS.player.wingsDescript(); },
+				"wingcolor"					: function(thisPtr:*):* { return kGAMECLASS.player.wings.color; },
 				"tail"						: function(thisPtr:*):* { return kGAMECLASS.player.tailDescript(); },
 				"onetail"					: function(thisPtr:*):* { return kGAMECLASS.player.oneTailDescript(); },
 

--- a/classes/classes/Parser/singleArgLookups.as
+++ b/classes/classes/Parser/singleArgLookups.as
@@ -72,6 +72,7 @@
 				"multicock"					: function(thisPtr:*):* { return kGAMECLASS.player.multiCockDescriptLight(); },
 				"multicockdescriptlight"	: function(thisPtr:*):* { return kGAMECLASS.player.multiCockDescriptLight(); },
 				"name"						: function(thisPtr:*):* { return kGAMECLASS.player.short;},
+				"neck"						: function(thisPtr:*):* { return kGAMECLASS.player.neckDescript(); },
 				"neckcolor"					: function(thisPtr:*):* { return kGAMECLASS.player.neck.color;},
 				"nipple"					: function(thisPtr:*):* { return kGAMECLASS.player.nippleDescript(0);},
 				"nipples"					: function(thisPtr:*):* { return kGAMECLASS.player.nippleDescript(0) + "s";},

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1579,6 +1579,8 @@ use namespace kGAMECLASS;
 				dragonCounter++;
 			if (eyeType == EYES_DRAGON)
 				dragonCounter++;
+			if (hasDragonNeck())
+				dragonCounter++;
 			return dragonCounter;
 		}
 

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1062,6 +1062,8 @@ use namespace kGAMECLASS;
 				cockatriceCounter++;
 			if (antennae == ANTENNAE_COCKATRICE)
 				cockatriceCounter++;
+			if (neck.type == NECK_TYPE_COCKATRICE)
+				cockatriceCounter++;
 			if (cockatriceCounter > 2) {
 				if (tongueType == TONGUE_LIZARD)
 					cockatriceCounter++;

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -550,6 +550,8 @@ package classes
 					else if (player.neck.len < 16) outputText("  You can bend it more than others with low effort.");
 					else outputText("  You are able to bend it in almost every direction and with some effort you even manage to take a glimpse at your back.");
 				}
+			} else if (player.neck.type == NECK_TYPE_COCKATRICE) {
+				outputText("  Around your neck is a ruff of [neckColor] feathers which tends to puff out with your emotions.");
 			}
 			//BODY PG HERE
 			outputText("\n\nYou have a humanoid shape with the usual torso, arms, hands, and fingers.");
@@ -598,7 +600,7 @@ package classes
 			// <mod name="BodyParts.UnderBody" author="Stadler76">
 			if (player.hasCockatriceSkin()) {
 				outputText("  You’ve got a thick layer of " + player.furColor + " feathers covering your body, while [skinFurScales] coat you from"
-				          +" chest to groin. Around your neck is a ruff of [underBody.skinFurScales] which tends to puff out with your emotions.");
+				          +" chest to groin.");
 			} else if (player.hasDifferentUnderBody()) {
 				outputText("  While most of your body is covered by [skinFurScales] you have [underBody.skinFurScales] covering your belly.");
 			}

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -527,6 +527,30 @@ package classes
 				else
 					outputText("  It has developed its own cute little spiral. You estimate it to be about "+numInchesOrCentimetres(12)+" long, "+numInchesOrCentimetres(2)+" thick and very sturdy. A very useful natural weapon.");
 			}
+			// neckLen
+			if (player.neck.type == NECK_TYPE_DRACONIC)
+			{
+				// length description
+				if (player.hasDragonNeck())
+					outputText("  Your neck starts at the backside of your head and is about two and a half feet long, roughly six inches longer, than your arm length.");
+				else {
+					var lengthText:String = "";
+					if (player.neck.len < 8) lengthText = "a few inches longer";
+					else if (player.neck.len < 13) lengthText = "somewhat longer";
+					else if (player.neck.len < 18) lengthText = "very long";
+					else lengthText = "extremely long";
+					outputText("  Where normal humans have a short neck, yours is " + lengthText + ", measuring " + player.neck.len + " inches.");
+				}
+
+				// bending your neck
+				if (player.hasDragonNeck())
+					outputText("  You manage to bend it in every direction you want and can easily take a look at your back.");
+				else {
+					if (player.neck.len < 10) outputText("  You can bend it a bit more than others with some effort.");
+					else if (player.neck.len < 16) outputText("  You can bend it more than others with low effort.");
+					else outputText("  You are able to bend it in almost every direction and with some effort you even manage to take a glimpse at your back.");
+				}
+			}
 			//BODY PG HERE
 			outputText("\n\nYou have a humanoid shape with the usual torso, arms, hands, and fingers.");
 			//WINGS!

--- a/classes/classes/PlayerHelper.as
+++ b/classes/classes/PlayerHelper.as
@@ -137,6 +137,37 @@ package classes
 			return game.bazaar.benoit.benoitBigFamily() && eyeType == EYES_BASILISK;
 		}
 
+		public function hasReptileTail():Boolean
+		{
+			return [TAIL_TYPE_LIZARD, TAIL_TYPE_DRACONIC, TAIL_TYPE_SALAMANDER].indexOf(tailType) != -1;
+		}
+
+		// For reptiles with predator arms I recommend to require hasReptileScales() before doing the armType TF to ARM_TYPE_PREDATOR
+		public function hasReptileArms():Boolean
+		{
+			return armType == ARM_TYPE_SALAMANDER || (armType == ARM_TYPE_PREDATOR && hasReptileScales());
+		}
+
+		public function hasReptileLegs():Boolean
+		{
+			return [LOWER_BODY_TYPE_LIZARD, LOWER_BODY_TYPE_DRAGON, LOWER_BODY_TYPE_SALAMANDER].indexOf(lowerBody) != -1;
+		}
+
+		public function hasDraconicBackSide():Boolean
+		{
+			return hasDragonWings(true) && hasDragonScales() && hasReptileTail() && hasReptileArms() && hasReptileLegs();
+		}
+
+		public function hasDragonNeck():Boolean
+		{
+			return neck.type == NECK_TYPE_DRACONIC && neck.isFullyGrown();
+		}
+
+		public function hasNormalNeck():Boolean
+		{
+			return neck.len <= 2;
+		}
+
 		public function featheryHairPinEquipped():Boolean
 		{
 			return hasKeyItem("Feathery hair-pin") >= 0 && keyItemv1("Feathery hair-pin") == 1;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1,6 +1,7 @@
-package classes
+﻿package classes
 {
 
+	import classes.BodyParts.Neck;
 	import classes.BodyParts.UnderBody;
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.GlobalFlags.kACHIEVEMENTS;
@@ -897,6 +898,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		// <mod name="BodyParts.Skin and UnderBody" author="Stadler76">
 		saveFile.data.underBody = player.underBody;
 		// </mod>
+		saveFile.data.neck = player.neck;
 		// <mod name="Predator arms" author="Stadler76">
 		saveFile.data.clawTone = player.clawTone;
 		saveFile.data.clawType = player.clawType;
@@ -1780,6 +1782,8 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		if (saveFile.data.underBody is UnderBody)
 			player.underBody.setAllProps(saveFile.data.underBody);
 		// </mod>
+		if (saveFile.data.neck is Neck)
+			player.neck.setAllProps(saveFile.data.neck);
 		// <mod name="Predator arms" author="Stadler76">
 		player.clawTone = (saveFile.data.clawTone == undefined) ? ""               : saveFile.data.clawTone;
 		player.clawType = (saveFile.data.clawType == undefined) ? CLAW_TYPE_NORMAL : saveFile.data.clawType;

--- a/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
+++ b/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
@@ -1041,6 +1041,9 @@ public class ErlKingScene extends BaseContent implements Encounter
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
 			// Main TFs
 			//------------
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) mutations.updateOvipositionPerk(tfSource);
 			//Gain deer ears
 			if (rand(3) == 0 && changes < changeLimit && player.earType != EARS_DEER) {

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -1459,6 +1459,9 @@ package classes.Scenes.Places.Bazaar
 				changes++;
 			}
 			//Transformations
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) mutations.updateOvipositionPerk(tfSource);
 
 			if (rand(3) == 0 && changes < changeLimit && player.hasScales()) {
@@ -1579,6 +1582,9 @@ package classes.Scenes.Places.Bazaar
 			if (rand(3) == 0 && player.rhinoScore() >= 2 && (rand(2) == 0 || !player.inRut) && player.hasCock()) {
 				player.goIntoRut(true);
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk loss
 			if (rand(5) == 0) mutations.updateOvipositionPerk(tfSource);
 			// Special TFs
 			//------------
@@ -2060,6 +2066,9 @@ package classes.Scenes.Places.Bazaar
 				player.shrinkTits();
 				changes++;
 			}
+			//Neck restore
+			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
+			//Ovi perk gain
 			if (rand(4) == 0 && changes < changeLimit && player.echidnaScore() >= 3 && player.hasVagina() && player.findPerk(PerkLib.Oviposition) < 0) {
 				mutations.updateOvipositionPerk(tfSource);
 			}

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -245,6 +245,7 @@ public static const UNDER_BODY_TYPE_COCKATRICE:int                              
 // neckType
 public static const NECK_TYPE_NORMAL:int                                            =   0; // normal human neck. neckLen = 2 inches
 public static const NECK_TYPE_DRACONIC:int                                          =   1; // (western) dragon neck. neckLen = 2-30 inches
+public static const NECK_TYPE_COCKATRICE:int                                        =   2;
 
 // piercingtypesNOPEDISABLED
 public static const PIERCING_TYPE_NONE:int                                          =   0;

--- a/includes/appearanceDefs.as
+++ b/includes/appearanceDefs.as
@@ -242,6 +242,10 @@ public static const UNDER_BODY_TYPE_NAGA:int                                    
 public static const UNDER_BODY_TYPE_WOOL:int                                        =   5; // Deprecated. Changed to 3 (UNDER_BODY_TYPE_FURRY) upon loading a savegame
 public static const UNDER_BODY_TYPE_COCKATRICE:int                                  =   6;
 
+// neckType
+public static const NECK_TYPE_NORMAL:int                                            =   0; // normal human neck. neckLen = 2 inches
+public static const NECK_TYPE_DRACONIC:int                                          =   1; // (western) dragon neck. neckLen = 2-30 inches
+
 // piercingtypesNOPEDISABLED
 public static const PIERCING_TYPE_NONE:int                                          =   0;
 public static const PIERCING_TYPE_STUD:int                                          =   1;


### PR DESCRIPTION
### Gameplay changes
- With the help of Embers Blood and if you have a dragon face, you'll now grow a long neck to make you more ... uuhm, dragon-ish
- With Ton'o'Trice you now grow a feathery cockatrice (bird-like) neck
- The feathers of a cockatrice neck can now be colored separately with Hair Dye 

### Internal changes
- Added the parser conditional `neckpos` which returns true, if the neck has been repositioned (currently dragon neck only)
- Added the parser tags:
  - `[neck]`
  - `[neckColor]`
  - `[wingColor]`
- Added the class `BaseBodyPart` with a few basics now to aid with handling Hair Dye, Skin Oil and so on.

### Notes
To everyone working on new TFs: Currently only two transformatives have their neck TF, hence, why I made it so that almost all other TFs lose it. I'd appreciate it, if there would be more TFs in the future, that adapt it. If you have any questions, how to handle this, just ask.
