### PR TITLE
Buff over max (e.g. Might) support

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -6,7 +6,9 @@ package classes
 	import classes.Items.Armors.GooArmor;
 	import classes.Items.*;
 	import classes.Saves;
-	import fl.controls.ComboBox;
+import classes.internals.Utils;
+
+import fl.controls.ComboBox;
 	import fl.data.DataProvider;
 	import flash.events.Event;
 	
@@ -1004,7 +1006,7 @@ package classes
 		}
 		private function chooseCockLength(length:Number):void {
 			player.cocks[0].cockLength = length;
-			player.cocks[0].cockThickness = Math.floor(((length / 5) - 0.1) * 10) / 10;
+			player.cocks[0].cockThickness = Utils.floor(((length / 5) - 0.1),1);
 			genericStyleCustomizeMenu();
 		}
 

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -192,7 +192,7 @@ import flash.errors.IllegalOperationError;
 			var prevSens:Number  = sens;
 			var prevLust:Number  = lust;
 			var prevCor:Number  = cor;
-			modStats(argz.str, argz.tou, argz.spe, argz.inte, argz.lib, argz.sens, argz.lust, argz.cor, argz.sca, argz.max);
+			modStats(argz.str, argz.tou, argz.spe, argz.inte, argz.lib, argz.sens, argz.lust, argz.cor, argz.scale, argz.max);
 			End("Creature","dynStats");
 			return {
 				str:str-prevStr,

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -2702,7 +2702,7 @@ use namespace kGAMECLASS;
 			return min;
 		}
 
-		override public function modStats(dstr:Number, dtou:Number, dspe:Number, dinte:Number, dlib:Number, dsens:Number, dlust:Number, dcor:Number, scale:Boolean = true):void {
+		override public function modStats(dstr:Number, dtou:Number, dspe:Number, dinte:Number, dlib:Number, dsens:Number, dlust:Number, dcor:Number, scale:Boolean, max:Boolean):void {
 
 			//Set original values to begin tracking for up/down values if
 			//they aren't set yet.
@@ -2767,7 +2767,7 @@ use namespace kGAMECLASS;
 				if (findPerk(PerkLib.Lusty) >= 0 && dlib >= 0) dlib*=1+perk(findPerk(PerkLib.Lusty)).value1;
 				if (findPerk(PerkLib.Sensitive) >= 0 && dsens >= 0) dsens*= 1+ perk(findPerk(PerkLib.Sensitive)).value1;
 			}
-			super.modStats(dstr, dtou, dspe, dinte, dlib, dsens, dlust, dcor, false);
+			super.modStats(dstr, dtou, dspe, dinte, dlib, dsens, dlust, dcor, false, max);
 			game.statScreenRefresh();
 		}
 
@@ -2788,10 +2788,10 @@ use namespace kGAMECLASS;
 		 * @return keys: str, tou, spe, inte
 		 */
 		public override function getAllMaxStats():Object {
-			var maxStr:int = 100;
-			var maxTou:int = 100;
-			var maxSpe:int = 100;
-			var maxInt:int = 100;
+			var maxStr:Number = 100;
+			var maxTou:Number = 100;
+			var maxSpe:Number = 100;
+			var maxInt:Number = 100;
 			//Apply New Game+
 			maxStr += ascensionFactor();
 			maxTou += ascensionFactor();

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1807,7 +1807,7 @@ public class Combat extends BaseContent
 			var lustDisplay:String = "";
 			var math:Number = monster.HPRatio();
 			//hpDisplay = "(<b>" + String(int(math * 1000) / 10) + "% HP</b>)";
-			hpDisplay   = Math.floor(monster.HP) + " / " + monster.maxHP() + " (" + (int(math * 1000) / 10) + "%)";
+			hpDisplay   = Math.floor(monster.HP) + " / " + monster.maxHP() + " (" + floor(math*100,1) + "%)";
 			lustDisplay = Math.floor(monster.lust) + " / " + monster.maxLust();
 			;
 			//imageText set in beginCombat()

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -1592,7 +1592,7 @@ public class CombatAbilities extends BaseContent
 				monster.spe -= damage/2;
 				damage = monster.lustVuln * damage;
 				//Clean up down to 1 decimal point
-				damage = Math.round(damage*10)/10;		
+				damage = round(damage,1);
 				monster.teased(damage);
 			}
 			//New lines and moving on!

--- a/classes/classes/StatusEffects/Combat/LizanBlowpipeDebuff.as
+++ b/classes/classes/StatusEffects/Combat/LizanBlowpipeDebuff.as
@@ -7,7 +7,7 @@ import classes.StatusEffectType;
 public class LizanBlowpipeDebuff extends CombatBuff {
 	public static const TYPE:StatusEffectType = register("Lizan Blowpipe", LizanBlowpipeDebuff);
 	public function LizanBlowpipeDebuff() {
-		super(TYPE, 'str', 'tou', 'spe', 'sen');
+		super(TYPE, 'str', 'tou', 'spe', 'sens');
 	}
 	public function debuffStrSpe():void {
 		var power:Number = 5;

--- a/classes/classes/StatusEffects/Combat/MightBuff.as
+++ b/classes/classes/StatusEffects/Combat/MightBuff.as
@@ -13,7 +13,7 @@ public class MightBuff extends CombatBuff {
 	override protected function apply(firstTime:Boolean):void {
 		var buff:Number = host.spellMod();
 		if (buff > 100) buff = 100;
-		buffHost('str',buff,'tou',buff,'scale',false);
+		buffHost('str',buff,'tou',buff,'scale',false,'max',false);
 	}
 
 }

--- a/classes/classes/StatusEffects/TemporaryBuff.as
+++ b/classes/classes/StatusEffects/TemporaryBuff.as
@@ -39,10 +39,10 @@ public class TemporaryBuff extends StatusEffectClass{
 		if (stat3) value3 += buff[stat3];
 		if (stat4) value4 += buff[stat4];
 		LOGGER.debug("buffHost("+args.join(",")+"): " +
-					 stat1+(stat1?buff[stat1]:"")+
-					 stat2+(stat2?buff[stat2]:"")+
-					 stat3+(stat3?buff[stat3]:"")+
-					 stat4+(stat4?buff[stat4]:"")+
+					 stat1+" "+(stat1?buff[stat1]:"")+" "+
+					 stat2+" "+(stat2?buff[stat2]:"")+" "+
+					 stat3+" "+(stat3?buff[stat3]:"")+" "+
+					 stat4+" "+(stat4?buff[stat4]:"")+" "+
 					 "->("+value1+", "+value2+", "+value3+", "+value4+")");
 		return buff;
 	}

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -59,6 +59,36 @@ package classes.internals
 			if (!isFinite(x)) return min;
 			return x < min ? min : x > max ? max : x;
 		}
+		public static function ipow(base:int,exponent:int):int {
+			if (exponent<0) return 0;
+			var x:int=1;
+			while(exponent-->0) x*=base;
+			return x;
+		}
+		/**
+		 * Round (value) to (decimals) decimal digits
+		 */
+		public static function round(value:Number,decimals:int=0):Number {
+			if (decimals<=0) return Math.round(value);
+			var factor:Number = ipow(10,decimals);
+			return Math.round(value*factor)/factor;
+		}
+		/**
+		 * Round (value) up to (decimals) decimal digits
+		 */
+		public static function ceil(value:Number,decimals:int=0):Number {
+			if (decimals<=0) return Math.ceil(value);
+			var factor:Number = ipow(10,decimals);
+			return Math.ceil(value*factor)/factor;
+		}
+		/**
+		 * Round (value) down to (decimals) decimal digits
+		 */
+		public static function floor(value:Number,decimals:int=0):Number {
+			if (decimals<=0) return Math.floor(value);
+			var factor:Number = ipow(10,decimals);
+			return Math.floor(value*factor)/factor;
+		}
 		/**
 		 * Deleting obj[key] with default.
 		 *


### PR DESCRIPTION
* New "max" (default true) flag to dynStat and alike: If false, allow…stats go over cap.
* Fixes Might not buffing str/tou above max
* parseDynstatArgs rewritten to be more easy to extend
* Other bugfixes (LizanBlowpipeDebuff)
* Utility functions:
  * ipow(base,exponent) - int**int=>int exponentiation
  * floor,round,ceil with specific precision