### PR TITLE
Adding [say: ] parser tag

### DIFF
--- a/classes/classes/Parser/Parser.as
+++ b/classes/classes/Parser/Parser.as
@@ -873,6 +873,18 @@ package classes.Parser
 				return false;
 		}
 
+		private function isSpeechStatement(textCtnt:String):Boolean
+		{
+			if (textCtnt.toLowerCase().indexOf("say: ") == 0)
+				return true;
+			else
+				return false;
+		}
+
+		private function parseSpeech(textCtnt:String):String{
+			return "\"<i>" + textCtnt.substring(5,textCtnt.length + 1) + "</i>\"";
+		}
+		
 		// Called to determine if the contents of a bracket are a parseable statement or not
 		// If the contents *are* a parseable, it calls the relevant function to evaluate it
 		// if not, it simply returns the contents as passed
@@ -1001,6 +1013,10 @@ package classes.Parser
 							retStr += parseConditional(tmpStr, depth)
 							if (conditionalDebug) trace("WARNING: ------------------0000000000000000000000000000000000000000000000000000000000000000-----------------------")
 							//trace("WARNING: Parsed Ccnditional - ", retStr)
+						}
+						else if (isSpeechStatement(tmpStr))
+						{
+							retStr += parseSpeech(recParser(tmpStr,depth));
 						}
 						else if (tmpStr)
 						{


### PR DESCRIPTION
Just one thing I found pretty useful while coding scenes. This turns [say: some text] into <i>\"some text\"</i>, which is remarkably faster and more comfortable, especially when there's a lot of talking to be coded in.