### PR TITLE
Updated the dragon tail and implemented (dragon) tail slam attack

### DIFF
--- a/classes/classes/Items/Consumables/EmberTFs.as
+++ b/classes/classes/Items/Consumables/EmberTFs.as
@@ -171,11 +171,20 @@ package classes.Items.Consumables
 				changes++;
 			}
 			//Gain Dragon Tail
-			if (player.tail.type != Tail.DRACONIC && changes < changeLimit && rand(3) == 0) {
+			if (player.tail.type !== Tail.DRACONIC && changes < changeLimit && rand(3) === 0) {
 				//(If no tail)
-				if (player.tail.type == Tail.NONE) output.text("\n\nA sudden dull, throbbing pain in your " + player.buttDescript() + " forces your hands to it; you can feel an ominous lump over your tail bone, swelling bigger and bigger with every heartbeat.  All of a sudden, it seems to explode, jutting out and around until it hovers near your ankles, the skin under your flesh hard and scaly.  <b>You now have a dragon tail flicking at your back, flexible as a whip.</b>");
+				if (player.tail.type === Tail.NONE) {
+					output.text("\n\nA sudden dull, throbbing pain in your [butt] forces your hands to it; you can feel an ominous lump over your"
+					           +" tail bone, swelling bigger and bigger with every heartbeat.  All of a sudden, it seems to explode,"
+					           +" jutting out and around until it hovers near your ankles, the skin under your flesh hard and scaly."
+					           +"  <b>You have grown a dragon tail; long, thick and muscular, yet flexible.</b>");
 				//(If tail)
-				else output.text("\n\nAn icy sensation fills your behind as your tail suddenly goes curiously numb.  Twisting your head around, you watch as it melts and transforms into a reptilian appendage, long and flexible, its tip adorned with wicked spikes.  <b>You now have a dragon tail.</b>");
+				} else {
+					output.text("\n\nAn icy sensation fills your behind as your tail suddenly goes curiously numb.  Twisting your head around,"
+					           +" you watch as it melts and transforms into a reptilian appendage, one thick and muscular, long and flexible,"
+					           +" tapering to a tip adorned with wicked spikes."
+					           +"  <b>You now have a dragon tail.</b>");
+				}
 				player.tail.type = Tail.DRACONIC;
 				changes++
 			}

--- a/classes/classes/Parser/singleArgLookups.as
+++ b/classes/classes/Parser/singleArgLookups.as
@@ -125,6 +125,17 @@
 				"tail"						: function(thisPtr:*):* { return kGAMECLASS.player.tailDescript(); },
 				"onetail"					: function(thisPtr:*):* { return kGAMECLASS.player.oneTailDescript(); },
 
+				//Monster strings
+				"monster.short"				: function(thisPtr:*):* { return kGAMECLASS.monster.short; },
+				"monster.a"					: function(thisPtr:*):* { return kGAMECLASS.monster.a; },
+				"monster.capitala"			: function(thisPtr:*):* { return kGAMECLASS.monster.capitalA; },
+				"monster.pronoun1"			: function(thisPtr:*):* { return kGAMECLASS.monster.pronoun1; },
+				"monster.pronoun1caps"		: function(thisPtr:*):* { return kGAMECLASS.monster.Pronoun1; },
+				"monster.pronoun2"			: function(thisPtr:*):* { return kGAMECLASS.monster.pronoun2; },
+				"monster.pronoun2caps"		: function(thisPtr:*):* { return kGAMECLASS.monster.Pronoun2; },
+				"monster.pronoun3"			: function(thisPtr:*):* { return kGAMECLASS.monster.pronoun3; },
+				"monster.pronoun3caps"		: function(thisPtr:*):* { return kGAMECLASS.monster.Pronoun3; },
+
 				//Prisoner
 				"captortitle"				: function(thisPtr:*):* { return kGAMECLASS.prison.prisonCaptor.captorTitle; },
 				"captorname"				: function(thisPtr:*):* { return kGAMECLASS.prison.prisonCaptor.captorName; },

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -873,12 +873,13 @@ package classes
 
 				case Tail.DRACONIC:
 					if (player.hasDifferentUnderBody()) {
-						outputText("  A thin, prehensile reptilian tail, covered in [skinFurScales] with [underBody.skinFurScales] along its"
-						          +" underside and almost as long as you are tall, swings behind you like a living bullwhip. Its tip menaces with"
-						          +" spikes of bone, meant to deliver painful blows.");
+						outputText("  A thick, muscular, reptilian tail covered in [skinFurScales] with [underBody.skinFurScales] along its"
+						          +" underside, almost as long as you are tall, swishes slowly from side to side behind you."
+						          +" Its tip menaces with sharp spikes of bone, and could easily cause serious harm with a good sweep.");
 					} else {
-						outputText("  A thin, scaly, prehensile reptilian tail, almost as long as you are tall, swings behind you"
-						          +" like a living bullwhip.  Its tip menaces with spikes of bone, meant to deliver painful blows.");
+						outputText("  A thick, muscular, reptilian tail, almost as long as you are tall, unconsciously swings behind you slowly"
+						          +" from side to side. Its tip menaces with sharp spikes of bone, and could easily cause grievous harm"
+						          +" with a single, powerful sweep.");
 					}
 					break;
 

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1477,7 +1477,7 @@ public class Combat extends BaseContent
 					var bleed:Number = (2 + rand(4))/100;
 					bleed *= player.HP;
 					bleed = takeDamage(bleed);
-					outputText("<b>You gasp and wince in pain, feeling fresh blood pump from your wounds. (<font color=\"" + mainViewManager.colorHpMinus() + "\">" + temp + "</font>)</b>\n\n");
+					outputText("<b>You gasp and wince in pain, feeling fresh blood pump from your wounds. " + getDamageText(bleed) + "</b>\n\n");
 				}
 			}
 			if (player.hasStatusEffect(StatusEffects.AcidSlap)) {


### PR DESCRIPTION
### Gameplay changes
The dragon tail now has a different and more fitting TF blurb and appearance description. In addition to that, the dragon tail now has an unique 'Tail Slam' attack, dealing quite some damage with a chance to stun the opponent and/or let it bleed for three rounds.

### Internal changes
- Added the following set of parser tags:
  - [monster.short]
  - [monster.a]
  - [monster.capitala]
  - [monster.pronoun1]
  - [monster.pronoun1caps]
  - [monster.pronoun2]
  - [monster.pronoun2caps]
  - [monster.pronoun3]
  - [monster.pronoun3caps]
- Fixed a small bug, where the bleed damage on the player displayed the wrong value.

### Notes
If you think, the new attack is unbalanced: The mechanics can always be changed later on.

### Credits
Attack texts, TF and appearance blurbs written by Ein.