### PR TITLE
Fixing blank screen when using Minotaur Blood

### DIFF
--- a/classes/classes/Items/Consumables/MinotaurBlood.as
+++ b/classes/classes/Items/Consumables/MinotaurBlood.as
@@ -156,8 +156,6 @@ package classes.Items.Consumables
 					}
 					else {
 						outputText("\n\nA tightness in your groin is the only warning you get before your <b>" + player.vaginaDescript(0) + " disappears forever</b>!");
-						//Goodbye womanhood!
-						player.removeVagina(0, 1);
 						if (player.cocks.length === 0) {
 							outputText("  Strangely, your clit seems to have resisted the change, and is growing larger by the moment... shifting into the shape of a small ribbed minotaur-like penis!  <b>You now have a horse-cock!</b>");
 							player.createCock();
@@ -166,6 +164,9 @@ package classes.Items.Consumables
 							player.cocks[0].cockType = CockTypesEnum.HORSE;
 							player.setClitLength(.25);
 						}
+						//Goodbye womanhood!
+						player.removeVagina(0, 1);
+
 					}
 					changes++;
 				}


### PR DESCRIPTION
Fixing a blank screen when using Minotaur Blood as a female. The game would remove the vagina, then create a cock based on the clit length. But there wasn't any clit to check due to the order.