### PR TITLE
Inject RNG

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -25,9 +25,14 @@ import classes.internals.profiling.Begin;
 import classes.internals.profiling.End;
 
 import flash.errors.IllegalOperationError;
+import classes.internals.LoggerFactory;
+import flash.display.InteractiveObject;
+import flash.errors.IllegalOperationError;
+import mx.logging.ILogger;
 
 	public class Creature extends Utils
 	{
+		private static const LOGGER:ILogger = LoggerFactory.getLogger(Creature);
 
 		include "../../includes/appearanceDefs.as";
 
@@ -2797,9 +2802,11 @@ import flash.errors.IllegalOperationError;
 				//Reset the timer on it to 0 when restretched.
 				else changeStatusValue(StatusEffects.ButtStretched,1,0);
 			}
+			
 			if (stretched) {
-				trace("BUTT STRETCHED TO " + (ass.analLooseness) + ".");
+				LOGGER.debug("Butt Stretched to {0}", ass.analLooseness);
 			}
+			
 			return stretched;
 		}
 

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -2768,24 +2768,24 @@ import flash.errors.IllegalOperationError;
 		public function buttChangeNoDisplay(cArea:Number):Boolean {
 			var stretched:Boolean = false;
 			//cArea > capacity = autostreeeeetch half the time.
-			if (cArea >= analCapacity() && rand(2) == 0) {
+			if (cArea >= analCapacity() && rng.random(2) === 0) {
 				ass.analLooseness++;
 				stretched = true;
 				//Reset butt stretchin recovery time
 				if (hasStatusEffect(StatusEffects.ButtStretched)) changeStatusValue(StatusEffects.ButtStretched,1,0);
 			}
 			//If within top 10% of capacity, 25% stretch
-			if (cArea < analCapacity() && cArea >= .9*analCapacity() && rand(4) == 0) {
+			if (cArea < analCapacity() && cArea >= .9*analCapacity() && rng.random(4) === 0) {
 				ass.analLooseness++;
 				stretched = true;
 			}
 			//if within 75th to 90th percentile, 10% stretch
-			if (cArea < .9 * analCapacity() && cArea >= .75 * analCapacity() && rand(10) == 0) {
+			if (cArea < .9 * analCapacity() && cArea >= .75 * analCapacity() && rng.random(10) === 0) {
 				ass.analLooseness++;
 				stretched = true;
 			}
 			//Anti-virgin
-			if (ass.analLooseness == 0) {
+			if (ass.analLooseness === 0) {
 				ass.analLooseness++;
 				stretched = true;
 			}

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -2771,6 +2771,7 @@ import mx.logging.ILogger;
 		}
 
 		public function buttChangeNoDisplay(cArea:Number):Boolean {
+			LOGGER.debug("Attempting anal stretch for {0} with anal capacity of {1} vs a cock area of {2}", this, analCapacity(), cArea);
 			var stretched:Boolean = false;
 			//cArea > capacity = autostreeeeetch half the time.
 			if (cArea >= analCapacity() && rng.random(2) === 0) {

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -54,8 +54,7 @@ import mx.logging.ILogger;
 		 * Normally creatures do not need a unique RNG,
 		 * so to avoid unnecessary memory usage they use the default instance.
 		 */
-		private static const DEFAULT_RNG:IRandomNumber = new RandomNumber();
-		private var _rng:IRandomNumber = DEFAULT_RNG;
+		private var _rng:IRandomNumber = Utils.DEFAULT_RNG;
 		
 		/**
 		 * Set the RNG this class uses. Intended for testing.

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -2778,7 +2778,9 @@ import mx.logging.ILogger;
 				ass.analLooseness++;
 				stretched = true;
 				//Reset butt stretchin recovery time
-				if (hasStatusEffect(StatusEffects.ButtStretched)) changeStatusValue(StatusEffects.ButtStretched,1,0);
+				if (hasStatusEffect(StatusEffects.ButtStretched)) {
+					changeStatusValue(StatusEffects.ButtStretched,1,0);
+				}
 			}
 			//If within top 10% of capacity, 25% stretch
 			if (cArea < analCapacity() && cArea >= .9*analCapacity() && rng.random(4) === 0) {
@@ -2795,13 +2797,20 @@ import mx.logging.ILogger;
 				ass.analLooseness++;
 				stretched = true;
 			}
-			if (ass.analLooseness > 5) ass.analLooseness = 5;
+			
+			if (ass.analLooseness > 5) {
+				ass.analLooseness = 5;
+			}
 			//Delay un-stretching
 			if (cArea >= .5 * analCapacity()) {
 				//Butt Stretched used to determine how long since last enlargement
-				if (!hasStatusEffect(StatusEffects.ButtStretched)) createStatusEffect(StatusEffects.ButtStretched,0,0,0,0);
+				if (!hasStatusEffect(StatusEffects.ButtStretched)) {
+					createStatusEffect(StatusEffects.ButtStretched,0,0,0,0);
+				}
 				//Reset the timer on it to 0 when restretched.
-				else changeStatusValue(StatusEffects.ButtStretched,1,0);
+				else {
+					changeStatusValue(StatusEffects.ButtStretched,1,0);
+				}
 			}
 			
 			if (stretched) {

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -16,7 +16,11 @@ import classes.StatusEffects.Combat.CombatStrBuff;
 import classes.StatusEffects.Combat.CombatTouBuff;
 import classes.internals.Profiling;
 import classes.internals.Utils;
-	import classes.Scenes.Places.TelAdre.UmasShop;
+import classes.internals.IRandomNumber;
+import classes.internals.RandomNumber;
+import classes.internals.Utils;
+import classes.VaginaClass;
+import classes.Scenes.Places.TelAdre.UmasShop;
 import classes.internals.profiling.Begin;
 import classes.internals.profiling.End;
 
@@ -40,6 +44,35 @@ import flash.errors.IllegalOperationError;
 		//"a" refers to how the article "a" should appear in text. 
 		private var _short:String = "You";
 		private var _a:String = "a ";
+		
+		/**
+		 * Normally creatures do not need a unique RNG,
+		 * so to avoid unnecessary memory usage they use the default instance.
+		 */
+		private static const DEFAULT_RNG:IRandomNumber = new RandomNumber();
+		private var _rng:IRandomNumber = DEFAULT_RNG;
+		
+		/**
+		 * Set the RNG this class uses. Intended for testing.
+		 * @param	rng to use for random numbers
+		 * @return the RNG that was set
+		 */
+		public function set rng(rng:IRandomNumber):void {
+			if (rng === null) {
+				throw new ArgumentError("RNG cannot be null");
+			}
+			
+			this._rng = rng;
+		}
+		
+		/**
+		 * Get the RNG this class uses. Intended for testing.
+		 * @return the RNG used
+		 */
+		public function get rng():IRandomNumber {
+			return this._rng;
+		}
+		
 		public function get short():String { return _short; }
 		public function set short(value:String):void { _short = value; }
 		public function get a():String { return _a; }

--- a/classes/classes/Scenes/Places/Bazaar.as
+++ b/classes/classes/Scenes/Places/Bazaar.as
@@ -18,13 +18,15 @@ package classes.Scenes.Places{
 //Set Up With The Travelling, Tainted Bazaar
 public function Bazaar(){
 }
+		private var rng:IRandomNumber = new RandomNumber();
+
 		public var blackCock:BlackCock = new BlackCock();
 		public var benoit:Benoit = new Benoit();
 		public var cinnabar:Cinnabar = new Cinnabar();
 		public var fapArena:FapArena = new FapArena();
 		public var lilium:Lilium = new Lilium();
-		public var roxanne:Roxanne = new Roxanne();
 		public var chillySmith:ChillySmith = new ChillySmith();
+		public var roxanne:Roxanne = new Roxanne(rng);
 
 //[Find Travelling Bazaar]
 public function findBazaar():void {

--- a/classes/classes/Scenes/Places/Bazaar/Roxanne.as
+++ b/classes/classes/Scenes/Places/Bazaar/Roxanne.as
@@ -192,31 +192,62 @@ protected function roxanneDrinkingContest():void {
 	spriteSelect(SpriteDb.s_poisontail);
 	clearOutput();
 	outputText("Roxanne ");
-	if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 200) outputText("stumbles over her huge manhood, working towards");
-	else outputText("saunters over to");
+	
+	if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 200) {
+		outputText("stumbles over her huge manhood, working towards");
+	} else { 
+		outputText("saunters over to");
+	}
+	
 	outputText(" the demonic-looking deer-taur working the tap and gives him a weighty gem-pouch, covering the cost of the contest and her mates' drinking in advance.  She lets the keg-keep top off the mug and throws it back, easily draining it with a few practiced swallows.  Her tail slaps the table in front of you as she teases, \"<i>Are you going to check me out all day or get smashed?  Come on!</i>\"\n\n");
 	outputText("You take the mug and hand it to the tainted 'taur working the tap.  ");
+	
 	if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] + flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] <= 0 || flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] == 2) {
 		outputText("He smirks at you as he fills it, radiating amusement at your attempt to out-drink Roxanne Poisontail.  It seems the locals don't believe you can win");
-		if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] == 2) outputText(" after your last humiliation.");
-		else outputText(" against such a renowned foe.");
+	
+		if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] == 2) {
+			outputText(" after your last humiliation.");
+		} else {
+			outputText(" against such a renowned foe.");
+		}
+	} else {
+		outputText("He leers at Roxanne as he fills your mug, remembering her last defeat and likely wishing he could feel her tongue as you did.");
 	}
-	else outputText("He leers at Roxanne as he fills your mug, remembering her last defeat and likely wishing he could feel her tongue as you did.");
+	
 	outputText("  You ");
-	if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] + flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] < 3) outputText("hesitantly sniff at the brew, taking in its dark color and heady, hoppy aroma before");
-	else outputText("smile and lick your lips, inhaling the hoppy aroma before");
+	if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] + flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] < 3) {
+		outputText("hesitantly sniff at the brew, taking in its dark color and heady, hoppy aroma before");
+	} else {
+		outputText("smile and lick your lips, inhaling the hoppy aroma before");
+	}
+	
 	outputText(" you slam the dark beer back and swallow.\n\n");
 		
 	//(FIRST TIME) 
-	if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] + flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] <= 0) outputText("\"<i>You call that drinking?  Watch and learn, " + player.mf("brother","sister") + "!</i>\" shouts Roxanne triumphantly as she holds her mug aloft overhead.  The frothy beverage begins to pour out, an amber waterfall of intoxicant raining down towards the lizan's face, but the canny pirate is ready for it.  She opens her jaw and extends her tongue, over two feet of the pink-hued organ, catching the alcoholic downpour and funneling it past her smiling lips.  Finished, she belches loudly and pumps her hips at you rudely.  \"<i>I hope you're ready to get fucked!</i>\"\n\n");
+	if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] + flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] <= 0) 
+	{
+		outputText("\"<i>You call that drinking?  Watch and learn, " + player.mf("brother","sister") + "!</i>\" shouts Roxanne triumphantly as she holds her mug aloft overhead.  The frothy beverage begins to pour out, an amber waterfall of intoxicant raining down towards the lizan's face, but the canny pirate is ready for it.  She opens her jaw and extends her tongue, over two feet of the pink-hued organ, catching the alcoholic downpour and funneling it past her smiling lips.  Finished, she belches loudly and pumps her hips at you rudely.  \"<i>I hope you're ready to get fucked!</i>\"\n\n");
+	}
 	//(REPEAT: PC HAS NOT YET WON) 
-	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] == 0) outputText("\"<i>You still drink like an amateur.  Still, it doesn't surprise me that you came back to old Captain Poisontail for a bout with my little manhood,</i>\" teases the lizan pirate as she wraps her tongue around the handle and lifts it to her lips, gulping the entire thing in one huge, throat-relaxing chug.  Roxanne belches loudly and pumps her hips at you as she says, \"<i>Ready for another fucking?</i>\"\n\n");
+	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] == 0) 
+	{
+		outputText("\"<i>You still drink like an amateur.  Still, it doesn't surprise me that you came back to old Captain Poisontail for a bout with my little manhood,</i>\" teases the lizan pirate as she wraps her tongue around the handle and lifts it to her lips, gulping the entire thing in one huge, throat-relaxing chug.  Roxanne belches loudly and pumps her hips at you as she says, \"<i>Ready for another fucking?</i>\"\n\n");
+	}
 	//(REPEAT: PC HAS WON AND NEVER LOST)
-	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] > 0 && flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] <= 0) outputText("\"<i>Last time I wasn't ready!  Well, I guess it's on!  This time I won't lose, and you can bet I'm gonna ride you twice as hard for payback!</i>\" Roxanne shouts with a feigned air of confidence.  She downs her drink quickly, foam frothing at the corners of her draconian muzzle in her hurry not to be outdone by you.  As you watch, she licks her lips and shivers, fidgeting uncomfortably while her cursed cock gets a bit harder in her pants.\n\n");
+	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] > 0 && flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] <= 0)
+	{
+		outputText("\"<i>Last time I wasn't ready!  Well, I guess it's on!  This time I won't lose, and you can bet I'm gonna ride you twice as hard for payback!</i>\" Roxanne shouts with a feigned air of confidence.  She downs her drink quickly, foam frothing at the corners of her draconian muzzle in her hurry not to be outdone by you.  As you watch, she licks her lips and shivers, fidgeting uncomfortably while her cursed cock gets a bit harder in her pants.\n\n");
+	}
 	//(REPEAT: PC HAS LOST BEFORE BUT WON LAST TIME)
-	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 0 && flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] == 1) outputText("\"<i>Don't get cocky, pup.  Roxanne Poisontail has defeated and claimed bigger sailors than you in her lifetime.  That last time was a fluke,</i>\" she proclaims.  The determined lizan swishes her full mug around for a moment before downing it in one huge, throat-bulging gulp.   Her prehensile tail slaps your " + player.buttDescript() + " without warning, and she chuckles when you nearly lurch out of your seat in surprise.  \"<i>That's just a warm-up.</i>\"\n\n");
+	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 0 && flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] == 1) 
+	{
+		outputText("\"<i>Don't get cocky, pup.  Roxanne Poisontail has defeated and claimed bigger sailors than you in her lifetime.  That last time was a fluke,</i>\" she proclaims.  The determined lizan swishes her full mug around for a moment before downing it in one huge, throat-bulging gulp.   Her prehensile tail slaps your " + player.buttDescript() + " without warning, and she chuckles when you nearly lurch out of your seat in surprise.  \"<i>That's just a warm-up.</i>\"\n\n");
+	}
 	//(REPEAT: PC HAS WON BEFORE BUT LOST LAST TIME) 
-	else outputText("\"<i>Don't you realize any previous victory was a fluke?  Watch and learn pup,</i>\" taunts Roxanne as she devours her mug in a single, throat-bulging swallow.  You chuckle, an involuntary burp interrupting your mirth as the piratical lizan pumps her hips at you rudely, her bulging manhood clearly outlined in the suddenly-tight trousers.  \"<i>I can't wait to bury this thing inside your ass again!</i>\"\n\n");
+	else 
+	{
+		outputText("\"<i>Don't you realize any previous victory was a fluke?  Watch and learn pup,</i>\" taunts Roxanne as she devours her mug in a single, throat-bulging swallow.  You chuckle, an involuntary burp interrupting your mirth as the piratical lizan pumps her hips at you rudely, her bulging manhood clearly outlined in the suddenly-tight trousers.  \"<i>I can't wait to bury this thing inside your ass again!</i>\"\n\n");
+	}
 
 	//[DRINKING CONTEST CONTINUES – not losing intentionally]
 	if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LOSE_ON_PURPOSE] == 0) {
@@ -292,11 +323,13 @@ protected function roxanneDrinkingContest():void {
 		} else {
 			addDisabledButton(0, "Cunnilingus");
 		}
+		
 		if (player.hasCock()) {
 			addButton(1, "Fellatio", roxanneGivesABlowjob);
 		} else {
 			addDisabledButton(1, "Fellatio");
 		}
+		
 		addButton(2, "Rimming", roxanneRimjob);
 	}
 }

--- a/classes/classes/Scenes/Places/Bazaar/Roxanne.as
+++ b/classes/classes/Scenes/Places/Bazaar/Roxanne.as
@@ -59,7 +59,7 @@ WIN:
 			//Increase Roxanne's growing dick size...
 			flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX]++;
 			//Reset if she finds someone to take it (random at high values)
-			if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 300 && model.time.hours == 1 && rand(5) == 0) flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 1;
+			if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 300 && model.time.hours == 1 && randomNumber.random(5) == 0) flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 1;
 			//hangover status stuff
 			if (player.hasStatusEffect(StatusEffects.Hangover)) {
 			//Countdown
@@ -243,7 +243,7 @@ protected function roxanneDrinkingContest():void {
 	}
 	//If score is less than 30-50 (Strahza is inconsistant!)
 	//[Lose!] 
-	if (score < (45 + rand(20))) {
+	if (score < (45 + randomNumber.random(20))) {
 		LOGGER.debug("Lost to Roxanne with a score of {0}", score);
 		//Increment loss count!
 		flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST]++;
@@ -262,7 +262,7 @@ protected function roxanneDrinkingContest():void {
 		outputText("  A scaled hand slaps your " + player.buttDescript() + " spinning you around to fall drunkenly into the pirate's soft, cushy chest.  \"<i>Don't worry, I'll be gentle,</i>\" she whispers, hooking an arm around your sagging frame.");
 		//CHOOSE SEX SCENE
 		//Chance of big booty butt loss!
-		if (player.buttRating > 12 && player.tone <= 50 && flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 1 && rand(2) == 0){
+		if (player.buttRating > 12 && player.tone <= 50 && flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 1 && randomNumber.random(2) == 0){
 			LOGGER.debug("Starting loss scene: Big booty");
 			doNext(bigBootyRoxanneContestLoss);
 		} else if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 200) {

--- a/classes/classes/Scenes/Places/Bazaar/Roxanne.as
+++ b/classes/classes/Scenes/Places/Bazaar/Roxanne.as
@@ -1,6 +1,8 @@
 package classes.Scenes.Places.Bazaar{
 	import classes.*;
 	import classes.GlobalFlags.kFLAGS;
+	import classes.internals.IRandomNumber;
+	import classes.internals.RandomNumber;
 	import mx.logging.ILogger;
 	import classes.internals.LoggerFactory;
 	import classes.display.SpriteDb;
@@ -8,6 +10,8 @@ package classes.Scenes.Places.Bazaar{
 
 	public class Roxanne extends BazaarAbstractContent implements TimeAwareInterface {
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(Roxanne);
+		
+		private var randomNumber:IRandomNumber;
 //Roxanne Poisontail
 //-no hair, 
 //-stand roughly 5'11\" in height, 
@@ -43,9 +47,10 @@ WIN:
 //226 -Is PC losing the Roxanne's drinking contest intentionally?
 //227 -Drinking Contest Bonus Score
 
-		public function Roxanne()
+		public function Roxanne(randomNumber:IRandomNumber = null)
 		{
 			CoC.timeAwareClassAdd(this);
+			this.randomNumber = randomNumber;
 		}
 
 		//Implementation of TimeAwareInterface

--- a/classes/classes/Scenes/Places/Bazaar/Roxanne.as
+++ b/classes/classes/Scenes/Places/Bazaar/Roxanne.as
@@ -47,7 +47,7 @@ WIN:
 //226 -Is PC losing the Roxanne's drinking contest intentionally?
 //227 -Drinking Contest Bonus Score
 
-		public function Roxanne(randomNumber:IRandomNumber = null)
+		public function Roxanne(randomNumber:IRandomNumber)
 		{
 			CoC.timeAwareClassAdd(this);
 			this.randomNumber = randomNumber;

--- a/classes/classes/Scenes/Places/Bazaar/Roxanne.as
+++ b/classes/classes/Scenes/Places/Bazaar/Roxanne.as
@@ -59,12 +59,16 @@ WIN:
 			//Increase Roxanne's growing dick size...
 			flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX]++;
 			//Reset if she finds someone to take it (random at high values)
-			if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 300 && model.time.hours == 1 && randomNumber.random(5) == 0) flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 1;
+			if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 300 && model.time.hours === 1 && randomNumber.random(5) === 0) {
+				flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 1;
+			}
+			
 			//hangover status stuff
 			if (player.hasStatusEffect(StatusEffects.Hangover)) {
 			//Countdown
-				if (player.statusEffectv1(StatusEffects.Hangover) > 0) player.addStatusValue(StatusEffects.Hangover,1,-1);
-				else {
+				if (player.statusEffectv1(StatusEffects.Hangover) > 0) {
+					player.addStatusValue(StatusEffects.Hangover,1,-1);
+				} else {
 					outputText("\n<b>Your head finally clears as your hangover wears off.  Drinking with the shemale lizard was definitely a bad idea.</b>\n");
 					//Restore stats
 					player.str += player.statusEffectv2(StatusEffects.Hangover);
@@ -76,7 +80,11 @@ WIN:
 					return true;
 				}
 			}
-			if (model.time.hours > 23 && flags[kFLAGS.ROXANNE_DRINKING_CONTEST_BONUS_SCORE] > 0) flags[kFLAGS.ROXANNE_DRINKING_CONTEST_BONUS_SCORE]--; //Reduce drinking contest bonus
+			
+			if (model.time.hours > 23 && flags[kFLAGS.ROXANNE_DRINKING_CONTEST_BONUS_SCORE] > 0) {
+				flags[kFLAGS.ROXANNE_DRINKING_CONTEST_BONUS_SCORE]--; //Reduce drinking contest bonus
+			}
+			
 			return false;
 		}
 	
@@ -202,10 +210,10 @@ protected function roxanneDrinkingContest():void {
 	outputText(" the demonic-looking deer-taur working the tap and gives him a weighty gem-pouch, covering the cost of the contest and her mates' drinking in advance.  She lets the keg-keep top off the mug and throws it back, easily draining it with a few practiced swallows.  Her tail slaps the table in front of you as she teases, \"<i>Are you going to check me out all day or get smashed?  Come on!</i>\"\n\n");
 	outputText("You take the mug and hand it to the tainted 'taur working the tap.  ");
 	
-	if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] + flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] <= 0 || flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] == 2) {
+	if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] + flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] <= 0 || flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] === 2) {
 		outputText("He smirks at you as he fills it, radiating amusement at your attempt to out-drink Roxanne Poisontail.  It seems the locals don't believe you can win");
 	
-		if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] == 2) {
+		if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] === 2) {
 			outputText(" after your last humiliation.");
 		} else {
 			outputText(" against such a renowned foe.");
@@ -229,7 +237,7 @@ protected function roxanneDrinkingContest():void {
 		outputText("\"<i>You call that drinking?  Watch and learn, " + player.mf("brother","sister") + "!</i>\" shouts Roxanne triumphantly as she holds her mug aloft overhead.  The frothy beverage begins to pour out, an amber waterfall of intoxicant raining down towards the lizan's face, but the canny pirate is ready for it.  She opens her jaw and extends her tongue, over two feet of the pink-hued organ, catching the alcoholic downpour and funneling it past her smiling lips.  Finished, she belches loudly and pumps her hips at you rudely.  \"<i>I hope you're ready to get fucked!</i>\"\n\n");
 	}
 	//(REPEAT: PC HAS NOT YET WON) 
-	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] == 0) 
+	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_WON] === 0) 
 	{
 		outputText("\"<i>You still drink like an amateur.  Still, it doesn't surprise me that you came back to old Captain Poisontail for a bout with my little manhood,</i>\" teases the lizan pirate as she wraps her tongue around the handle and lifts it to her lips, gulping the entire thing in one huge, throat-relaxing chug.  Roxanne belches loudly and pumps her hips at you as she says, \"<i>Ready for another fucking?</i>\"\n\n");
 	}
@@ -239,7 +247,7 @@ protected function roxanneDrinkingContest():void {
 		outputText("\"<i>Last time I wasn't ready!  Well, I guess it's on!  This time I won't lose, and you can bet I'm gonna ride you twice as hard for payback!</i>\" Roxanne shouts with a feigned air of confidence.  She downs her drink quickly, foam frothing at the corners of her draconian muzzle in her hurry not to be outdone by you.  As you watch, she licks her lips and shivers, fidgeting uncomfortably while her cursed cock gets a bit harder in her pants.\n\n");
 	}
 	//(REPEAT: PC HAS LOST BEFORE BUT WON LAST TIME)
-	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 0 && flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] == 1) 
+	else if (flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 0 && flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LAST_WINNER] === 1) 
 	{
 		outputText("\"<i>Don't get cocky, pup.  Roxanne Poisontail has defeated and claimed bigger sailors than you in her lifetime.  That last time was a fluke,</i>\" she proclaims.  The determined lizan swishes her full mug around for a moment before downing it in one huge, throat-bulging gulp.   Her prehensile tail slaps your " + player.buttDescript() + " without warning, and she chuckles when you nearly lurch out of your seat in surprise.  \"<i>That's just a warm-up.</i>\"\n\n");
 	}
@@ -250,10 +258,15 @@ protected function roxanneDrinkingContest():void {
 	}
 
 	//[DRINKING CONTEST CONTINUES – not losing intentionally]
-	if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LOSE_ON_PURPOSE] == 0) {
+	if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LOSE_ON_PURPOSE] === 0) {
 		outputText("The 'taur at the tap quickly grows bored with the constant bantering between the scaly swashbuckler and yourself, only bothering to look your way when the two of you walk back for a refill.  The gluttonous chugging that started the contest gives way to a more languid pace as you and Roxanne become increasingly intoxicated, slowing down in hopes that the other will be judged unfit first.  It does get a little hard to focus with the way she's constantly eyeballing you, and her curvy figure and ");
-		if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 200) outputText("massive, seam-ripping bulge");
-		else outputText("hard-to-hide bulge");
+		
+		if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 200) {
+			outputText("massive, seam-ripping bulge");
+		} else {
+			outputText("hard-to-hide bulge");
+		}
+		
 		outputText(" give you more than an eyeful every time you return her leer.  Still, the scaly shemale must be feeling the same way, judging by the large damp spot her cock is making.\n\n");
 		dynStats("lus", 25);
 	}
@@ -261,16 +274,35 @@ protected function roxanneDrinkingContest():void {
 	else {
 		outputText("The 'taur at the tap quickly grows bored with the constant bantering from Roxanne and the flirting you shower the lizan in.  You down your drinks quickly, even sneaking refills while the lizan is distracted in order to speed your inevitable loss.  She looks at you, clearly checking you out while you unabashedly fixate on the pulsing mass of cock-flesh that strains her oh-so-tight pants.  Roxanne stops drinking and walks over to you, a little unsteady but still in control of herself, and pulls your head against her groin, letting you nuzzle it while she puts filled mugs in your hands.  \"<i>Go on and drink... good " + player.mf("boy","girl") + ",</i>\" she coos when you turn to the side and swallow more of the delicious brew.\n\n");
 	}
+	
 	var score:Number = 0;
+	
 	//Calculate score if not 
-	if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LOSE_ON_PURPOSE] == 0) {
+	if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LOSE_ON_PURPOSE] === 0) {
 		score = (player.tallness * ((player.thickness + 100) / 200) * (player.tou / 100)) + flags[kFLAGS.ROXANNE_DRINKING_CONTEST_BONUS_SCORE];
-		if (player.findPerk(PerkLib.SatyrSexuality) >= 0) score += 10; // satyrs are not easy to beat in drinking contest!
-		if (player.findPerk(PerkLib.Lustzerker) >= 0) score += 10; // as well as salamanders
-		if (player.findPerk(PerkLib.Dragonfire) >= 0) score += 10; // and dragons
-		if (player.findPerk(PerkLib.EnlightenedNinetails) >= 0 || player.findPerk(PerkLib.CorruptedNinetails) >= 0) score += 10; // kitsune would always find a way to trick
-		if (player.findPerk(PerkLib.Medicine) >= 0) score += 5; // it gives poison resistances, after all
-		if (player.findPerk(PerkLib.Resolute) >= 0) score += 5; // never surrender!
+		if (player.findPerk(PerkLib.SatyrSexuality) >= 0) {
+			score += 10; // satyrs are not easy to beat in drinking contest!
+		}
+		
+		if (player.findPerk(PerkLib.Lustzerker) >= 0) {
+			score += 10; // as well as salamanders
+		}
+		
+		if (player.findPerk(PerkLib.Dragonfire) >= 0) {
+			score += 10; // and dragons
+		}
+		
+		if (player.findPerk(PerkLib.EnlightenedNinetails) >= 0 || player.findPerk(PerkLib.CorruptedNinetails) >= 0) {
+			score += 10; // kitsune would always find a way to trick
+		}
+		
+		if (player.findPerk(PerkLib.Medicine) >= 0) {
+			score += 5; // it gives poison resistances, after all
+		}
+		
+		if (player.findPerk(PerkLib.Resolute) >= 0) {
+			score += 5; // never surrender!
+		}
 	}
 	//If score is less than 30-50 (Strahza is inconsistant!)
 	//[Lose!] 
@@ -284,7 +316,7 @@ protected function roxanneDrinkingContest():void {
 		flags[kFLAGS.ROXANNE_DRINKING_CONTEST_BONUS_SCORE] += 10;
 		outputText("Giggling and nearly tripping up on your own " + player.feet() + ", you stumble up to the corrupted deer-taur.  He looks at your wobbling stance, nearly-vacant eyes, and dopey grin before he shakes his head from side to side and says, \"<i>No.</i>\"  ");
 		
-		if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LOSE_ON_PURPOSE] == 0) {
+		if (flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LOSE_ON_PURPOSE] === 0) {
 			outputText("Nooooo! You're cut off! That means Roxanne won...");
 		}else{
 			outputText("Yessss!  You finally got so drunk that Roxanne has no excuse not to pack your drunk ass full of lizan-spoo!");
@@ -293,7 +325,7 @@ protected function roxanneDrinkingContest():void {
 		outputText("  A scaled hand slaps your " + player.buttDescript() + " spinning you around to fall drunkenly into the pirate's soft, cushy chest.  \"<i>Don't worry, I'll be gentle,</i>\" she whispers, hooking an arm around your sagging frame.");
 		//CHOOSE SEX SCENE
 		//Chance of big booty butt loss!
-		if (player.buttRating > 12 && player.tone <= 50 && flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 1 && randomNumber.random(2) == 0){
+		if (player.buttRating > 12 && player.tone <= 50 && flags[kFLAGS.ROXANNE_DRINING_CONTEST_LOST] > 1 && randomNumber.random(2) === 0){
 			LOGGER.debug("Starting loss scene: Big booty");
 			doNext(bigBootyRoxanneContestLoss);
 		} else if (flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] >= 200) {
@@ -318,6 +350,7 @@ protected function roxanneDrinkingContest():void {
 		outputText("The other lizans are looking at you with a watchful eye.  It looks like you'll have to stick by the terms of the contest.  What manner of oral service do you make her provide?");
 		//[Fellatio] [Cunnilingus] [Rimming]
 		menu();
+		
 		if (player.hasVagina()) {
 			addButton(0, "Cunnilingus", roxanneCunnilingus);
 		} else {

--- a/classes/classes/internals/IRandomNumber.as
+++ b/classes/classes/internals/IRandomNumber.as
@@ -1,0 +1,23 @@
+package classes.internals 
+{
+	
+	/**
+	 * Interface that provides methods for getting random numbers.
+	 */
+	public interface IRandomNumber
+	{
+		/**
+		 * Returns a number that is between 0 and max - 1 inclusive.
+		 * @param	max the upper limit for the random number
+		 * @return a value between 0 and max - 1
+		 */
+		function random(max:int):int;
+		
+		/**
+		 * Returns a number that is between 0 and max inclusive.
+		 * @param	max the upper limit for the random number
+		 * @return a value between 0 and max inclusive
+		 */
+		function randomCorrected(max:int):int;
+	}
+}

--- a/classes/classes/internals/RandomNumber.as
+++ b/classes/classes/internals/RandomNumber.as
@@ -1,0 +1,28 @@
+package classes.internals 
+{
+	/**
+	 * Class that provides random numbers.
+	 */
+	public class RandomNumber implements IRandomNumber
+	{
+		/**
+		 * Returns a number that is between 0 and max exclusive.
+		 * @param	max the upper limit for the random number
+		 * @return a value between 0 and max - 1
+		 */
+		public function random(max:int):int 
+		{
+			return Utils.rand(max);
+		}
+		
+		/**
+		 * Returns a number that is between 0 and max inclusive.
+		 * @param	max the upper limit for the random number
+		 * @return a value between 0 and max inclusive
+		 */
+		public function randomCorrected(max:int):int 
+		{
+			return Utils.rand(max + 1);
+		}
+	}
+}

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -10,6 +10,11 @@ package classes.internals
 		private static const NUMBER_WORDS_CAPITAL:Array		= ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"];
 		private static const NUMBER_WORDS_POSITIONAL:Array	= ["zeroth", "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth"];
 
+		/**
+		 * Default RNG instance. Uses Utils.rand internally.
+		 */
+		public static const DEFAULT_RNG:IRandomNumber = new RandomNumber();
+		
 		public function Utils()
 		{
 		}

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -344,6 +344,11 @@ package classes.internals
 			return false;
 		}
 		
+		/**
+		 * Generate a random number from 0 to max - 1 inclusive.
+		 * @param	max the upper limit for the generated number
+		 * @return a number from 0 to max - 1 inclusive
+		 */
 		public static function rand(max:Number):int
 		{
 			return int(Math.random() * max);

--- a/test/classes/CreatureTest.as
+++ b/test/classes/CreatureTest.as
@@ -1,4 +1,6 @@
 package classes{
+	import classes.internals.IRandomNumber;
+	import classes.internals.RandomNumber;
     import org.flexunit.asserts.*;
 	import org.hamcrest.assertThat;
 	import org.hamcrest.core.*;
@@ -58,7 +60,8 @@ package classes{
 		}
          
         [Before]
-        public function setUp():void {  
+        public function setUp():void {
+			cut = new Creature();
 			noVagina = new Creature();
 			
 			oneVagina = new Creature();
@@ -558,6 +561,21 @@ package classes{
 			noVagina.createVagina();
 			
 			assertThat(noVagina.gender, equalTo(GENDER_HERM));
+		}
+		
+		[Test]
+		public function setNewRng():void {
+			var rng:IRandomNumber = new RandomNumber();
+			
+			cut.rng = rng;
+			
+			assertThat(cut.rng, strictlyEqualTo(rng))
+		}
+		
+		
+		[Test(expected="ArgumentError")]
+		public function setNullForRng():void {
+			cut.rng = null;
 		}
     }
 }

--- a/test/classes/CreatureTest.as
+++ b/test/classes/CreatureTest.as
@@ -27,11 +27,14 @@ package classes{
 		private const VAGINAL_CAPCITY_OFFSET:Number = 2;
 		private const VAGINAL_CAPCITY_TEST_DELTA:Number = 2;
 		private const RECOVERY_COUNT:Number = 5;
+		private const ANAL_LOOSENESS:Number = 1;
+		private const ANAL_CAPACITY:Number = 6;
 		
         private var cut:Creature;
 		private var noVagina:Creature;
 		private var oneVagina:Creature;
 		private var maxVagina:Creature;
+		private var alwaysZero:IRandomNumber;
 		
 		private function createVaginas(numberOfVaginas:Number, instance:Creature):void {
 			var i:Number;
@@ -61,7 +64,12 @@ package classes{
          
         [Before]
         public function setUp():void {
+			alwaysZero = new AlwaysZeroRNG();
+			
 			cut = new Creature();
+			cut.rng = alwaysZero;
+			cut.ass.analLooseness = ANAL_LOOSENESS;
+			
 			noVagina = new Creature();
 			
 			oneVagina = new Creature();
@@ -577,5 +585,34 @@ package classes{
 		public function setNullForRng():void {
 			cut.rng = null;
 		}
+		
+		[Test]
+		public function analStretchWithAreaGreaterThanCapacity(): void {
+			assertThat(cut.buttChangeNoDisplay(ANAL_CAPACITY), equalTo(true));
+		}
+		
+		[Test]
+		public function analStretchWithArea80PercentOfCapacity(): void {
+			assertThat(cut.buttChangeNoDisplay(ANAL_CAPACITY * 0.8), equalTo(true));
+		}
+		
+		[Test]
+		public function analStretchWithArea90PercentOfCapacity(): void {
+			assertThat(cut.buttChangeNoDisplay(ANAL_CAPACITY * 0.9), equalTo(true));
+		}
     }
+}
+
+import classes.internals.IRandomNumber;
+
+class AlwaysZeroRNG implements IRandomNumber {
+	public function random(max:int):int 
+	{
+		return 0;
+	}
+	
+	public function randomCorrected(max:int):int 
+	{
+		return 0;
+	}
 }

--- a/test/classes/InternalsSuit.as
+++ b/test/classes/InternalsSuit.as
@@ -3,6 +3,7 @@ package classes {
 	import classes.helper.MemoryLogTargetTest;
 	import classes.internals.LoggerFactoryTest;
 	import classes.internals.SerializationUtilTest;
+	import classes.internals.UtilsTest;
 	
 	[Suite]
 	[RunWith("org.flexunit.runners.Suite")]
@@ -10,5 +11,6 @@ package classes {
 	{
 		public var loggerFactoryTest:LoggerFactoryTest;
 		public var serializationUtilTest:SerializationUtilTest;
+		public var utilsTest:UtilsTest;
 	}
 }

--- a/test/classes/InternalsSuit.as
+++ b/test/classes/InternalsSuit.as
@@ -2,6 +2,7 @@ package classes {
 	import classes.helper.MemoryLogTarget;
 	import classes.helper.MemoryLogTargetTest;
 	import classes.internals.LoggerFactoryTest;
+	import classes.internals.RandomNumberTest;
 	import classes.internals.SerializationUtilTest;
 	import classes.internals.UtilsTest;
 	
@@ -12,5 +13,6 @@ package classes {
 		public var loggerFactoryTest:LoggerFactoryTest;
 		public var serializationUtilTest:SerializationUtilTest;
 		public var utilsTest:UtilsTest;
+		public var randomNumberTest:RandomNumberTest;
 	}
 }

--- a/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
+++ b/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
@@ -1,6 +1,7 @@
 package classes.Scenes.Places.Bazaar{
 	import classes.Appearance;
 	import classes.helper.FireButtonEvent;
+	import classes.internals.IRandomNumber;
     import org.flexunit.asserts.*;
 	import org.hamcrest.assertThat;
 	import org.hamcrest.core.*;
@@ -17,7 +18,7 @@ package classes.Scenes.Places.Bazaar{
 	import classes.GlobalFlags.kFLAGS;
      
     public class RoxanneTest {
-		private static const EVENT_ITERATIONS:int = 20;
+		private static const EVENT_ITERATIONS:int = 5;
 		
         private var cut:RoxanneForTest;
 		private var player:Player;
@@ -29,10 +30,15 @@ package classes.Scenes.Places.Bazaar{
 		}
          
         [Before]
-        public function setUp():void {  
-			cut = new RoxanneForTest();
+        public function setUp():void {
+			var rng:IRandomNumber = new RngMock();
+			
+			cut = new RoxanneForTest(rng);
+			
 			player = new Player();
+			player.rng = rng;
 			kGAMECLASS.player = player;
+			
 			fireButtons = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
 			
 			player.flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 10;
@@ -51,7 +57,7 @@ package classes.Scenes.Places.Bazaar{
 			}
 		}
 		
-		[Test(description="This test may show sporadic failures due to the use of rand() in the code under test")] 
+		[Test] 
         public function roxanneStretchLowTime():void {
 			
 			var testFunction:Function = function():void {
@@ -78,7 +84,7 @@ package classes.Scenes.Places.Bazaar{
 			player.flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 290;
 		}
 		
-		[Test(description="This test may show sporadic failures due to the use of rand() in the code under test")] 
+		[Test] 
         public function roxanneRepeatedStretchingWithHighTime():void {
 			setRoxanneLargeSize();
 			
@@ -122,6 +128,7 @@ package classes.Scenes.Places.Bazaar{
 			assertThat(cut.collectedOutput, hasItem(startsWith("Gods, your head is swimming!")));
 		}
 		
+
 		[Test] 
         public function roxanneCounterResetWithBigBooty():void {
 			setRoxanneLargeSize();
@@ -142,13 +149,13 @@ package classes.Scenes.Places.Bazaar{
 
 import classes.Scenes.Places.Bazaar.Roxanne;
 import classes.internals.IRandomNumber;
-import classes.internals.RandomNumber;
 
 class RoxanneForTest extends Roxanne {
-	public var collectedOutput:Vector.<String> = new Vector.<String>(); 
+	public var collectedOutput:Vector.<String> = new Vector.<String>();
 	
-	public function RoxanneForTest() {
-		super(new RandomNumberMock());
+	public function RoxanneForTest(rng:IRandomNumber) 
+	{
+		super(rng);
 	}
 
 	public function roxanneDrinkingContestTest():void {
@@ -160,16 +167,16 @@ class RoxanneForTest extends Roxanne {
 	}
 }
 
-class RandomNumberMock implements IRandomNumber {
-	public var valueToReturn:int = 0;
+class RngMock implements IRandomNumber {
+	public var randomValue:int = 0;
 	
 	public function random(max:int):int 
 	{
-		return valueToReturn;
+		return randomValue;
 	}
 	
 	public function randomCorrected(max:int):int 
 	{
-		return valueToReturn;
+		return randomValue;
 	}
 }

--- a/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
+++ b/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
@@ -105,8 +105,7 @@ package classes.Scenes.Places.Bazaar{
 			assertThat(cut.collectedOutput, hasItem(startsWith("Gosh, Roxanne is so strong...")));
 		}
 		
-		[Ignore(description="Needs injected RNG")]
-		[Test(description="This test may show sporadic failures due to the use of rand() in the code under test")] 
+		[Test] 
         public function roxanneRepeatedStretchingWithBigBooty():void {
 			setRoxanneLargeSize();
 			player.buttRating = Appearance.BUTT_RATING_EXPANSIVE;
@@ -123,8 +122,7 @@ package classes.Scenes.Places.Bazaar{
 			assertThat(cut.collectedOutput, hasItem(startsWith("Gods, your head is swimming!")));
 		}
 		
-		[Ignore(description="Needs injected RNG")]
-		[Test(description="This test may show sporadic failures due to the use of rand() in the code under test")] 
+		[Test] 
         public function roxanneCounterResetWithBigBooty():void {
 			setRoxanneLargeSize();
 			player.buttRating = Appearance.BUTT_RATING_EXPANSIVE;
@@ -143,9 +141,15 @@ package classes.Scenes.Places.Bazaar{
 }
 
 import classes.Scenes.Places.Bazaar.Roxanne;
+import classes.internals.IRandomNumber;
+import classes.internals.RandomNumber;
 
 class RoxanneForTest extends Roxanne {
 	public var collectedOutput:Vector.<String> = new Vector.<String>(); 
+	
+	public function RoxanneForTest() {
+		super(new RandomNumberMock());
+	}
 
 	public function roxanneDrinkingContestTest():void {
 		super.roxanneDrinkingContest();
@@ -153,5 +157,19 @@ class RoxanneForTest extends Roxanne {
 	
 	override protected function outputText(output:String):void {
 		collectedOutput.push(output);
+	}
+}
+
+class RandomNumberMock implements IRandomNumber {
+	public var valueToReturn:int = 0;
+	
+	public function random(max:int):int 
+	{
+		return valueToReturn;
+	}
+	
+	public function randomCorrected(max:int):int 
+	{
+		return valueToReturn;
 	}
 }

--- a/test/classes/internals/RandomNumberTest.as
+++ b/test/classes/internals/RandomNumberTest.as
@@ -1,0 +1,48 @@
+package classes.internals
+{
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	public class RandomNumberTest
+	{
+		private static const RANDOM_NUMBER_ITERATIONS:int = 100;
+		private static const RANDOM_NUMBER_MAX:int = 5;
+		
+		private var cut:RandomNumber;
+		
+		[Before]
+		public function setUp():void
+		{
+			cut = new RandomNumber;
+		}
+		
+		[Test]
+		public function genratedRandomNumber():void
+		{
+			var randomNumbers:Vector.<Number> = new Vector.<Number>();
+			
+			for (var i:int = 0; i < RANDOM_NUMBER_ITERATIONS; i++ ){
+				randomNumbers.push(cut.random(RANDOM_NUMBER_MAX));
+			}
+			
+			assertThat(randomNumbers, hasItems(0, 1, 2, 3, 4));
+		}
+		
+		[Test]
+		public function genratedRandomNumberCorrected():void
+		{
+			var randomNumbers:Vector.<Number> = new Vector.<Number>();
+			
+			for (var i:int = 0; i < RANDOM_NUMBER_ITERATIONS; i++ ){
+				randomNumbers.push(cut.randomCorrected(RANDOM_NUMBER_MAX));
+			}
+			
+			assertThat(randomNumbers, hasItems(0, 1, 2, 3, 4, 5));
+		}
+	}
+}

--- a/test/classes/internals/RandomNumberTest.as
+++ b/test/classes/internals/RandomNumberTest.as
@@ -10,6 +10,12 @@ package classes.internals
 	
 	public class RandomNumberTest
 	{
+		/**
+		 * If the max is 5, odds of not rolling a 5 (with 0 to 5): 5/6
+		 * Chance of not rolling a 5 for n iterations: (5/6)^n
+		 * 
+		 * so (5/6)^10000 = 1.5400666762244415926880991148594e-792
+		 */
 		private static const RANDOM_NUMBER_ITERATIONS:int = 10000;
 		private static const RANDOM_NUMBER_MAX:int = 5;
 		

--- a/test/classes/internals/RandomNumberTest.as
+++ b/test/classes/internals/RandomNumberTest.as
@@ -10,7 +10,7 @@ package classes.internals
 	
 	public class RandomNumberTest
 	{
-		private static const RANDOM_NUMBER_ITERATIONS:int = 100;
+		private static const RANDOM_NUMBER_ITERATIONS:int = 10000;
 		private static const RANDOM_NUMBER_MAX:int = 5;
 		
 		private var cut:RandomNumber;

--- a/test/classes/internals/UtilsTest.as
+++ b/test/classes/internals/UtilsTest.as
@@ -1,0 +1,36 @@
+package classes.internals
+{
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	public class UtilsTest
+	{
+		private static const RANDOM_NUMBER_ITERATIONS:int = 100;
+		private static const RANDOM_NUMBER_MAX:int = 5;
+		
+		private var cut:Utils;
+		
+		[Before]
+		public function setUp():void
+		{
+			cut = new Utils();
+		}
+		
+		[Test]
+		public function genratedRandomNumber():void
+		{
+			var randomNumbers:Vector.<Number> = new Vector.<Number>();
+			
+			for (var i:int = 0; i < RANDOM_NUMBER_ITERATIONS; i++ ){
+				randomNumbers.push(Utils.rand(RANDOM_NUMBER_MAX));
+			}
+			
+			assertThat(randomNumbers, hasItems(0, 1, 2, 3, 4));
+		}
+	}
+}

--- a/test/classes/internals/UtilsTest.as
+++ b/test/classes/internals/UtilsTest.as
@@ -10,7 +10,7 @@ package classes.internals
 	
 	public class UtilsTest
 	{
-		private static const RANDOM_NUMBER_ITERATIONS:int = 100;
+		private static const RANDOM_NUMBER_ITERATIONS:int = 10000;
 		private static const RANDOM_NUMBER_MAX:int = 5;
 		
 		private var cut:Utils;


### PR DESCRIPTION
- Interface for random numbers
- Allows injecting RNG into classes
- `Utils.DEFAULT_RNG` random number generator instance that uses `Utils.rand` internally
- Code cleanup in touched functions

Code that uses `Utils.rand` is very difficult or outright impossible to test, as calls to `Utils.rand` cannot be intercepted.
This allows for testing specific random events.