### PR TITLE
Credits box

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -44,6 +44,11 @@
 			return kGAMECLASS.output;
 		}
 
+		protected function get credits():Credits
+		{
+			return kGAMECLASS.credits;
+		}
+
 		protected function get measurements():Measurements
 		{
 			return kGAMECLASS.measurements;

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -300,6 +300,7 @@ package classes
 		
 		public var bindings:Bindings = new Bindings();
 		public var output:Output = Output.init();
+		public var credits:Credits = Credits.init();
 		public var measurements:Measurements = Measurements.init();
 		/****
 		   This is used purely for bodges while we get things cleaned up.

--- a/classes/classes/Credits.as
+++ b/classes/classes/Credits.as
@@ -1,0 +1,48 @@
+package classes 
+{
+	import classes.GlobalFlags.kGAMECLASS;
+	import flash.text.TextField;
+
+	 /**
+	 * Class to handle the credits box
+	 * @since  22.12.2017
+	 * @author Stadler76
+	 */
+	public class Credits 
+	{
+		public var headline:String = 'Scene by:';
+		public var authorText:String = '';
+
+		private static var _instance:Credits = new Credits();
+
+		public function Credits()
+		{
+			if (_instance != null)
+			{
+				throw new Error("Credits can only be accessed through Credits.init()");
+			}
+		}
+
+		public static function init():Credits { return _instance; }
+
+		protected function get creditsBox():TextField
+		{
+			return kGAMECLASS.mainView.creditsBox;
+		}
+
+		public function show():void
+		{
+			if (authorText === '')
+				return;
+
+			creditsBox.htmlText = '<font face="Georgia"><b>' + headline + '</b></font>\n' + authorText;
+		}
+
+		public function clear():void
+		{
+			creditsBox.htmlText = '';
+			headline = 'Scene by:';
+			authorText = '';
+		}
+	}
+}

--- a/classes/classes/Items/Consumable.as
+++ b/classes/classes/Items/Consumable.as
@@ -3,6 +3,7 @@
  */
 package classes.Items
 {
+	import classes.Credits;
 	import classes.GlobalFlags.*;
 	import classes.CoC_Settings;
 	import classes.Scenes.Camp;
@@ -24,6 +25,7 @@ package classes.Items
 		protected function set changeLimit(val:int):void { mutations.changeLimit = val; }
 
 		protected function get output():Output { return kGAMECLASS.output; }
+		protected function get credits():Credits { return kGAMECLASS.credits; }
 		protected function get player():Player { return kGAMECLASS.player; }
 		protected function get prison():Prison { return kGAMECLASS.prison; }
 		protected function get flags():DefaultDict { return kGAMECLASS.flags; }

--- a/classes/classes/Items/Consumables/RedRiverRoot.as
+++ b/classes/classes/Items/Consumables/RedRiverRoot.as
@@ -43,6 +43,7 @@ package classes.Items.Consumables
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
 
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("Having bought that odd-looking root on the bakery, you give it a try, only to face the mildly spicy taste"
 			          +" of the transformative. Still, it has a rich flavour and texture, but soon that becomes secondary,"
 			          +" as you realize that the foreign rhizome is changing your body!");

--- a/classes/classes/Items/Consumables/TonOTrice.as
+++ b/classes/classes/Items/Consumables/TonOTrice.as
@@ -47,6 +47,7 @@ package classes.Items.Consumables
 			if (player.findPerk(PerkLib.TransformationResistance) >= 0) changeLimit--;
 
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			outputText("You drink the slimy concoction, grimacing as it reaches your tongue. At first you’re shocked you don’t gag but once you taste"
 			          +" the mixture you realise it's not so bad, almost having a hint of almond behind that thick texture.");
 

--- a/classes/classes/MainMenu.as
+++ b/classes/classes/MainMenu.as
@@ -170,7 +170,8 @@ package classes
 			mainView.addElementAt(_mainMenu, 2);
 		}
 		public function hideMainMenu():void {
-			_mainMenu.visible = false;
+			if (_mainMenu !== null)
+				_mainMenu.visible = false;
 			mainView.showMainText();
 			mainView.setTextBackground(flags[kFLAGS.TEXT_BACKGROUND_STYLE]);
 			mainView.creditsBox.visible = true;

--- a/classes/classes/MainMenu.as
+++ b/classes/classes/MainMenu.as
@@ -37,6 +37,7 @@ package classes
 			kGAMECLASS.gameStateDirectSet(3);
 			clearOutput();
 			mainView.hideMainText();
+			mainView.creditsBox.visible = false;
 			if (_mainMenu == null) {
 				configureMainMenu();
 			}
@@ -172,6 +173,7 @@ package classes
 			_mainMenu.visible = false;
 			mainView.showMainText();
 			mainView.setTextBackground(flags[kFLAGS.TEXT_BACKGROUND_STYLE]);
+			mainView.creditsBox.visible = true;
 		}
 		
 		public function startupScreenBody():void {

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -1,8 +1,8 @@
 package classes 
 {
-import flash.utils.setTimeout;
+	import flash.utils.setTimeout;
 
-/**
+	/**
 	 * Class to replace the old and somewhat outdated output-system, which mostly uses the include-file includes/engineCore.as
 	 * @since  08.08.2016
 	 * @author Stadler76
@@ -86,6 +86,7 @@ import flash.utils.setTimeout;
 		public function flush():void
 		{
 			mainViewManager.setText(_currentText);
+			credits.show();
 		}
 
 		/**
@@ -118,6 +119,7 @@ import flash.utils.setTimeout;
 			nextEntry();
 			_currentText = "";
 			mainView.clearOutputText();
+			credits.clear();
 			return this;
 		}
 

--- a/classes/classes/Scenes/Areas/HighMountains/CockatriceScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/CockatriceScene.as
@@ -15,6 +15,7 @@ package classes.Scenes.Areas.HighMountains {
 			var cockatrice:Cockatrice = new Cockatrice();
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			if (flags[kFLAGS.TIMES_ENCOUNTERED_COCKATRICES] == 0) { //First encounter:
 				outputText("As you follow the trails in the high mountains, the rocky terrain becomes less stable, the path devolving into a series of loose crags with gravel like sediment surrounding large boulders and rough stepping stone-like structures. "
 				          +"As you cling to the rock face trying to step from one rock to another you see something in the distance. "
@@ -75,6 +76,7 @@ package classes.Scenes.Areas.HighMountains {
 		public function defeatCockatrice():void {
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			if (flags[kFLAGS.SFW_MODE] > 0) {
 				outputText("You smile in satisfaction as the " + monster.short + " collapses, unable to continue fighting.");
 				combat.cleanupAfterCombat();
@@ -116,6 +118,7 @@ package classes.Scenes.Areas.HighMountains {
 		private function cockatriceRideHimVag():void {
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			rideCockatriceForeplay();
 			outputText("\n\nHis cute begging face and the way he keeps his tongue working your "
 			          +"[if (hasCock)turgid cock|hungry cunt] regardless of your actions speeds up your decision, making you push him back by his firm but downy shoulders. "
@@ -173,6 +176,7 @@ package classes.Scenes.Areas.HighMountains {
 		private function cockatriceRideHimAnal():void {
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			rideCockatriceForeplay();
 			outputText("\n\nHis large rounded pupils give him a cute, almost puppy dog look, as he stares up at you. "
 			          +"If it werent for his flushed face and lolling tongue adding such a lewd edge, you’d sweep him up into a big hug and pet him. "
@@ -237,6 +241,7 @@ package classes.Scenes.Areas.HighMountains {
 		private function cockatriceButtfuck():void {
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			outputText("You make your way over to him, [if (hasArmor) stripping yourself of your [armor] piece by piece, putting on quite the show,] a sensuous sway in your [hips]. "
 			          +"He looks up at you from the ground, confusion and lust in his eyes as you bare yourself to him. "
 			          +"Throughout the fight you couldn't keep your eyes off his firm, downy rump and now you're gonna claim it for yourself.\n\n");
@@ -309,6 +314,7 @@ package classes.Scenes.Areas.HighMountains {
 		private function cockatriceOralCock():void {
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			outputText("You casually approach him [if (hasArmor)stripping your [armor] and tossing it aside confidently], admiring his prone form. "
 			          +"The cockatrice lays on his back, tail lazily resting between his legs as he runs a clawed finger over his pecs. "
 			          +"His sapphire eyes are fixed firmly on you, drinking in your naked form. "
@@ -355,6 +361,7 @@ package classes.Scenes.Areas.HighMountains {
 		private function cockatriceOralVag():void {
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			outputText("You casually approach him[if (hasArmor) stripping your [armor] and tossing it aside confidently], admiring his prone form. "
 			          +"The cockatrice lays on his back, tail lazily resting between his legs as he runs a clawed finger over his pecs. "
 			          +"His sapphire eyes are fixed firmly on you, drinking in your naked form. "
@@ -386,6 +393,7 @@ package classes.Scenes.Areas.HighMountains {
 		private function cockatriceTaurButtFuck():void {
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			outputText("As you decide what to do with the cockatrice, your loins heated with arousal, you realise a you’ll have a hard time managing anything, what with your tauric form being less than compatible with what many folk are packing. "
 			          +"Looking around briefly, you notice an alcove on the mountainside which spawns a brilliant idea. "
 			          +"You could use the rock to pin him at the right height to fuck your ass with that nubby reptile cock of his. Talk about between a rock and a hard place!\n\n");
@@ -430,6 +438,7 @@ package classes.Scenes.Areas.HighMountains {
 			else choice = player.hasVagina() ? CHOICE_PUSSY : CHOICE_COCK;
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			outputText(images.showImage("cockatrice-ridehim-drider"));
 			outputText("As you decide what to do with the cockatrice, your loins heated with arousal, you realise a you’ll have a hard time managing anything, what with your spider like form being less than compatible with what many folk are packing. "
 			          +"Looking around briefly, you notice an alcove on the mountainside which spawns a brilliant idea. "
@@ -483,6 +492,7 @@ package classes.Scenes.Areas.HighMountains {
 
 		private function rideCockatriceForeplay():void {
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			const FOREPLAY_NEUTRAL:int = 0;
 			const FOREPLAY_BLOWJOB:int = 1;
 			const FOREPLAY_VAGINAL:int = 2;
@@ -571,6 +581,7 @@ package classes.Scenes.Areas.HighMountains {
 		public function loseToCockatrice():void {
 			//spriteSelect(75);
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			if ((player.isTaur() || player.isDrider()) && player.hasVagina()) cockatriceLossOral(); // Maybe later this could be replaced with a taur/drider vag sex scene?
 			else if (player.isTaur() || player.isDrider()) cockatriceLossOral();
 			else if (player.hasVagina()) cockatriceLossVaginal();
@@ -581,6 +592,7 @@ package classes.Scenes.Areas.HighMountains {
 		//Player lost -> Anal sex
 		public function cockatriceLossAnal():void {
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			outputText("You fall to the ground [if (hp < 1)utterly exhausted|too aroused to continue]. "
 			          +"The Cockatrice, knowing that he’s won, approaches you slowly, eyes roving over your body hungrily. "
 			          +"[if (hasArmor) He makes short work of your [armor], tossing it aside with little care.] "
@@ -612,6 +624,7 @@ package classes.Scenes.Areas.HighMountains {
 		//Player lost -> Vag sex
 		public function cockatriceLossVaginal():void {
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			outputText("You fall to the ground [if (hp < 1)utterly exhausted|too aroused to continue]. "
 			          +"The Cockatrice, knowing that he’s won, approaches you slowly, eyes roving over your body hungrily. "
 			          +"[if (hasArmor)He makes short work of your [armor], tossing it aside with little care.] "
@@ -680,6 +693,7 @@ package classes.Scenes.Areas.HighMountains {
 		//Player lost -> Taur/Drider oral
 		public function cockatriceLossOral():void {
 			clearOutput();
+			credits.authorText = "MissBlackthorne";
 			outputText("You fall to the ground [if (hp < 1)utterly exhausted|too aroused to continue]. "
 			          +"The cockatrice stalks over to you, eyeing you up as he strokes his rapidly emerging cock. "
 			          +"His casual approach has you mesmerised, such calm confidence something you didn't expect from the  hyperactive reptile. "

--- a/classes/classes/Scenes/Dungeons/AnzuPalace.as
+++ b/classes/classes/Scenes/Dungeons/AnzuPalace.as
@@ -70,6 +70,7 @@ package classes.Scenes.Dungeons
 		
 		public function enterDungeon():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			if ((flags[kFLAGS.ANZU_RELATIONSHIP_LEVEL] < 2 && flags[kFLAGS.ANZU_AFFECTION] >= 25) || (flags[kFLAGS.ANZU_RELATIONSHIP_LEVEL] < 3 && flags[kFLAGS.ANZU_AFFECTION] >= 50) || (flags[kFLAGS.ANZU_RELATIONSHIP_LEVEL] < 4 && flags[kFLAGS.ANZU_AFFECTION] >= 75)) {
 				anzuScene.anzuTransition();
 				return;
@@ -83,6 +84,7 @@ package classes.Scenes.Dungeons
 		private function exitDungeon():void {
 			kGAMECLASS.inDungeon = false;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("You leave the palace behind and take off through the glacial rift back towards camp.");
 			doNext(camp.returnToCampUseOneHour);	
 		}
@@ -98,6 +100,7 @@ package classes.Scenes.Dungeons
 		public function roomEntrance():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_OUTSIDE;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Palace Grounds</u></b>\n");
 			outputText("The outsides of the palace look way different from how it was before Anzu’s arrival. Mostly covered in snow, but visible, instead of the original shape of a Norse castle made of stone, with the majolica tiles in a vibrant teal, and ornaments in gold covering the walls, and the new shape, looks more like a palace from ancient times. During the night, the lights from the inside contrast against the darkness of the Rift.");
 			outputText("\n\nThe gate, in turquoise tiles, leads to a huge door made of solid iron which serves as the palace principal entrance. The area around the palace is mostly covered in snow and pines, except a small path made of stones, that lead to the bottom of the hill.");
@@ -111,6 +114,7 @@ package classes.Scenes.Dungeons
 		public function roomFoyer():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_HALL_FLOOR1;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Hall, Floor 1</u></b>\n");
 			outputText("You’re standing inside the first floor of Anzu’s Palace. A long hall, marked with a beautiful red rug and flanked with two rows of columns in golden marble, connecting all the rooms in this floor. Immediately near the start of the hall, to the west, is the living room.");
 			outputText("\n\nTo the east you can see a dining room, with two wooden tables and chairs. Connected to the dining room from the north is the kitchen. Near the end of the hall, a door leads to the baths.");
@@ -122,6 +126,7 @@ package classes.Scenes.Dungeons
 		public function roomLivingRoom():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_LIVING_ROOM;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Living Room</u></b>\n");
 			outputText("Like most of the house, the living room is richly decorated. Golden columns with ornamented chapiters surround the area, with very colorful patterned decorations in silk hanging from them. The walls are decorated with mosaics in the shape of flowers and stars, made of semiprecious stones. The floor is made of mosaics and covered with some rugs.");
 			outputText("\n\nAncient looking statues made of alabaster and beautiful vases containing violets decorate the area. The entire room is illuminated by a lamp hanging from the ceiling, with an almost white flame, bright enough to enlighten all the room. In the center, a big fireplace brings warmth to the place.");
@@ -132,6 +137,7 @@ package classes.Scenes.Dungeons
 		public function roomBathroom():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_BATHROOM;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Bathroom</u></b>\n");
 			outputText("A central round pool, with almost thirty feet of diameter, dominates the center of the room. The warm water of the pool is so clear that you can see the light blue colored tiles of its bottom. Several columns in a light golden marble surround the pool, and give the room a cozy feeling. They’re eleven in total, now that you can count them well.");
 			outputText("\n\nThe rest of the room is covered with light brown tiles on the floor and the lower part of the walls, and a pattern of golden tiles and gold inlaids on the upper walls, separated by a band of mosaics displaying fish in exotic colors, sea serpents and aquatic monsters of a kind that you can’t recognize.");
@@ -141,6 +147,7 @@ package classes.Scenes.Dungeons
 		public function roomDiningRoom():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_DINING_ROOM;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Dining Room</u></b>\n");
 			outputText("Two polished wooden tables, pretty large, occupy the center of the room. Surrounding them, between forty and fifty chairs give enough sitting room for a small army. Anzu must feel quite lonely when dining.");
 			outputText("\n\nDecorating the corners are vases with violets, whose smell perfumes the air. The columns in golden marble and the colorful decorations in silk hanging from them complete the room atmosphere.");
@@ -150,6 +157,7 @@ package classes.Scenes.Dungeons
 		public function roomKitchen():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_KITCHEN;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Kitchen</u></b>\n");
 			outputText("A big oven made of iron dominates the kitchen. To the sides many drawers contain a wide variety of cooking utensils. Knives, spoons, forks, dishes, glasses, all stored in their respective place. A place for cleaning the utensils and a stove have a place too on opposite sides of the kitchen.");
 			outputText("\n\nIn the back of the room, a wooden door leads to the place where Anzu stores food. Inside are grains, bread, cheese, several crates containing wine, and in some containers, wrapped inside snow and ice, are big pieces of meat.");
@@ -160,6 +168,7 @@ package classes.Scenes.Dungeons
 		public function roomHallFloor2():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_HALL_FLOOR2;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Hall, Floor 2</u></b>\n");
 			outputText("The second floor is in U-shaped, with two different rooms on each side and one at the end. The remaining space is occupied by the staircases which go to the third floor and to the first floor, with the hall connecting the three rooms. This hall is decorated too with a red rug and golden columns.");
 			outputText("\n\nThe room in the west is Anzu’s bedroom. A calm and peaceful sensation emanates from the door that leads to it.");
@@ -172,6 +181,7 @@ package classes.Scenes.Dungeons
 		public function roomBedroom():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_BEDROOM;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Bedroom</u></b>\n");
 			outputText("The golden columns decorate this room too. More silken colorful decorations cover them, with the mosaics doing the same to the bedroom walls. In a similar fashion of the living room, vases with violets and alabaster statues complete the room ornaments, with some armchairs giving place of rest.");
 			outputText("\n\nAnzu’s bed is huge, even for Marethian standards. Soft cushions and linen sheets cover the mattress. The bed itself releases an aromatic smell. You have the temptation of climb in and sleep on it all day.");
@@ -181,6 +191,7 @@ package classes.Scenes.Dungeons
 		public function roomLibrary():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_LIBRARY;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Library</u></b>\n");
 			outputText("Many bookshelves filled with at least one thousand books occupy most of the walls. The ambience inside is quiet and peaceful. Some armchairs give a comfortable place to read. This books must’ve been the only friendly company of your avian friend in many years. ");
 			outputText("\n\nOn the end of the place, is Anzu’s private study. A desk, a chair, some bookcases next to it. Nothing extraordinary.");
@@ -190,6 +201,7 @@ package classes.Scenes.Dungeons
 		public function roomMultiuse():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_MULTIUSE_ROOM;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Multi-use Room</u></b>\n");
 			outputText("This room used to be the bedroom of most of the Valkyries that used to live there. Since he has his own bedroom now, Anzu has little use for this room, and given his word, it remains empty. Actually, you could peek inside if you want...");
 			outputText("\n\nYeah, empty. There is nothing else to do there that look the corners.");
@@ -200,6 +212,7 @@ package classes.Scenes.Dungeons
 		public function roomHallFloor3():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_HALL_FLOOR3;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Hall, Floor 3</u></b>\n");
 			outputText("This floor has a disposition similar to the second, with the only difference being only two rooms and a huge window which gives a great view of the snow covered hills and the forest across the Rift. The usual staircase leads down to the second floor and up to the roof.");
 			outputText("\n\nTo the left is the treasure room, the place when probably half of Mareth treasures are stored.");
@@ -210,6 +223,7 @@ package classes.Scenes.Dungeons
 		public function roomVault():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_PALACE_VAULTS;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Vault</u></b>\n");
 			outputText("As expected from a treasure room, it's filled to the brim with boxes of golden coins and jewels. Diamonds, rubies, amethysts, sapphires, alexandrites, name a jewel and you probably could find here in insane quantities.");
 			outputText("\n\nGold objects, like plates, coins, goblets, chains, rings and utensils are stored in crates. Rugs and carpets are folded in many heaps in one corner. Bottles with aromatic oils are stored in shelves in another side of the room.");
@@ -220,6 +234,7 @@ package classes.Scenes.Dungeons
 		public function roomAlchemyRoom():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_ALCHEMY_ROOM;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Alchemy Room</u></b>\n");
 			outputText("In the north of the room is a kind of desk, with many alchemical devices. Currently, are some metals made liquid, in an attempt to made an alloy. This is probably the place where Anzu creates electrum. A bookshelf containing books of alchemy is located close.");
 			outputText("\n\nThe center of the room has what looks like a scale map from Mareth, the transmutation table, and the drawers containing ingredients are in the south of the room. Many concoctions and liquid metals are saved in shelves next to it.");
@@ -231,6 +246,7 @@ package classes.Scenes.Dungeons
 		public function roomRoof():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_ROOF;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Roof</u></b>\n");
 			outputText("The view here is amazing! This places offers a magnificent sight of the sky above and the hills and forest around.");
 			outputText("\n\nThe forest and the snow covered hills extend as far as the eye can see. The fresh air, though cold, bring you a peace which takes you away from the corruption and the horrors of this land for a moment.");
@@ -241,6 +257,7 @@ package classes.Scenes.Dungeons
 		public function roomBasement():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_BASEMENT;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Basement</u></b>\n");
 			outputText("A chariot dominates most of the open area of the basement. It's made of strong and sturdy wood, with a soft mattress and covered in silk. It doesn’t look like it’s designed to be pulled in a normal way, and judging by its nature and origin, probably moves by a magical force.");
 			outputText("\n\nSome feet behind the chariot, a door leads to Anzu’s armory. Inside is a collection of swords, knives, spears, and blades big enough to equip a small army. ");
@@ -250,6 +267,7 @@ package classes.Scenes.Dungeons
 		public function roomArmory():void {
 			kGAMECLASS.dungeonLoc = DungeonCore.DUNGEON_ANZU_ARMORY;
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b><u>Armory</u></b>\n");
 			outputText("This room contains a collection of swords, knives, spears, and blades big enough to equip a small army. At the end is an ornate armor probably once worn by the elite valkyries. You don't think Anzu would like you taking it without his permission.");
 			outputText("\n\nThere is a door leading back to the main basement room.");

--- a/classes/classes/Scenes/Dungeons/AnzuPalace/AnzuScene.as
+++ b/classes/classes/Scenes/Dungeons/AnzuPalace/AnzuScene.as
@@ -38,6 +38,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		//INTRO
 		public function initialPalaceEncounter():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("Wandering across the snow and forest covered hills of the Rift, you continue to travel without finding anything of interest. Without warning, a torrential gust of wind nearly blows you over. Taking a moment to orient yourself, you catch your footing, only to see the makings of a blizzard flying in upon the wind. Thinking fast, you search for a place for refuge. A nearby hill covered in thick pines catches your eye. It’s far from ideal, but better than nothing.");
 			outputText("\n\nWhen the blizzard settles down, you look towards the horizon, where an exceptionally large hill which you haven’t seen before catches your attention. It looks completely normal, being covered with a forest of snowy pines, but has a strange detail: something that looks like a building is jutting out on one of its sides.");
 			outputText("\n\nBewildered, you decide to approach the hill to see it more clearly, holding your [weapon] incase something comes out from the hills. You walk for awhile towards your goal, only to find that the hill in question is farther than you thought. After another hour, your suspicions are confirmed. There’s a building located near the hill’s summit surrounded by a forest. Even from hundreds of meters away it looks like some kind of palace, probably built for giants given its dimensions. Judging by the state of the building, it’s probably inhabited.");
@@ -50,6 +51,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function apporachInitialPalace():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("What could go wrong? You’re the Champion of Ingnam after all. If you’ve survived minotaurs, demons, giants and everything else that Mareth has to offer, whatever lives in that building shouldn’t be a problem if it decides to attack you. ");
 			if (flags[kFLAGS.LETHICE_DEFEATED] > 0 || flags[kFLAGS.CORRUPTED_MARAE_KILLED] > 0 || flags[kFLAGS.PURE_MARAE_ENDGAME] > 0) outputText("Even the so-called gods and lords of this land couldn’t stand against your might, so whoever, or whatever who resides there surely won’t be a threat.");
 			else outputText("Besides, after the snowstorm, you’ve been frozen to the bones. Hopefully inside will be warmer.");
@@ -121,6 +123,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function leaveInitialPalace():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("Well, if this place looks dangerous enough to keep giants away, then it probably means whatever lives here is something that you want to avoid. Since it doesn’t look like an area inhabited by demons, it's none of your business.");
 			doNext(camp.returnToCampUseOneHour);
 		}
@@ -203,6 +206,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		}
 		private function anzuRelatLvl3Help():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("What kind of friend would leave him to suffer alone? You tell him that he has no reason to be ashamed. In fact, you’d like to help him to get some release.");
 			outputText("\n\n\"<i>What? No [name]. I couldn’t ask you such a thing. Well, we’re friends and all, but this is asking too much...</i>\"");
 			outputText("\n\nFriends help each other, right? And it was the fault of your tickle attack after all. What could happen to him if he wanders outside in that state? Would you let your friend, weakened by lust, get ravaged by a Jotun or a yeti in the wilderness?");
@@ -230,6 +234,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		}
 		private function anzuRelatLvl3Dont():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("Excusing yourself, you ask him if he needs to attend something, you’ll give him the time.");
 			outputText("\n\n\"<i>Oh, thanks…</i>\" he says, quickly catching your idea. \"<i>Suddenly, I feel as if my bladder is full. I need to use the bathroom as soon as I can.</i>\"");
 			outputText("\n\nHurrying to the mentioned room, the avian leaves you alone in the living room, enjoying the warmness of the fireplace. After a few seconds, the obvious sound of someone jerking off is heard across the hall. Judging from the size of Anzu’s...attributes, he’ll have much to clean up after he finishes.");
@@ -238,6 +243,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function anzuRelatLvl4Sex():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("You answer him that you love him back too. The avian lowers himself until both of you meet eye to eye. His arms surround you, and soon you’re in the warmness of his embrace. Soon, the force of his grip becomes so strong it threatens to leave you without air.");
 			outputText("\n\n\"<i>Thanks [name]. You have no idea how happy I feel knowing that you feel the same way!</i>\"");
 			outputText("\n\nMaybe if he lets you breath a little, you could express your happiness too.");
@@ -250,6 +256,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		}
 		private function anzuRelatLvl4Dont():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("You give an uncomfortable look at the avian, who despite being initially confused to your reaction, quickly understands what you mean, releasing you from his embrace.");
 			outputText("\n\n\"<i>Sorry [name], I think I let my mind fly around those strange ideas.</i>\" He says, visibly embarrassed \"<i>But if you don’t feel that way…</i>\"");
 			outputText("\n\nThere is a long awkward silence, but you decide to calm down the situation by telling him that you don’t want to make him feel bad, you make clear who you still think on him as one of your best friends, and you hope that won’t be a problem.");
@@ -267,6 +274,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		//MENU & INTERACTIONS
 		public function anzuMenus():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("\"<i>Do you need anything?</i>\" Anzu asks patiently.");
 			menu();
 			addButton(0, "Appearance", anzuAppearance).hint("Take a closer look at the avian deity.");
@@ -286,6 +294,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		//Appearance
 		private function anzuAppearance():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("Anzu is a 18'2\" tall avian, with a strong and athletic build, worthy of a god.");
 			outputText("\n\nHis head is shaped like that of a predatory bird, with a beak and a long tongue. His ears have some resemblance with that of a cat, but they’re somewhat more elongated and streamlined, more adapted to flight. A gold earring with an amethyst gemstone hangs from his left ear. His hair is made of a crest of golden-orange fluffy feathers, with bright red feathers on the tip of his hair. The rest of his head is covered in orange feathers which shade to golden in an autumnal pattern. His eyes have a turquoise iris with a dark turquoise sclera.");
 			outputText("\n\nAnzu’s hands are almost human in shape, but are covered in a layer of small golden scales with small claws on the tips. His arms have a soft layer of golden feathers that reach almost to his wrists. A bracer of gold rests on each one of them. On his chest he has a pair of flat manly pecs, covered in feathers.");
@@ -299,6 +308,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		//Talk
 		private function anzuTalkMenu():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("\"<i>What would you like to talk about, " + player.mf("boy", "girl") + "?</i>\" Anzu asks.");
 			menu();
 			addButton(0, "His Past", anzuTalkPast).hint("Ask Anzu about his past.");
@@ -311,6 +321,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function anzuTalkPast():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-talk-past"));
 			outputText("You ask Anzu about what was he doing before he lived in Mareth. He said he was an empty shell of his former power, and he protected a city called Mittani.");
 			outputText("\n\n\"<i>First of all, I should explain to you about my full name,</i>\" Anzu says, \"<i>The Annuna is the common surname of the fifty powerful gods which are part of the council of gods that rule my former world. They're commonly known as the Council of the Annuna</i>\"");
@@ -335,6 +346,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		}
 		private function anzuTalkPalace():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-talk-palace"));
 			outputText("He said something about valkyries living here before he arrived. How was the palace before?");
 			outputText("\n\n\"<i>The group of women that used to live here before? With them, this place looked a little more rustic back then. Wooden tables, iron decorations, weapons hanging on the walls, and a fountain containing something they call mead. I had to redecorate the place after I threw them out.</i>\"");
@@ -379,6 +391,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		}
 		private function anzuTalkRift():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-talk-rift"));
 			outputText("Besides exploring and fighting some monsters, you know very few things about the Rift. Since Anzu has been living here for fifteen years, he could explain to you some details about the land. And, you still have doubts about how exactly he ended up in this place, and not, for example, the plains, or like you, the barrens.");
 			outputText("\n\n\"<i>The Rift is likely one of the largest areas in the realm of Mareth, although I admit that I’ve yet to explore much outside the Rift. The weather is always snowy, and usually has sudden snowstorms. A multitude of hills, mostly covered in forests across the land. All the trees are pines, etc.");
@@ -396,6 +409,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		}
 		private function anzuTalkPowers():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-talk-powers"));
 			outputText("Anzu said before he was a powerful deity. What are his powers exactly?");
 			outputText("\n\n\"<i>The term ‘god of storms’ mean anything to you?</i>\" Anzu says mockingly");
@@ -442,6 +456,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		}
 		private function anzuTalkMaraeAndLethice():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-talk-marae-lethice"));
 			outputText("Anzu said he was aware of the war between Marae and Lethice. After fifteen years in the Rift, he hasn’t been tempted to support one side?");
 			outputText("\n\n\"<i>I’ve said before, [name]. I act for myself. Always have been that way. Even before coming here. Besides, even if I sided with you and helped Marae, her followers probably wouldn’t look well on me.</i>\"");
@@ -480,6 +495,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		private function anzuSexMenu(showText:Boolean = true):void {
 			if (showText) {
 				clearOutput();
+				credits.authorText = "Coalsack";
 				outputText(images.showImage("anzu-sex-stripping"));
 				if (anzuSexCounter() == 0) {
 					outputText("You ask Anzu if he is up to a little fun in his bedroom.");
@@ -518,6 +534,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function catchAnalPart1():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-sex-anal-catch"));
 			if (flags[kFLAGS.ANZU_ANAL_CATCH_COUNTER] == 0) {
 				outputText("Looking at the handsome avian, your eyes quickly dart to the huge bulge on his pants. You look it, thinking how must feel to have that thick and huge monster inside. Anzu, who laughs nervously at your staring, seems to have realized what you have on mind.");
@@ -550,6 +567,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function catchAnalPart2():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			var wasVirgin:Boolean = player.ass.analLooseness < 1;
 			outputText("Climbing over him, you " + (player.hasLongTongue() ? "wrap your nimble tongue around" : "start caressing and licking the sides of") + " his partially hard avian meat. After a bit of licking across its length, you switch you attentions to his tip, taking the point of the tapered penis on your mouth and sliding playfully your tongue on his cumslit. Soon, the forty-inch rod rises to full erection, and the first droplets of pre dribble from his tip and land in your tongue. You remove your mouth and take some of his leaking pre in your hand, smearing it carefully across your soon-to-be ravaged [asshole]. Despite being already lubed by your saliva, you take some more pre and use it for lube every corner of Anzu’s semi-hard maleness.");
 			outputText("\n\nThe avian seems to be enjoying this treatment, given how his erection twitches, staining your hands with his dribbling pre. When you are sure that both your [asshole] and his cock are thoroughly lubed, you let him take control.");
@@ -628,6 +646,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function catchVaginal():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-sex-vaginal-catch"));
 			if (flags[kFLAGS.ANZU_VAGINAL_CATCH_COUNTER] == 0) {
 				outputText("Finding yourself on Anzu’s embrace, this time you wonder if the avian would like the idea to get intimate with you, in the most traditional way. The idea of enticing your avian friend on sliding that monster inside your vagina, while he pounds you with enough force to make you scream and finally, having his thick load flooding your womb is something that you can’t resist,  With that on mind, you slip down one of your hands to his crotch, and sliding down his underwear, start grabbing at the girthy meat that lies within. The avian lets out a moan at your sudden touch, but don’t removes your hand.");
@@ -678,6 +697,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function getBlown():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-sex-give-blowjob"));
 			if (flags[kFLAGS.ANZU_BLOWN_YOU_COUNTER] == 0) {
 				outputText("Deciding to take the initiative, you tell him that you have an uncomfortable pressure " + (player.balls > 0 ? "in your balls" : "on your loins") + ", and if he was kind enough to help you with….");
@@ -717,6 +737,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function suckOffDeitysCock():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-sex-receive-blowjob"));
 			if (flags[kFLAGS.ANZU_SUCKED_OFF_COUNTER] == 0) {
 				outputText("Now that you’ve played a bit on the bed, it time to get into business. The perfumed scent of the avian has been driving you crazy for a while, and now that you have a full sight of his athletic form, you attention goes down to his crotch. The thought of the hefty package inside his pants makes your mouth water. You then say Anzu that if he is stressed you’ll be more than happy to help him relieve pressure.");
@@ -773,6 +794,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function fuckGodlyBirdButt():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-sex-analpitch"));
 			outputText("In the mood for some bird butt, you tell Anzu that you'd like a turn on his ass.");
 			if (flags[kFLAGS.ANZU_ANAL_PITCH_COUNTER] == 0) {
@@ -815,6 +837,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function feedAnzu():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-sex-feeding"));
 			if (flags[kFLAGS.ANZU_FED_COUNTER] == 0) {
 				outputText("While resting with him on the bed, you feel a familiar weight on your breasts. Sensing the milky gift barely contained by your [chest], why not share a little of it with your avian " + (anzuRelationshipLevel() >= 4 ? "lover" : "friend") + "?");
@@ -876,6 +899,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		//Racing
 		private function racingWithAnzu():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-racing-intro"));
 			if (flags[kFLAGS.ANZU_TIMES_RACED] == 0) {
 				outputText("Standing on the roof, you see Anzu again, looking thoughtfully at the snowed hills that surround the place. Judging by the way he flexes his quartet of wings, he is about to depart, probably to exercise his otherwise idle wings. While at a first though he seems oblivious at your arrival, when you get a bit closer, he turns back and greets you with a friendly smile.");
@@ -894,12 +918,14 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function racingWithAnzuDecline():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("Letting him know that you’re pretty tired now, you tell him that you’ll have to pass this time. Next time maybe, with a little luck.");
 			outputText("\n\n“No problem. I understand. Flying tired isn’t exactly a relaxing activity ,”Anzu answers “Maybe, when you feel alright you could came here again...if you want, of course.” he continues “I usually fly at this hour almost every day.”");
 			outputText("\n\nAnswering him that you’ll think about it one of these days, you leave him to his exercise routine, while you return to the safety of your camp.");
 		}
 		private function racingWithAnzuAccept():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-racing-scene"));
 			outputText("Well, a bit of extra exercise would certainly help your body. Telling Anzu that you agree on his offer, you stand next to him on the border of the roof. Thankfully, it seems like he keeps the place where you’re standing clear of snow, otherwise you’ll probably trip and end up falling from the—now you realize, somewhat frightening—height of the palace.");
 			outputText("\n\nFocusing again on the thought of flying, you give a nod to the avian, saying that you’re ready to start.");
@@ -924,6 +950,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		//Dinner
 		private function dinnerWithAnzu():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			if (model.time.hours < 8) {
 				outputText(images.showImage("anzu-prep-breakfast"));
 				if (flags[kFLAGS.ANZU_TIMES_DINED_BREAKFAST] == 0) {
@@ -981,6 +1008,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function eatFoodWithAnzu():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			//Determine amount to refill hunger
 			var hungerRefillAmount:int = 50;
 			hungerRefillAmount -= Math.floor(player.hunger / 4);
@@ -1059,6 +1087,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		}
 		private function dontEatFoodWithAnzu():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			//Scene GO!
 			if (model.time.hours < 8) {
 				outputText("You thank him for his offer, but state how you already had your breakfast.");
@@ -1076,7 +1105,6 @@ package classes.Scenes.Dungeons.AnzuPalace
 				outputText("\n\n“Well, friend, I’ll be here is you change your mind” he answers.");
 				outputText("\n\nLeaving Anzu with the cake, you wave off him and return to your camp.");
 			}
-			clearOutput();
 		}
 		
 		/*private function diningSexGoodness():void {
@@ -1120,6 +1148,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		//------------
 		public function anzuBathTimeBeginning():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-bathtime-begin"));
 			outputText("Wandering again across the halls of the palace, you notice than Anzu isn't in his usual spot at this time of the day, reading a book in the tranquility of his living room. Actually, he isn’t in the kitchen either. A little confused about his whereabouts you search him across the palace, a task a bit difficult given its dimensions and the quantity of rooms.");
 			outputText("\n\nAfter an infructuous search you end looking at the window of the third floor, thinking that he may be gone outside, until you realize that you haven’t searched in one of the most obvious places: his bedroom. Joining action to the thought, you return downstairs to the first floor, and opening the gate to the opulent room, you find it empty. Seems like the bird doesn’t want to be found today.");
@@ -1138,6 +1167,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function anzuBathTimeAccept():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-bathtime-mid"));
 			outputText("Well, a warm bath sounds nice at this time of the day, and Anzu seems to be enjoying it, so, why not? " + player.clothedOrNaked("Leaving your " + player.armorDescript() + "aside, on a nearby table, y", "Y") + "ou get in the pool, not without making sure that Anzu gets a good view of your naked body when entering on it. When you return the look, you manage to see his avian manhood under the water, hanging limp and lazy between his legs. Even on it's unaroused state, it remains quite impressive. Under it, a pair of huge, feather-covered, nuts lie, moving slightly with the water.");
 			outputText("\n\n\"<i>Ehh, you…you look pretty nice today, [name]</i>\"  the avian says, interrupting your ogling of his privates, while blushing deeply without keeping his eyes away of your body and " + (player.hasCock() ? "hanging [cock] that swings playfully as you descend upon the pool" : "your exposed nether lips as your descend upon the pool") + ".");
@@ -1161,6 +1191,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function anzuBathTimeSex():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-bathtime-sex"));
 			outputText("You take the initiative, rubbing your backside against Anzu’s maleness, who stands proudly erect, now smearing your back with avian pre, that is quickly washed away by the water.");
 			outputText("\n\n\"<i>Heh, seems like a got a bit...., you know...[name]</i>\" Anzu says with a soft laugh, yet a bit embarrassed, after seeing his raging erection over your back. \"<i>And, having you so close, it’s no wonder that I eventually got a bit excited.</i>\"  he admits.");
@@ -1175,6 +1206,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function anzuBathTimeRelax():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-bathtime-relax"));
 			outputText("As fun as it could be, you decided to take a bath for cleanse your body, no for making it dirtier, so you attention diverges from Anzu's rod. ");
 			outputText("\n\nNow focusing on having all stressful thing that plague Mareth of your mind, you let your [legs] rest on the tiled bottom of the indoor pool, while your body enjoys the warm feeling of water on your [skin/fur/scales]. Your mind diverges to peaceful thoughts, away from this cursed place, reminiscences of your home on Ingnam, your village, and about all the good things that you have found that this land, that despite its cursed nature, has allowed to survive fills your mind and calm your troubled body.");
@@ -1191,6 +1223,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		}
 		private function anzuBathTimeDecline():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("Not in the mood of getting your " + player.skin.desc + " wet (and sticky) at this time of day, you thanks him for his offer but explain that you’re not exactly in the mood to get wet. Bidding him farewell, you leave him to his own matters and return to your camp.");
 			kGAMECLASS.inDungeon = false;
 			kGAMECLASS.dungeonLoc = -1;
@@ -1202,6 +1235,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		//------------
 		public function sleepWithAnzuInvitation():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-bed-begin"));
 			outputText("Satisfied in many senses, you feel a bit drowsy after all that cooking, eating and fucking, you let out a loud yawn and extend your body on one of the comfy couches in the living room.");
 			outputText("\n\n\"<i>Hey there, little friend</i>\" Anzu salutes you, as he returns too from the kitchen. \"<i>Feeling a bit tired after all that…exercise</i>\" he jokes.");
@@ -1215,6 +1249,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function declineSleepingWithAnzu():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("Tired as you are, a task is a task. You answer the avian that sadly, you have to keep guard tonight on the portal, so it will be on another time. Though a bit disappointed, the avian quickly cheers up and nuzzles your neck playfully, then he hugs you again and helps you to stand up. Gathering your things, you make it to the door, not without getting another playful nibble as you leave.");
 			outputText("\n\n\"<i>Be careful on your way to the camp, little friend</i>\" he says from the door while waving you. Waving him back you cross the Rift and return to your camp.");
 			kGAMECLASS.inDungeon = false;
@@ -1224,6 +1259,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function acceptSleepingWithAnzu():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-bed-mid"));
  			outputText("Well, with him as company, who wouldn’t want to stay in the palace for the night, you answer. The avian, overjoyed, despite being almost as tired as you, hugs you even tighter and proceeds to carry you on his arms, a " + (player.tallness >= 120 ? "a simple task, given his strength" : "a very easy task, given his strength and much larger frame") + ".");
 			outputText("\n\nSuddenly lifted from the ground by a couple of softly feathered arms, you let your body relax as  you let out a loud yawn. While on his arms you can feel his strong muscles embracing you, and you rest you head on his shoulder, " + (player.hair.length > 0 ? "while he ruffles your hair lovingly" : "rubs your neck, as he walks to his room") + ".");
@@ -1252,6 +1288,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function sleepingWithAnzuPart2():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("<b>At some moment, near midnight…</b>");
 			outputText("\n\nYaaaawn.");
 			outputText("\n\nWhat time of the night is? You can’t say the exact hour without a moon on the night sky that you manage to see through the window, but if your inner clock works well, you are pretty sure that it’s barely past midnight.");
@@ -1263,6 +1300,7 @@ package classes.Scenes.Dungeons.AnzuPalace
 	
 		private function sleepingWithAnzuBlowjob():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText(images.showImage("anzu-bed-blowjob"));
 			outputText("Softy disentangling yourself from the avian’s embrace, you try to get off from the unsurprisingly tall bed, without luck, as your " + player.feet() + " get stuck with something as you climb down the bed. Then, a familiar wetness near the area where your [leg] got stuck, reinforced with a tugging from the thing that refrains you from leaving, makes you turn back, only to found that the thing entangled with your " + player.foot() + " is nothing less than the avian’s underwear.");
 			outputText("\n\nSofty disentangling yourself from the avian’s embrace, you try to get off from the unsurprisingly tall bed, without luck, as your " + player.feet() + " get stuck with something as you climb down the bed. Then, a familiar wetness near the area where your [leg] got stuck, reinforced with a tugging from the thing that refrains you from leaving, makes you turn back, only to found that the thing entangled with your " + player.foot() + " is nothing less than the avian’s underwear.");
@@ -1290,12 +1328,14 @@ package classes.Scenes.Dungeons.AnzuPalace
 		
 		private function sleepingWithAnzuNoBJ():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			outputText("You shake your head and close your eyes. It takes quite a while but eventually, you succeed in catching your sleep again and make your way back to the dreamland.");
 			doNext(sleepWithAnzuProcess);
 		}
 		
 		private function sleepWithAnzuProcess():void {
 			clearOutput();
+			credits.authorText = "Coalsack";
 			kGAMECLASS.timeQ = 10;
 			goNext(timeQ, true);
 			wakeUpWithAnzuGoodMorningBirdie();

--- a/classes/coc/view/MainView.as
+++ b/classes/coc/view/MainView.as
@@ -119,6 +119,11 @@ public class MainView extends Block {
 	internal static const SPRITE_X:Number = GAP;
 	internal static const SPRITE_Y:Number = SCREEN_H - SPRITE_H - GAP;
 
+	internal static const CREDITS_X:Number = GAP;
+	internal static const CREDITS_Y:Number = STATBAR_Y + STATBAR_H + GAP;
+	internal static const CREDITS_W:Number = STATBAR_W - GAP;
+	internal static const CREDITS_H:Number = SPRITE_Y - CREDITS_Y;
+
 	internal static const TOPROW_W:Number = STATBAR_W + 2 * GAP + TEXTZONE_W;
 
 	internal static const BOTTOM_X:Number         = STATBAR_W + GAP;
@@ -139,6 +144,7 @@ public class MainView extends Block {
 
 	public var mainText:TextField;
 	public var nameBox:TextField;
+	public var creditsBox:TextField;
 	public var eventTestInput:TextField;
 	public var aCb:ComboBox;
 
@@ -245,6 +251,19 @@ public class MainView extends Block {
 			mouseEnabled     : true,
 			defaultTextFormat: {
 				size: 20
+			}
+		});
+		creditsBox = addTextField({
+			multiline        : true,
+			wordWrap         : true,
+			x                : CREDITS_X,
+			y                : CREDITS_Y,
+			width            : CREDITS_W,
+			height           : CREDITS_H,
+			mouseEnabled     : true,
+			defaultTextFormat: {
+				size: 16,
+				font: 'Arial'
 			}
 		});
 		scrollBar = new UIScrollBar();


### PR DESCRIPTION
Added the credits box, so you can now give credit to scene authors.

Usage:
```ts
credits.headline = "..."; // Sets the headline (Default: "Scene by:")
credits.authorText = "..."; // Sets the author(s) string (Default empty)
credits.show(); // Displays the credits, if the author string is not empty. auto-called, when flushing the output.
credits.clear(); // Resets author and header to the defaults and removed the credits text. auto-calls, when clearing the output
```
In most cases you just need to set `credits.authorText` after the `clearOutput();`-call of the corresponding scene.

For usage examples see the changes to the following files:
- CockatriceScene.as
- AnzuScene.as
- AnzuPalace.as
- RedRiverRoot.as
- TonOTrice.as