### PR TITLE
Parser smoke tests

### DIFF
--- a/test/classes/CoCTest.as
+++ b/test/classes/CoCTest.as
@@ -11,22 +11,22 @@ package classes{
 	import classes.CoC;
 	import classes.helper.StageLocator;
 	
-    public class CoCTest {
-        private var cut:CoC;
+	public class CoCTest {
+		private var cut:CoC;
 		
-        [Before]
-        public function runBeforeEveryTest():void {
+		[Before]
+		public function runBeforeEveryTest():void {
 			assertThat(StageLocator.stage, not(nullValue()));
-        }  
-     
-        [Test] 
-        public function injectStageForTest():void {
-            cut = new CoC(StageLocator.stage);
-        }
+		}
+
+		[Test] 
+		public function injectStageForTest():void {
+			cut = new CoC(StageLocator.stage);
+		}
 		
 		[Test(expected="TypeError")] 
-        public function noInjectedStage():void {
-            cut = new CoC();
-        }
-    }
+		public function noInjectedStage():void {
+			cut = new CoC();
+		}
+	}
 }

--- a/test/classes/CoCTest.as
+++ b/test/classes/CoCTest.as
@@ -46,8 +46,9 @@ package classes{
 		public function eventTesterSmokeTest(): void {
 			cut.eventTester();
 			
-			fireButton.fireButtonClick(0);
-			fireButton.fireButtonClick(4);
+			//Button presses are required to stop the test from hanging
+			fireButton.fireButtonClick(0); //press 'proceed' button
+			fireButton.fireButtonClick(4); //press 'exit' button
 		}
 	}
 }

--- a/test/classes/CoCTest.as
+++ b/test/classes/CoCTest.as
@@ -17,6 +17,9 @@ package classes{
 		[Before]
 		public function runBeforeEveryTest():void {
 			assertThat(StageLocator.stage, not(nullValue()));
+			
+			cut = new CoC(StageLocator.stage);
+			cut.player.createVagina();
 		}
 
 		[Test] 
@@ -27,6 +30,11 @@ package classes{
 		[Test(expected="TypeError")] 
 		public function noInjectedStage():void {
 			cut = new CoC();
+		}
+		
+		[Test]
+		public function parserSmokeTest(): void {
+			cut.doThatTestingThang();
 		}
 	}
 }

--- a/test/classes/CoCTest.as
+++ b/test/classes/CoCTest.as
@@ -10,9 +10,12 @@ package classes{
 	
 	import classes.CoC;
 	import classes.helper.StageLocator;
+	import classes.helper.FireButtonEvent;
+	import classes.GlobalFlags.kGAMECLASS;
 	
 	public class CoCTest {
 		private var cut:CoC;
+		private var fireButton:FireButtonEvent;
 		
 		[Before]
 		public function runBeforeEveryTest():void {
@@ -20,6 +23,8 @@ package classes{
 			
 			cut = new CoC(StageLocator.stage);
 			cut.player.createVagina();
+			
+			fireButton = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
 		}
 
 		[Test] 
@@ -35,6 +40,14 @@ package classes{
 		[Test]
 		public function parserSmokeTest(): void {
 			cut.doThatTestingThang();
+		}
+		
+		[Test]
+		public function eventTesterSmokeTest(): void {
+			cut.eventTester();
+			
+			fireButton.fireButtonClick(0);
+			fireButton.fireButtonClick(4);
 		}
 	}
 }


### PR DESCRIPTION
This will run the both the `Options -> Debug Info` `Parser Test` and `Input Test`.
Should give early warning if something in the parser is broken (like #1008).