### PR TITLE
Fix formatting in JoyScene.as

### DIFF
--- a/classes/classes/Parser/conditionalConverters.as
+++ b/classes/classes/Parser/conditionalConverters.as
@@ -53,7 +53,11 @@
 				"hasbeak"			: function(thisPtr:*):* {return  kGAMECLASS.player.hasBeak();},
 				"hasdragonneck"		: function(thisPtr:*):* {return  kGAMECLASS.player.hasDragonNeck();},
 				"neckpos"			: function(thisPtr:*):* {return  kGAMECLASS.player.neck.pos;},
-				"isherm"			: function(thisPtr:*):* {return  (kGAMECLASS.player.gender == 3);},
+				"ismale"			: function(thisPtr:*):* {return  (kGAMECLASS.player.isMale());},
+				"isfemale"			: function(thisPtr:*):* {return  (kGAMECLASS.player.isFemale());},
+				"isherm"			: function(thisPtr:*):* {return  (kGAMECLASS.player.isHerm());},
+				"ismaleorherm"		: function(thisPtr:*):* {return  (kGAMECLASS.player.isMaleOrHerm());},
+				"isfemaleorherm"	: function(thisPtr:*):* {return  (kGAMECLASS.player.isFemaleOrHerm());},
 				"cumnormal"			: function(thisPtr:*):* {return  (kGAMECLASS.player.cumQ() <= 150);},
 				"cummedium"			: function(thisPtr:*):* {return  (kGAMECLASS.player.cumQ() > 150 && kGAMECLASS.player.cumQ() <= 350);},
 				"cumhigh"			: function(thisPtr:*):* {return  (kGAMECLASS.player.cumQ() > 350 && kGAMECLASS.player.cumQ() <= 1000);},
@@ -76,5 +80,9 @@
 				//Prison
 				"esteem"			: function(thisPtr:*):* {return  kGAMECLASS.player.esteem; },
 				"obey"				: function(thisPtr:*):* {return  kGAMECLASS.player.obey; },
-				"will"				: function(thisPtr:*):* {return  kGAMECLASS.player.will; }
+				"will"				: function(thisPtr:*):* {return  kGAMECLASS.player.will; },
+
+				//---[NPCs]---
+				//Joy
+				"joyhascock"		: function(thisPtr:*):* {return  kGAMECLASS.joyScene.joyHasCock(); }
 			}

--- a/classes/classes/Scenes/NPCs/JoyScene.as
+++ b/classes/classes/Scenes/NPCs/JoyScene.as
@@ -574,22 +574,15 @@ package classes.Scenes.NPCs
 					outputText("\"<i>You look like... Well, you look... I don't know what you look like... I've never seen anything like you before, so I guess that make you, like, unique?</i>\"");
 			}
 			//Gender check
-			outputText("\n\nHaving commented on your race, the bimbo next casts her eye over your crotch and your [chest]. \"<i>You're a ");
-			if (player.gender == GENDER_MALE) {
-				outputText(" guy, and I'm, like, super-happy that's what you are - it means I can play with your funstick.");
-			}
-			else if (player.gender == GENDER_FEMALE) {
-				if (joyHasCock()) outputText("girl, with a yummy baby-hole for me to stick my funstick into and fill you full of mousey-cream.");
-				else outputText("girl... And that's not a bad thing, but I kinda, like, wish one of us had a funstick; it'd be more fun that way! Oooh! And imagine the fun we could have if we both had funsticks!");
-			}
-			else if (player.gender == GENDER_HERM) {
-				if (joyHasCock()) outputText("herm and I'm sooo happy about it; we can have so much fun!");
-				else outputText("herm, with yummy [tits] and a cute [vag] for me to lick and a nice [cock] for me to suck and rub and fill my fun-holes with; I just love it when you put cream in my hungry-achey little belly.");
-			}
-			else {
-				outputText("...Well, you're not really anything. And it's not really a lot of fun... can't you turn into a boy or a girl?");
-			}
-			outputText("</i>\"");
+			outputText("\n\nHaving commented on your race, the bimbo next casts her eye over your crotch and your [chest]. [say: You're a "
+			          +"[if (isMale) guy, and I'm, like, super-happy that's what you are - it means I can play with your funstick.|"
+			          +"[if (isFemale)[if(joyHasCock)girl, with a yummy baby-hole for me to stick my funstick into and fill you full of mousey-cream."
+			          +"|girl... And that's not a bad thing, but I kinda, like, wish one of us had a funstick; it'd be more fun that way! Oooh!"
+			          +" And imagine the fun we could have if we both had funsticks!]|"
+			          +"[if (isHerm)[if(joyHasCock)herm and I'm sooo happy about it; we can have so much fun!|"
+			          +"herm, with yummy [tits] and a cute [vag] for me to lick and a nice [cock] for me to suck and rub and fill my fun-holes with;"
+			          +" I just love it when you put cream in my hungry-achey little belly.]|"
+			          +"...Well, you're not really anything. And it's not really a lot of fun... can't you turn into a boy or a girl?]]]]");
 			//Corruption and perk check
 			outputText("\n\nNext, Joy closes her eyes and focuses on your aura.");
 			if (player.cor < 5) { //Pure

--- a/classes/classes/Scenes/NPCs/JoyScene.as
+++ b/classes/classes/Scenes/NPCs/JoyScene.as
@@ -574,7 +574,7 @@ package classes.Scenes.NPCs
 					outputText("\"<i>You look like... Well, you look... I don't know what you look like... I've never seen anything like you before, so I guess that make you, like, unique?</i>\"");
 			}
 			//Gender check
-			outputText("\n\nHaving commented on your race, the bimbo next casts her eye over your crotch and your " + player.chestDesc() + ". \"<i>You're a ");
+			outputText("\n\nHaving commented on your race, the bimbo next casts her eye over your crotch and your [chest]. \"<i>You're a ");
 			if (player.gender == GENDER_MALE) {
 				outputText(" guy, and I'm, like, super-happy that's what you are - it means I can play with your funstick.");
 			}
@@ -584,11 +584,12 @@ package classes.Scenes.NPCs
 			}
 			else if (player.gender == GENDER_HERM) {
 				if (joyHasCock()) outputText("herm and I'm sooo happy about it; we can have so much fun!");
-				else outputText("herm, with yummy " + player.breastDescript(0) + " and a cute " + player.vaginaDescript() + " for me to lick and a nice " + player.cockDescript() + " for me to suck and rub and fill my fun-holes with; I just love it when you put cream in my hungry-achey little belly.");
+				else outputText("herm, with yummy [tits] and a cute [vag] for me to lick and a nice [cock] for me to suck and rub and fill my fun-holes with; I just love it when you put cream in my hungry-achey little belly.");
 			}
 			else {
 				outputText("...Well, you're not really anything. And it's not really a lot of fun... can't you turn into a boy or a girl?");
 			}
+			outputText("</i>\"");
 			//Corruption and perk check
 			outputText("\n\nNext, Joy closes her eyes and focuses on your aura.");
 			if (player.cor < 5) { //Pure


### PR DESCRIPTION
- In the Talk about yourself dialog the 'speech' wasn't closed with a `</i>"` at the end, resulting in the game text being all italics.
  ... and some more parser tag fun.
- Converted the 'Gender check' chunk to parser only code
- In addition to that, added the conditionalConverters:
  - `ismale`
  - `isfemale`
  - `ismaleorherm`
  - `isfemaleorherm`
  - `joyhascock`