### PR TITLE
Minor tweaks and fixes

### DIFF
--- a/classes/classes/Items/Consumables/Reptilum.as
+++ b/classes/classes/Items/Consumables/Reptilum.as
@@ -45,7 +45,7 @@ package classes.Items.Consumables
 
 			//Statistical changes:
 			//-Reduces speed down to 50.
-			if (player.spe100 > 50 && changes < changeLimit && rand(4) === 0) {
+			if (player.spe > player.ngPlus(50) && changes < changeLimit && rand(4) === 0) {
 				outputText("\n\nYou start to feel sluggish and cold.  Lying down to bask in the sun might make you feel better.");
 				dynStats("spe", -1);
 				changes++;
@@ -79,14 +79,14 @@ package classes.Items.Consumables
 			}
 			//-Raises toughness to 70
 			//(+3 to 40, +2 to 55, +1 to 70)
-			if (player.tou100 < 70 && changes < changeLimit && rand(3) === 0) {
+			if (player.tou < player.ngPlus(70) && changes < changeLimit && rand(3) === 0) {
 				//(+3)
-				if (player.tou100 < 40) {
+				if (player.tou < player.ngPlus(40)) {
 					outputText("\n\nYour body and skin both thicken noticeably.  You pinch your " + player.skinDesc + " experimentally and marvel at how much tougher your hide has gotten.");
 					dynStats("tou", 3);
 				}
 				//(+2)
-				else if (player.tou100 < 55) {
+				else if (player.tou < player.ngPlus(55)) {
 					outputText("\n\nYou grin as you feel your form getting a little more solid.  It seems like your whole body is toughening up quite nicely, and by the time the sensation goes away, you feel ready to take a hit.");
 					dynStats("tou", 2);
 				}

--- a/classes/classes/Parser/Parser.as
+++ b/classes/classes/Parser/Parser.as
@@ -867,22 +867,16 @@ package classes.Parser
 
 		private function isIfStatement(textCtnt:String):Boolean
 		{
-			if (textCtnt.toLowerCase().indexOf("if") == 0)
-				return true;
-			else
-				return false;
+			return textCtnt.toLowerCase().indexOf("if") == 0;
 		}
 
 		private function isSpeechStatement(textCtnt:String):Boolean
 		{
-			if (textCtnt.toLowerCase().indexOf("say: ") == 0)
-				return true;
-			else
-				return false;
+			return textCtnt.toLowerCase().indexOf("say: ") == 0;
 		}
 
 		private function parseSpeech(textCtnt:String):String{
-			return "\"<i>" + textCtnt.substring(5,textCtnt.length + 1) + "</i>\"";
+			return "\u201c<i>" + textCtnt.substring(5,textCtnt.length + 1) + "</i>\u201d";
 		}
 		
 		// Called to determine if the contents of a bracket are a parseable statement or not

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1448,14 +1448,12 @@ use namespace kGAMECLASS;
 				lizardCounter++;
 			if (armType == ARM_TYPE_PREDATOR && clawType == CLAW_TYPE_LIZARD)
 				lizardCounter++;
-			if (eyeType == EYES_LIZARD)
-				lizardCounter++;
 			if (lizardCounter > 2) {
 				if ([TONGUE_LIZARD, TONGUE_SNAKE].indexOf(tongueType) != -1)
 					lizardCounter++;
 				if (lizardCocks() > 0)
 					lizardCounter++;
-				if (eyeType == EYES_BASILISK)
+				if ([EYES_LIZARD, EYES_BASILISK].indexOf(eyeType) != -1)
 					lizardCounter++;
 				if (hasReptileScales())
 					lizardCounter++;

--- a/classes/classes/StatusEffects/Combat/MightBuff.as
+++ b/classes/classes/StatusEffects/Combat/MightBuff.as
@@ -11,7 +11,7 @@ public class MightBuff extends CombatBuff {
 	}
 
 	override protected function apply(firstTime:Boolean):void {
-		var buff:Number = host.spellMod();
+		var buff:Number = 10 * host.spellMod();
 		if (buff > 100) buff = 100;
 		buffHost('str',buff,'tou',buff,'scale',false,'max',false);
 	}

--- a/classes/coc/view/MainView.as
+++ b/classes/coc/view/MainView.as
@@ -369,7 +369,7 @@ public class MainView extends Block {
 			});
 			button.preCallback = (function(i:int):Function{
 				return function(b:CoCButton):void{
-					if (_onBottomButtonClick) _onBottomButtonClick(i);
+					if (_onBottomButtonClick != null) _onBottomButtonClick(i);
 				};
 			})(bi);
 			this.bottomButtons.push(button);


### PR DESCRIPTION
### Changes
- Fix a warning in MainView.as
- Both lizard eye types now require a lizardScore > 2 to count toward lizardScore
- Fixed MightBuff calculation
- Restore previous speed and toughness thresholds for reptilum
- Mini tweaks to the parser

### Notes
- The change to `Player.lizardScore()` is merely for the sake of consistency á la: Why do basilisk eyes require a minimum lizardScore to add points to it, while lizard eyes don't?
  In short: It's a change for consistency. Most player won't even recognize any difference.
- The intention of using `ngPlus()` for the stat change thresholds was, that they are solely dependent on the ascension factor and nothing else. A basilisk has 40 speed at new game+-level 0 and 140 speed (40 + 4*25) at new game+-level 4 or higher, but reptilum reduces your speed down to 100 in the latter case? Doesn't make much sense to me TBH. Hence why I reverted that part to its previous version.
  PS: If you intend to port this to other TFs, then why wait? Reptilum was just the first POC for that anyway ^^