### PR TITLE
Stare combat ability was made too OP. Fixed that.

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -3894,7 +3894,7 @@ package classes
 			return 10;
 		}
 		public function minLust():Number {
-			return 100;
+			return 0;
 		}
 
 		public function maxLust():Number

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -1458,9 +1458,7 @@ package classes.Scenes.Combat
 				        + " helplessness of it feels so good... " + monster.pronoun1 + " can't banish the feeling that really, " + monster.pronoun1
 				        + " wants to look into your eyes forever, for you to have total control over " + monster.pronoun2 + ". ";
 				slowEffect++;
-				if (monster.spe > 1) monster.spe -= 16 + stareTraining * 8 - slowEffect * (4 + stareTraining * 2);
-				if (monster.spe < 1) monster.spe = 1;
-				bse.count++;
+				bse.applyEffect(16 + stareTraining * 8 - slowEffect * (4 + stareTraining * 2));
 				flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] += 4;
 				speedDiff = Math.round(oldSpeed - monster.spe);
 				output.text(message + combat.getDamageText(speedDiff) + "\n\n");

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -1403,7 +1403,7 @@ package classes.Scenes.Combat
 			var TheMonster:String      = monster.capitalA + monster.short;
 			var stareTraining:Number   = flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] / 100;
 			var bse:BasiliskSlowDebuff = monster.createOrFindStatusEffect(StatusEffects.BasiliskSlow) as BasiliskSlowDebuff;
-			var slowEffect:Number      = -bse.buffValue('spe');
+			var slowEffect:Number      = bse.count;
 			var oldSpeed:Number        = monster.spe;
 			var speedDiff:int          = 0;
 			var message:String         = "";
@@ -1458,7 +1458,9 @@ package classes.Scenes.Combat
 				        + " helplessness of it feels so good... " + monster.pronoun1 + " can't banish the feeling that really, " + monster.pronoun1
 				        + " wants to look into your eyes forever, for you to have total control over " + monster.pronoun2 + ". ";
 				slowEffect++;
-				bse.applyEffect(16 + stareTraining * 8 - slowEffect * (4 + stareTraining * 2));
+				if (monster.spe > 1) monster.spe -= 16 + stareTraining * 8 - slowEffect * (4 + stareTraining * 2);
+				if (monster.spe < 1) monster.spe = 1;
+				bse.count++;
 				flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] += 4;
 				speedDiff = Math.round(oldSpeed - monster.spe);
 				output.text(message + combat.getDamageText(speedDiff) + "\n\n");

--- a/classes/classes/StatusEffects/Combat/BasiliskSlowDebuff.as
+++ b/classes/classes/StatusEffects/Combat/BasiliskSlowDebuff.as
@@ -9,7 +9,7 @@ public class BasiliskSlowDebuff extends CombatBuff {
 	}
 
 	public function applyEffect(amount:Number):void {
-		buffHost('spe', -amount);
+		buffHost('spe', -amount, 'scale', false, 'max', false);
 		count++;
 	}
 }

--- a/classes/classes/StatusEffects/Combat/BasiliskSlowDebuff.as
+++ b/classes/classes/StatusEffects/Combat/BasiliskSlowDebuff.as
@@ -2,13 +2,15 @@ package classes.StatusEffects.Combat {
 import classes.StatusEffectType;
 
 public class BasiliskSlowDebuff extends CombatBuff {
+	public var count:int = 0;
 	public static const TYPE:StatusEffectType = register("BasiliskSlow",BasiliskSlowDebuff);
 	public function BasiliskSlowDebuff() {
 		super(TYPE,'spe');
 	}
 
 	public function applyEffect(amount:Number):void {
-		buffHost('spe',-amount);
+		buffHost('spe', -amount);
+		count++;
 	}
 }
 


### PR DESCRIPTION
nvm the workaround. I could work out a fix that minimized the changes along with a fix for `Creature.minLust()` returning 100, where it should return 0, which it does now.