### PR TITLE
takeLustDamage applies resistance by default

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -610,7 +610,7 @@ use namespace kGAMECLASS;
 			return returnDamage;
 		}
 
-		public function takeLustDamage(lustDmg:Number, display:Boolean = true, applyRes:Boolean = false):Number{
+		public function takeLustDamage(lustDmg:Number, display:Boolean = true, applyRes:Boolean = true):Number{
 			//Round
 			lustDmg = Math.round(lustDmg);
 			var lust:int = game.player.lust;


### PR DESCRIPTION
I believe this is how it was intended. Currently only one call to takeLustDamage uses the third flag at all(Corrupted Marae's tentacle fun), and it's set to "false", which is redundant.