### PR TITLE
Drinking too many OviMax-elixirs may now grant the Oviposition perk

### DIFF
--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -1300,7 +1300,7 @@ public static const UNKNOWN_FLAG_NUMBER_01291:int                               
 public static const UNKNOWN_FLAG_NUMBER_01292:int                                   = 1292;
 public static const UNKNOWN_FLAG_NUMBER_01293:int                                   = 1293;
 public static const UNKNOWN_FLAG_NUMBER_01294:int                                   = 1294;
-public static const UNKNOWN_FLAG_NUMBER_01295:int                                   = 1295;
+public static const OVIMAX_OVERDOSE:int                                             = 1295;
 public static const MINO_CHEF_TALKED_RED_RIVER_ROOT:int                             = 1296;
 public static const RATHAZUL_MIXOLOGY_XP:int                                        = 1297; // 0-200, currently for selling new skin oils only
 public static const DISABLE_QUICKLOAD_CONFIRM:int                                   = 1298; // Disable the confirmation-dialog on quickload

--- a/classes/classes/Items/Consumables/CustomOviElixir.as
+++ b/classes/classes/Items/Consumables/CustomOviElixir.as
@@ -2,7 +2,9 @@
  * Created by aimozg on 01.04.2017.
  */
 package classes.Items.Consumables {
+import classes.GlobalFlags.kFLAGS;
 import classes.Items.Consumable;
+import classes.PerkLib;
 import classes.PregnancyStore;
 import classes.StatusEffects;
 //Oviposition Elixer!
@@ -49,6 +51,18 @@ public class CustomOviElixir extends Consumable {
 		}
 		var changeOccurred:Boolean = false;
 		if (game.player.pregnancyType == PregnancyStore.PREGNANCY_OVIELIXIR_EGGS) { //If player already has eggs, chance of size increase!
+			if (this is OvipositionMax && !player.hasPerk(PerkLib.Oviposition) && !canSpeedUp()) {
+				outputText("\n\nYou start to feel a bit of a rumble. You look down at your belly, and it seems to have started a slight twitch,"
+				          +" and then stops. You take a look at the empty ovimax bottle for information when suddenly your womb lurches forward"
+				          +" and your stomach starts to slightly expand. Dropping the ovimax bottle to the ground, you moan as your bury your face"
+				          +" in the parched earth, a silent scream leaving your mouth as the rumbling in your tummy is turning more violent,"
+				          +" and more painful...and then it stops completely. You shudder in the fetal position,"
+				          +" waiting for another seizure that didn't come. Maybe you should stop drinking these things.");
+
+				// raises chance to gain the Oviposition perk due to overdosing. 1/3 per overdose.
+				// Would happen, when actually laying those eggs.
+				flags[kFLAGS.OVIMAX_OVERDOSE]++;
+			}
 			if (game.player.hasStatusEffect(StatusEffects.Eggs)) {
 				//If eggs are small, chance of increase!
 				if (game.player.statusEffectv2(StatusEffects.Eggs) == 0) {

--- a/classes/classes/Parser/conditionalConverters.as
+++ b/classes/classes/Parser/conditionalConverters.as
@@ -2,6 +2,7 @@
 		import classes.GlobalFlags.kFLAGS;
 		import classes.GlobalFlags.kGAMECLASS;
 		import classes.Items.ArmorLib;
+		import classes.Items.WeaponLib;
 		import classes.Items.UndergarmentLib;
 
 		/**
@@ -27,6 +28,7 @@
 				"days"				: function(thisPtr:*):* {return  kGAMECLASS.model.time.days;},
 				"hasarmor"			: function(thisPtr:*):* {return  kGAMECLASS.player.armor != ArmorLib.NOTHING;},
 				"haslowergarment"	: function(thisPtr:*):* {return  kGAMECLASS.player.lowerGarment != UndergarmentLib.NOTHING;},
+				"hasweapon"			: function(thisPtr:*):* {return  kGAMECLASS.player.weapon != WeaponLib.FISTS;},
 				"tallness"			: function(thisPtr:*):* {return  kGAMECLASS.player.tallness;},
 				"hairlength"		: function(thisPtr:*):* {return  kGAMECLASS.player.hair.length;},
 				"femininity"		: function(thisPtr:*):* {return  kGAMECLASS.player.femininity;},

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -2,6 +2,7 @@ package classes.Scenes
 {
 	import classes.*;
 	import classes.GlobalFlags.*;
+	import classes.Items.ArmorLib;
 	
 	public class PregnancyProgression extends BaseContent
 	{
@@ -2090,7 +2091,23 @@ package classes.Scenes
 					if (player.vaginas.length == 0) {
 						outputText("You feel a terrible pressure in your groin... then an incredible pain accompanied by the rending of flesh.  <b>You look down and behold a new vagina</b>.\n\n");
 						player.createVagina();
-					}		
+					}
+					var oviMaxOverdoseGainedOviPerk:Boolean = false;
+					if (!player.hasPerk(PerkLib.Oviposition) && flags[kFLAGS.OVIMAX_OVERDOSE] > 0 && rand(3) < flags[kFLAGS.OVIMAX_OVERDOSE]) {
+						outputText("You instantly feel your body seize up and you know something is wrong."
+						          +" [if (hasWeapon)You let go of your [weapon] before your|Your] legs completely give out from under you and"
+						          +" a high pitched, death curdle escapes your lips as you fall to your knees. Clutching your stomach,"
+						          +" you bury your face into the ground, your screaming turning into a violent high pitched wail."
+						          +" Deep inside your uterus you feel a shuddering, inhuman change as your womb violently and painfully,"
+						          +" shifts and warps around your unfertilized eggs, becoming a more accommodating, cavernous home for them."
+						          +" Your wails quieted down and became a mess of heaving sighs and groans. Your eyes weakly register as your belly"
+						          +" trembles with a vengeance, and you realize there is still more to come.\n\n");
+						if (player.armor !== ArmorLib.NOTHING) {
+							outputText("Realizing you're about to give birth, you rip off your [armor] before it can be ruined by what's coming.\n\n");
+						}
+						oviMaxOverdoseGainedOviPerk = true;
+					}
+					flags[kFLAGS.OVIMAX_OVERDOSE] = 0;
 					//Small egg scenes
 					if (player.statusEffectv2(StatusEffects.Eggs) == 0) {
 						//light quantity
@@ -2126,6 +2143,10 @@ package classes.Scenes
 						outputText("\n\nYou gaze down at the mess, counting " + eggDescript() + ".");
 						player.orgasm('Vaginal');
 						dynStats("scale", false);
+					}
+					if (oviMaxOverdoseGainedOviPerk) {
+						outputText("\n\n(<b>Perk Gained: Oviposition</b>)");
+						player.createPerk(PerkLib.Oviposition, 0, 0, 0, 0);
 					}
 					outputText("\n\n<b>You feel compelled to leave the eggs behind, ");
 					if (player.hasStatusEffect(StatusEffects.AteEgg)) outputText("but you remember the effects of the last one you ate.\n</b>");


### PR DESCRIPTION
### Gameplay changes
Excessive drinking of OviMax-elixirs now has an overdose mechanics, that has a chance of 1/3 per overdose to grant the player the Oviposition perk upon laying those eggs.

### Internal changes
- Added the flag: `public static const OVIMAX_OVERDOSE:int = 1295;`
- Added the parser conditional: `[if (hasWeapon)HERP|DERP]`

### Credits
Scene texts written by MuffDiver