### PR TITLE
Removed changes++ from changes that only affect base stats

### DIFF
--- a/classes/classes/Items/Consumables/BeeHoney.as
+++ b/classes/classes/Items/Consumables/BeeHoney.as
@@ -115,7 +115,7 @@ package classes.Items.Consumables
 			if (changes < changeLimit && Utils.rand(2) == 0 && player.inte100 < 80) {
 				getGame().dynStats("int", 0.1 * (80 - player.inte100));
 				outputText("\n\nYou spend a few moments analyzing the taste and texture of the honey's residue, feeling awfully smart.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Sexual Stuff
 			//No idears

--- a/classes/classes/Items/Consumables/Clovis.as
+++ b/classes/classes/Items/Consumables/Clovis.as
@@ -33,22 +33,22 @@ package classes.Items.Consumables
 			if (player.inte > 90 && rand(3) === 0 && changes < changeLimit) {
 				dynStats("int", -(rand(1) + 1));
 				outputText("\n\nThe sense of calm the potion gives you slowly fades into dopey bliss. You haven't a care in the world, not even the fact that you've got a little dumber.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			if (rand(3) === 0 && changes < changeLimit) {
 				dynStats("tou", rand(1) + 1);
 				outputText("\n\nYou feel a wave of stubborn pride wash over you as you finish the potion. You’re sure nothing could stop you now, not even the demons.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			if (player.spe < 75 && rand(3) === 0 && changes < changeLimit) {
 				dynStats("spe", rand(2) + 1);
 				outputText("\n\nYou feel oddly compelled to jump from rock to rock across a nearby stream, a sense of sure footedness and increased agility deep within you. To your surprise, you make it across with no trouble. The damp and uneven rocks are barely a challenge to your increased speed.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			if (rand(3) === 0 && changes < changeLimit) {
 				dynStats("sens", -(rand(1) + 1));
 				outputText("\n\nYou feel less sensitive to the touch, a slight numbness pervading your body as if truly wrapped in cotton wool. The numbness eventually fades, leaving you now less affected by the lusty touches of your foes.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			if (rand(3) === 0 && changes < changeLimit) {
 				dynStats("cor", -(rand(3) + 2));

--- a/classes/classes/Items/Consumables/Ectoplasm.as
+++ b/classes/classes/Items/Consumables/Ectoplasm.as
@@ -33,14 +33,14 @@ package classes.Items.Consumables
 				outputText("\n\nYou groan softly as your head begins pounding something fierce.  Wincing in pain, you massage your temples as the throbbing continues, and soon, the pain begins to fade; in its place comes a strange sense of sureness and wit.");
 				dynStats("int", 1);
 				if (player.inte100 < 50) dynStats("int", 1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Effect script 2:  (lower sensitivity)
 			if (player.sens100 >= 20 && rand(3) === 0 && changes < changeLimit) {
 				outputText("\n\nWoah, what the... you pinch your " + player.skinFurScales() + " to confirm your suspicions; the ghostly snack has definitely lowered your sensitivity.");
 				dynStats("sen", -2);
 				if (player.sens100 >= 75) dynStats("sen", -2);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Effect script 3:  (higher libido)
 			if (player.lib100 < 100 && rand(3) === 0 && changes < changeLimit) {
@@ -50,7 +50,7 @@ package classes.Items.Consumables
 				outputText(" a trace amount of the ghost girl's lust is transferred into you.  How horny IS she, you have to wonder...");
 				dynStats("lib", 1);
 				if (player.lib100 < 50) dynStats("lib", 1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Effect script a:  (human wang)
 			if (player.hasCock() && changes < changeLimit) {
@@ -106,7 +106,7 @@ package classes.Items.Consumables
 			if (changes === 0) {
 				outputText("You feel strangely refreshed, as if you just gobbled down a bottle of sunshine.  A smile graces your lips as vitality fills you.  ");
 				game.HPChange(player.level * 5 + 10, true);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Incorporeality Perk Text:  You seem to have inherited some of the spiritual powers of the residents of the afterlife!  While you wouldn't consider doing it for long due to its instability, you can temporarily become incorporeal for the sake of taking over enemies and giving them a taste of ghostly libido.
 

--- a/classes/classes/Items/Consumables/EmberTFs.as
+++ b/classes/classes/Items/Consumables/EmberTFs.as
@@ -325,13 +325,13 @@ package classes.Items.Consumables
 					output.text("rut");
 					
 					player.goIntoRut(false);
-					changes++; // is this really worth incrementing the changes? It even ignores the changeLimit
+					//[removed:1.4.10]//changes++; // is this really worth incrementing the changes? It even ignores the changeLimit
 				}
 				else {
 					output.text("heat");
 					
 					player.goIntoHeat(false);
-					changes++; // is this really worth incrementing the changes? It even ignores the changeLimit
+					//[removed:1.4.10]//changes++; // is this really worth incrementing the changes? It even ignores the changeLimit
 				}
 				output.text("</b>.");
 			}

--- a/classes/classes/Items/Consumables/Equinum.as
+++ b/classes/classes/Items/Consumables/Equinum.as
@@ -110,7 +110,7 @@ package classes.Items.Consumables
 				else {
 					dynStats("str", 1);
 					outputText("\n\nYour muscles clench and surge, making you feel as strong as a horse.");
-					changes++;
+					//[removed:1.4.10]//changes++;
 				}
 			}
 			//TOUGHNESS
@@ -125,7 +125,7 @@ package classes.Items.Consumables
 				else {
 					dynStats("tou", 1.25);
 					outputText("\n\nYour body suddenly feels tougher and more resilient.");
-					changes++;
+					//[removed:1.4.10]//changes++;
 				}
 			}
 			//INTELLECT
@@ -136,27 +136,27 @@ package classes.Items.Consumables
 				if (player.inte100 < 10 && player.inte100 > 5) {
 					dynStats("int", -1);
 					outputText("\n\nYou smile vacantly as you drink the potion, knowing you're just a big dumb animal who loves to fuck.");
-					changes++;
+					//[removed:1.4.10]//changes++;
 				}
 				if (player.inte100 <= 20 && player.inte100 >= 10) {
 					dynStats("int", -2);
 					outputText("\n\nYou find yourself looking down at the empty bottle in your hand and realize you haven't thought ANYTHING since your first sip.");
-					changes++;
+					//[removed:1.4.10]//changes++;
 				}
 				if (player.inte100 <= 30 && player.inte100 > 20) {
 					dynStats("int", -3);
 					outputText("\n\nYou smile broadly as your cares seem to melt away.  A small part of you worries that you're getting dumber.");
-					changes++;
+					//[removed:1.4.10]//changes++;
 				}
 				if (player.inte100 <= 50 && player.inte100 > 30) {
 					dynStats("int", -4);
 					outputText("\n\nIt becomes harder to keep your mind focused as your intellect diminishes.");
-					changes++;
+					//[removed:1.4.10]//changes++;
 				}
 				if (player.inte100 > 50) {
 					dynStats("int", -5);
 					outputText("\n\nYour usually intelligent mind feels much more sluggish.");
-					changes++;
+					//[removed:1.4.10]//changes++;
 				}
 			}
 			//Neck restore

--- a/classes/classes/Items/Consumables/FerretFruit.as
+++ b/classes/classes/Items/Consumables/FerretFruit.as
@@ -68,7 +68,7 @@ package classes.Items.Consumables
 			if (player.spe100 < 80 && rand(3) === 0 && changes < changeLimit) {
 				outputText("\n\nYour muscles begin to twitch rapidly, but the feeling is not entirely unpleasant.  In fact, you feel like running.");
 				dynStats("spe",1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//- If male with a hip rating >4 or a female/herm with a hip rating >6:
 			if (((!player.hasCock() && player.hipRating > 6) || (player.hasCock() && player.hipRating > 4)) && rand(3) === 0 && changes< changeLimit)

--- a/classes/classes/Items/Consumables/GoblinAle.as
+++ b/classes/classes/Items/Consumables/GoblinAle.as
@@ -63,7 +63,7 @@ package classes.Items.Consumables
 			if (rand(3) === 0 && player.spe100 < 50 && changes < changeLimit) {
 				dynStats("spe", 1 + rand(2));
 				outputText("\n\nYou feel like dancing, and stumble as your legs react more quickly than you'd think.  Is the alcohol slowing you down or are you really faster?  You take a step and nearly faceplant as you go off balance.  It's definitely both.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Neck restore
 			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);

--- a/classes/classes/Items/Consumables/MinotaurBlood.as
+++ b/classes/classes/Items/Consumables/MinotaurBlood.as
@@ -62,7 +62,7 @@ package classes.Items.Consumables
 					outputText("\n\nYou begin to feel that the size of your muscles is starting to slow you down.");
 					dynStats("spe", -1);
 				}
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Toughness (chance of - sensitivity)
 			if (rand(3) === 0 && changes < changeLimit) {
@@ -96,7 +96,7 @@ package classes.Items.Consumables
 						dynStats("sen", -3);
 					}
 				}
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//SEXUAL
 			//Boosts ball size MORE than equinum :D:D:D:D:D:D:
@@ -131,7 +131,7 @@ package classes.Items.Consumables
 			//+hooves
 			if (player.lowerBody !== LOWER_BODY_TYPE_HOOFED) {
 				if (changes < changeLimit && rand(3) === 0) {
-					changes++;
+					//[removed:1.4.10]//changes++;
 					if (player.lowerBody === LOWER_BODY_TYPE_HUMAN) outputText("\n\nYou stagger as your feet change, curling up into painful angry lumps of flesh.  They get tighter and tighter, harder and harder, until at last they solidify into hooves!");
 					else if (player.lowerBody === LOWER_BODY_TYPE_DOG) outputText("\n\nYou stagger as your paws change, curling up into painful angry lumps of flesh.  They get tighter and tighter, harder and harder, until at last they solidify into hooves!");
 					else if (player.lowerBody === LOWER_BODY_TYPE_NAGA) outputText("\n\nYou collapse as your sinuous snake-tail tears in half, shifting into legs.  The pain is immense, particularly in your new feet as they curl inward and transform into hooves!");

--- a/classes/classes/Items/Consumables/MouseCocoa.as
+++ b/classes/classes/Items/Consumables/MouseCocoa.as
@@ -64,7 +64,7 @@ package classes.Items.Consumables
 			//lose tough
 			if (player.tou100 > 50 && changes < changeLimit && rand(3) === 0) {
 				outputText("\n\nYou feel a bit less sturdy, both physically and mentally.  In fact, you'd prefer to have somewhere to hide for the time being, until your confidence returns.  The next few minutes are passed in a mousey funk - even afterward, you can't quite regain the same sense of invincibility you had before.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 				dynStats("tou", -1);
 				if (player.tou100 >= 75) dynStats("tou", -1);
 				if (player.tou100 >= 90) dynStats("tou", -1);

--- a/classes/classes/Items/Consumables/Reptilum.as
+++ b/classes/classes/Items/Consumables/Reptilum.as
@@ -48,13 +48,13 @@ package classes.Items.Consumables
 			if (player.spe > player.ngPlus(50) && changes < changeLimit && rand(4) === 0) {
 				outputText("\n\nYou start to feel sluggish and cold.  Lying down to bask in the sun might make you feel better.");
 				dynStats("spe", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//-Reduces sensitivity.
 			if (player.sens100 > 20 && changes < changeLimit && rand(3) === 0) {
 				outputText("\n\nThe sensation of prickly pins and needles moves over your body, leaving your senses a little dulled in its wake.");
 				dynStats("sen", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Raises libido greatly to 50, then somewhat to 75, then slowly to 100.
 			if (player.lib100 < 100 && changes < changeLimit && rand(3) === 0) {
@@ -75,7 +75,7 @@ package classes.Items.Consumables
 				if (player.lib100 < 75) dynStats("lib", 1);
 				//+1 if above 75.
 				dynStats("lib", 1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//-Raises toughness to 70
 			//(+3 to 40, +2 to 55, +1 to 70)
@@ -95,7 +95,7 @@ package classes.Items.Consumables
 					outputText("\n\nYou snarl happily as you feel yourself getting even tougher.  It's a barely discernible difference, but you can feel your " + player.skinDesc + " getting tough enough to make you feel invincible.");
 					dynStats("tou", 1);
 				}
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 
 			//Sexual Changes:

--- a/classes/classes/Items/Consumables/RingtailFig.as
+++ b/classes/classes/Items/Consumables/RingtailFig.as
@@ -33,7 +33,7 @@ package classes.Items.Consumables
 			//gain speed to ceiling of 80
 			if (player.spe100 < 80 && rand(3) === 0 && changes < changeLimit) {
 				outputText("\n\nYou twitch and turn your head this way and that, feeling a bit more alert.  This will definitely help when defending your personal space from violators.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 				if (player.spe100 < 40) dynStats("spe", 1);
 				dynStats("spe", 1);
 			}
@@ -42,14 +42,14 @@ package classes.Items.Consumables
 				outputText("\n\nThe wrinkled rind suddenly feels alarmingly distinct in your hands, and you drop the remnants of the fruit.  Wonderingly, you touch yourself with a finger - you can feel even the lightest pressure on your " + player.skinFurScales() + " much more clearly now!");
 				if (player.sens100 < 60) dynStats("sen", 2);
 				dynStats("sen", 2);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//lose toughness to floor of 50
 			if (rand(4) === 0 && player.tou100 > 50 && changes < changeLimit) {
 				outputText("\n\nYou find yourself wishing you could just sit around and eat all day, and spend a while lazing about and doing nothing before you can rouse yourself to get moving.");
 				if (player.tou100 > 75) dynStats("tou", -1);
 				dynStats("tou", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 
 			//Sex stuff
@@ -57,7 +57,7 @@ package classes.Items.Consumables
 				//gain ball size
 				if (player.balls > 0 && player.ballSize < 15 && rand(4) === 0 && changes < changeLimit) {
 					outputText("\n\nYour [balls] inflate, stretching the skin of your sack.  Exposing them, you can see that they've grown several inches!  How magical!");
-					changes++;
+					//[removed:1.4.10]//changes++;
 					player.ballSize += 2 + rand(3);
 					dynStats("lib", 1);
 				}

--- a/classes/classes/Items/Consumables/Salamanderfirewater.as
+++ b/classes/classes/Items/Consumables/Salamanderfirewater.as
@@ -40,13 +40,13 @@ package classes.Items.Consumables
 			if (player.spe100 > 70 && changes < changeLimit && rand(4) === 0) {
 				outputText("\n\nYou start to feel sluggish.  Lying down and enjoying liquor might make you feel better.");
 				dynStats("spe", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//-Reduces intelligence down to 60.
 			if (player.inte100 > 60 && changes < changeLimit && rand(4) === 0) {
 				outputText("\n\nYou start to feel a bit dizzy, but the sensation quickly passes.  Thinking hard on it, you mentally brush away the fuzziness that seems to permeate your brain and determine that this firewater may have actually made you dumber.  It would be best not to drink too much of it.");
 				dynStats("int", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//-Raises libido up to 90.
 			if (player.lib100 < 90 && changes < changeLimit && rand(3) === 0) {
@@ -62,7 +62,7 @@ package classes.Items.Consumables
 				//(TARDS)
 				else outputText("puddling in your featureless crotch for a split-second before it slides into your " + player.assDescript() + ".  You want to be fucked, filled, and perhaps even gain a proper gender again.  Through the lust you realize your sex-drive has been permanently increased.");
 				dynStats("lib", 2);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//-Raises toughness up to 90.
 			//(+3 to 50, +2 to 70, +1 to 90)
@@ -82,13 +82,13 @@ package classes.Items.Consumables
 					outputText("\n\nYou snarl happily as you feel yourself getting even tougher.  It's a barely discernible difference, but you can feel your " + player.skinDesc + " getting tough enough to make you feel invincible.");
 					dynStats("tou", 1);
 				}
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//-Raises strength to 80.
 			if (player.str100 < 80 && rand(3) === 0 && changes < changeLimit) {
 				outputText("\n\nWhile heat builds in your muscles, their already-potent mass shifting slightly as they gain even more strength than before.");
 				dynStats("str", 1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Sexual Changes:
 			//-Lizard dick - first one

--- a/classes/classes/Items/Consumables/ShriveledTentacle.as
+++ b/classes/classes/Items/Consumables/ShriveledTentacle.as
@@ -35,12 +35,12 @@ package classes.Items.Consumables
 			if (rand(3) === 0 && player.tou100 < 50 && changes < changeLimit) {
 				outputText("\n\nYour skin feels clammy and a little rubbery.  You touch yourself experimentally and notice that you can barely feel the pressure from your fingertips.  Consumed with curiosity, you punch yourself lightly in the arm; the most you feel is a dull throb!");
 				dynStats("tou", 1, "sen", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//- speed down
 			if (rand(3) === 0 && player.spe100 > 40 && changes < changeLimit) {
 				outputText("\n\nA pinprick sensation radiates from your stomach down to your knees, as though your legs were falling asleep.  Wobbling slightly, you stand up and take a few stumbling steps to work the blood back into them.  The sensation fades, but your grace fails to return and you stumble again.  You'll have to be a little more careful moving around for a while.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 				dynStats("spe", -1);
 			}
 			//- corruption increases by 1 up to low threshold (~20)

--- a/classes/classes/Items/Consumables/SnakeOil.as
+++ b/classes/classes/Items/Consumables/SnakeOil.as
@@ -58,7 +58,7 @@ package classes.Items.Consumables
 				dynStats("spe", (2 - (player.spe / 10 / 5)));
 				outputText("\n\nYour muscles quiver, feeling ready to strike as fast as a snake!");
 				if (player.spe100 < 40) outputText("  Of course, you're nowhere near as fast as that.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Neck restore
 			if (player.neck.type != NECK_TYPE_NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);

--- a/classes/classes/Items/Consumables/Taurinum.as
+++ b/classes/classes/Items/Consumables/Taurinum.as
@@ -26,7 +26,7 @@ package classes.Items.Consumables
 			clearOutput();
 			outputText("You down the potion, grimacing at the strong taste.");
 			if (changes < changeLimit && rand(2) === 0 && player.spe100 < 80) {
-				changes++;
+				//[removed:1.4.10]//changes++;
 				outputText("\n\nAfter drinking the potion, you feel a bit faster.");
 				dynStats("spe", 1);
 			}

--- a/classes/classes/Items/Consumables/TonOTrice.as
+++ b/classes/classes/Items/Consumables/TonOTrice.as
@@ -57,14 +57,14 @@ package classes.Items.Consumables
 				if (player.lib < 75) dynStats("spe", 1);
 				//+1 if above 75.
 				dynStats("spe", 1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 
 			if (player.tou > player.ngPlus(80) && changes < changeLimit && rand(4) == 0) {
 				outputText("\n\nYou feel yourself become a little more delicate, as though you can’t handle quite so strong hits anymore. Then again,"
 				          +" who needs to withstand a blow when you can just move with the speed of the wind and dodge it?");
 				dynStats("tou", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 
 			}
 
@@ -72,7 +72,7 @@ package classes.Items.Consumables
 			if (player.sens > 20 && changes < changeLimit && rand(3) == 0) {
 				outputText("\n\nThe sensation of prickly pins and needles moves over your body, leaving your senses a little dulled in its wake.");
 				dynStats("sen", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 
 			//Raises libido greatly to 50, then somewhat to 75, then slowly to 100.
@@ -101,7 +101,7 @@ package classes.Items.Consumables
 				if (player.lib < 75) dynStats("lib", 1);
 				//+1 if above 75.
 				dynStats("lib", 1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 
 			//Sexual changes

--- a/classes/classes/Items/Consumables/TrapOil.as
+++ b/classes/classes/Items/Consumables/TrapOil.as
@@ -38,26 +38,26 @@ package classes.Items.Consumables
 			if (player.spe100 < 100 && rand(3) === 0 && changes < changeLimit) {
 				outputText("\n\nYou feel fleet and lighter on your toes; you sense you could dodge, dart or skip away from anything.");
 				dynStats("spe", 1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Strength Loss:
 			else if (player.str100 > 40 && rand(3) === 0 && changes < changeLimit) {
 				outputText("\n\nA sense of helplessness settles upon you as your limbs lose mass, leaving you feeling weaker and punier.");
 				dynStats("str", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Sensitivity Increase:
 			if (player.sens100 < 70 && player.hasCock() && rand(3) === 0 && changes < changeLimit) {
 				outputText("\n\nA light breeze brushes over you and your skin tingles.  You have become more sensitive to physical sensation.");
 				dynStats("sen", 5);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Libido Increase:
 			if (player.lib100 < 70 && player.hasVagina() && rand(3) === 0 && changes < changeLimit) {
 				outputText("\n\nYou feel your blood quicken and rise, and a desire to... hunt builds within you.");
 				dynStats("lib", 2);
 				if (player.lib100 < 30) dynStats("lib", 2);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Body Mass Loss:
 			if (player.thickness > 40 && rand(3) === 0 && changes < changeLimit) {

--- a/classes/classes/Items/Consumables/WhiskerFruit.as
+++ b/classes/classes/Items/Consumables/WhiskerFruit.as
@@ -53,14 +53,14 @@ package classes.Items.Consumables
 					outputText("\n\nYou pause mid-step and crouch. Your leg muscles have cramped up like crazy. After a few moments, the pain passes and you feel like you could chase anything down.");
 					dynStats("spe", .5);
 				}
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Strength raises to 40
 			if (player.str100 < 40 && rand(3) === 0 && changes < changeLimit) {
 				if (rand(2) === 0) outputText("\n\nYour muscles feel taut, like a coiled spring, and a bit more on edge.");
 				else outputText("\n\nYou arch your back as your muscles clench painfully.  The cramp passes swiftly, leaving you feeling like you've gotten a bit stronger.");
 				dynStats("str", 1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Strength ALWAYS drops if over 60
 			//Does not add to change total
@@ -94,7 +94,7 @@ package classes.Items.Consumables
 				//High intelligence
 				else outputText("\n\nYou start to feel a bit dizzy, but the sensation quickly passes.  Thinking hard on it, you mentally brush away the fuzziness that seems to permeate your brain and determine that this fruit may have actually made you dumber.  It would be best not to eat too much of it.");
 				dynStats("int", -1);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//Libido gain
 			if (player.lib100 < 80 && changes < changeLimit && rand(4) === 0) {
@@ -113,7 +113,7 @@ package classes.Items.Consumables
 					outputText("turned on.");
 				}
 				dynStats("lib", 1, "sen", .25);
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			
 			//Sexual changes would go here if I wasn't a tard.

--- a/classes/classes/Items/Consumables/WolfPepper.as
+++ b/classes/classes/Items/Consumables/WolfPepper.as
@@ -44,20 +44,20 @@ package classes.Items.Consumables
 				dynStats("tou", (1 * crit));
 				if (crit > 1) outputText("\n\nYou roll your shoulders and tense your arms experimentally. You feel more durable, and your blood seems to run through you more clearly. You know you have more endurance.");
 				else outputText("\n\nYour muscles feel denser and more durable. Not so much that feel stronger, but you feel like you can take more hits.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			if (player.spe100 > 30 && rand(7) === 0 && changes < changeLimit) {
 				dynStats("spe", (-1 * crit));
 				if (crit > 1) outputText("\n\nThe pepper's strong taste makes you take a couple steps back and lean against the nearest solid object. You don't feel like you'll be moving very fast anymore.");
 				else outputText("\n\nYou stumble forward, but manage to catch yourself. Still, though, you feel somewhat slower.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			if (player.inte100 < 60 && rand(7) === 0 && changes < changeLimit) {
 				dynStats("int", (1 * crit));
 				outputText("\n\nThe spiciness makes your head twirl, but you manage to gather yourself. A strange sense of clarity comes over you in the aftermath, and you feel ");
 				if (crit > 1) outputText("a lot ");
 				outputText("smarter somehow.");
-				changes++;
+				//[removed:1.4.10]//changes++;
 			}
 			//MUTATIONZZZZZ
 			//PRE-CHANGES: become biped, remove horns, remove wings, give human tongue, remove claws, remove antennea

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -1555,7 +1555,7 @@ package classes.Scenes.Places.Bazaar
 			// Stats Changes
 			//------------
 			if (rand(3) == 0 && player.str100 < 100) {
-				changes++;
+				//[removed:1.4.10]//changes++;
 				if (player.str100 < 50) {
 					outputText("\n\nShivering, you feel a feverish sensation that reminds you of the last time you got sick. Thankfully, it passes swiftly, leaving slightly enhanced strength in its wake.");
 					dynStats("str", .5);


### PR DESCRIPTION
### Gameplay changes
- Removed `changes++` from str, tou, spe, int, lib and sens
- Same for going into rut/heat as a dragon.
- Removed the `changes++` from Ectoplasm, when it resulted into no TF.

### Notes
Quite often the stat changes resulted in the changeLimit being reached. Thus the TF didn't result in any body part being TFed. With this change many TF should be at least a little faster. On the other hand the flag `TIMES_TRANSFORMED` went up quite fast so you'd reach the threshold for transformation resistance a bit too fast IMHO. Then some TF could have resulted into more `TIMES_TRANSFORMED++` after all possible body part changes have finished. Other TFs (e. g. dragon TF and ectoplasm aka ghost TF) resulted into unlimited `changes++`, although no actual TF has occured.
The only drawback would be, that players who target the **Transformation Resistance Perk** now need more transformatives to reach that goal.