### PR TITLE
Add PlayerTest.as

### DIFF
--- a/classes/classes/BodyParts/Neck.as
+++ b/classes/classes/BodyParts/Neck.as
@@ -17,6 +17,7 @@ package classes.BodyParts
 		public var color:String = "no";
 
 		private var _nlMax:Array = [];
+		public function get nlMax():Array { return _nlMax; }
 
 		public function Neck()
 		{

--- a/classes/classes/BreastRowClass.as
+++ b/classes/classes/BreastRowClass.as
@@ -1,16 +1,13 @@
 ﻿package classes
 {
 	import classes.internals.Utils;
+	import classes.lists.BreastCup;
 
 	public class BreastRowClass
 	{
-		//constructor
-		public function BreastRowClass()
-		{
-		}
 		public var breasts:Number = 2;
 		public var nipplesPerBreast:Number = 1;
-		public var breastRating:Number = 0;
+		public var breastRating:Number = BreastCup.FLAT;
 		public var lactationMultiplier:Number = 0;
 		//Fullness used for lactation....if 75 or greater warning bells start going off!
 		//If it reaches 100 it reduces lactation multiplier.
@@ -18,7 +15,7 @@
 		public var fullness:Number = 0;
 		public var fuckable:Boolean = false;
 		public var nippleCocks:Boolean = false;
-		
+
 		public function validate():String
 		{
 			var error:String = "";
@@ -28,21 +25,35 @@
 			]);
 			return error;
 		}
-		/*
-		0 - manchest
-		1 - A cup
-		2 - B cup
-		3 - C cup
-		4 - D cup
-		5 - DD cup
-		6 - E cup
-		7 - F cup
-		8 - G cup
-		9 - GG cup
-		10 - H
-		11 - HH cup
-		12 - HHH cup
-		13 - beachball sized
-		14 - ???*/
+
+		public function restore():void
+		{
+			breasts = 2;
+			nipplesPerBreast = 1;
+			breastRating = BreastCup.FLAT;
+			lactationMultiplier = 0;
+			milkFullness = 0;
+			fullness = 0;
+			fuckable = false;
+			nippleCocks = false;
+		}
+
+		public function setProps(p:Object):void
+		{
+			if (p.hasOwnProperty('breasts'))             breasts             = p.breasts;
+			if (p.hasOwnProperty('nipplesPerBreast'))    nipplesPerBreast    = p.nipplesPerBreast;
+			if (p.hasOwnProperty('breastRating'))        breastRating        = p.breastRating;
+			if (p.hasOwnProperty('lactationMultiplier')) lactationMultiplier = p.lactationMultiplier;
+			if (p.hasOwnProperty('milkFullness'))        milkFullness        = p.milkFullness;
+			if (p.hasOwnProperty('fullness'))            fullness            = p.fullness;
+			if (p.hasOwnProperty('fuckable'))            fuckable            = p.fuckable;
+			if (p.hasOwnProperty('nippleCocks'))         nippleCocks         = p.nippleCocks;
+		}
+
+		public function setAllProps(p:Object):void
+		{
+			restore();
+			setProps(p);
+		}
 	}
 }

--- a/test/ClassesSuit.as
+++ b/test/ClassesSuit.as
@@ -1,6 +1,7 @@
 package {
 	import classes.HelperSuit;
 	import classes.InternalsSuit;
+	import classes.PlayerTest;
 	import classes.ScenesSuit;
 	import classes.ItemsSuit;
 
@@ -27,6 +28,7 @@ package {
 		 public var charCreationTest:CharCreationTest; 
 		 public var monsterTest:MonsterTest;
 		 public var creaturTest:CreatureTest;
+		 public var playerTest:PlayerTest;
 		 public var vaginaClass:VaginaClassTest;
 		 public var savesTest:SavesTest;
 		 public var playerEventsTest:PlayerEventsTest;

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -457,5 +457,33 @@ package classes
 
 			assertThat(lizardPlayer.lizardScore(), greaterThan(0));
 		}
+
+		[Test]
+		public function testSpiderScore():void
+		{
+			var driderPlayer:Player = new Player();
+			driderPlayer.eyes.setProps({type: Eyes.SPIDER, count: 4});
+			driderPlayer.face.type = Face.SPIDER_FANGS;
+			driderPlayer.arms.type = Arms.SPIDER;
+			driderPlayer.lowerBody.type = LowerBody.DRIDER;
+			driderPlayer.tail.type = Tail.SPIDER_ABDOMEN;
+			driderPlayer.skin.type = Skin.PLAIN;
+
+			assertThat(driderPlayer.spiderScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testHorseScore():void
+		{
+			var horsePlayer:Player = new Player();
+			createCock(CockTypesEnum.HORSE, horsePlayer);
+			horsePlayer.face.type = Face.HORSE;
+			horsePlayer.ears.type = Ears.HORSE;
+			horsePlayer.tail.type = Tail.HORSE;
+			horsePlayer.lowerBody.type = LowerBody.HOOFED;
+			horsePlayer.skin.type = Skin.FUR;
+
+			assertThat(horsePlayer.horseScore(), greaterThan(0));
+		}
 	}
 }

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -269,6 +269,22 @@ package classes
 		}
 
 		[Test]
+		public function testBeeScore():void
+		{
+			var beePlayer:Player = new Player();
+			beePlayer.hair.color = "black and yellow";
+			beePlayer.antennae.type = Antennae.BEE;
+			beePlayer.face.type = Face.HUMAN;
+			beePlayer.arms.type = Arms.BEE;
+			beePlayer.lowerBody.type = LowerBody.BEE;
+			beePlayer.createVagina();
+			beePlayer.tail.type = Tail.BEE_ABDOMEN;
+			beePlayer.wings.type = Wings.BEE_LIKE_SMALL;
+
+			assertThat(beePlayer.beeScore(), greaterThan(0));
+		}
+
+		[Test]
 		public function testLizardScore():void
 		{
 			var lizardPlayer:Player = new Player();

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -505,5 +505,28 @@ package classes
 
 			assertThat(kitsunePlayer.kitsuneScore(), greaterThan(0));
 		}
+
+		[Test]
+		public function testDragonScore():void
+		{
+			var dragonPlayer:Player = new Player();
+			createCock(CockTypesEnum.DRAGON, dragonPlayer);
+			createPerk(PerkLib.Dragonfire, dragonPlayer);
+			dragonPlayer.face.type = Face.DRAGON;
+			dragonPlayer.ears.type = Ears.DRAGON;
+			dragonPlayer.tail.type = Tail.DRACONIC;
+			dragonPlayer.tongue.type = Tongue.DRACONIC;
+			dragonPlayer.wings.type = Wings.DRACONIC_LARGE;
+			dragonPlayer.lowerBody.type = LowerBody.DRAGON;
+			dragonPlayer.skin.type = Skin.DRAGON_SCALES;
+			dragonPlayer.horns.type = Horns.DRACONIC_X4_12_INCH_LONG;
+			dragonPlayer.arms.type = Arms.PREDATOR;
+			dragonPlayer.claws.type = Claws.DRAGON;
+			dragonPlayer.eyes.type = Eyes.DRAGON;
+			dragonPlayer.neck.modify(Infinity, Neck.DRACONIC);
+			dragonPlayer.rearBody.type = RearBody.DRACONIC_SPIKES;
+
+			assertThat(dragonPlayer.dragonScore(), greaterThan(0));
+		}
 	}
 }

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -32,15 +32,10 @@ package classes
 				instance.createVagina();
 			}
 		}
-		
+
 		private function createMaxVaginas(instance:Player):void
 		{
 			createVaginas(MAX_SUPPORTED_VAGINAS, instance);
-		}
-		
-		private function createPerk(perk:PerkType, instance:Player):void
-		{
-			instance.createPerk(perk, 1, 1, 1, 1);
 		}
 
 		private function removeExtraBreastRows(instance:Player):void
@@ -68,6 +63,17 @@ package classes
 				return;
 
 			instance.removeVagina(0, instance.vaginas.length);
+		}
+
+		private function createPerk(perk:PerkType, instance:Player):void
+		{
+			instance.createPerk(perk, 1, 1, 1, 1);
+		}
+
+		private function createStatusEffect(stype:StatusEffectType, instance:Player):void
+		{
+			if (!instance.hasStatusEffect(stype))
+				instance.createStatusEffect(stype, 1, 1, 1, 1);
 		}
 
 		[BeforeClass]
@@ -241,6 +247,20 @@ package classes
 			cowPlayer.face.type = Face.COW_MINOTAUR;
 
 			assertThat(cowPlayer.cowScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testSandTrapScore():void
+		{
+			var sandTrapPlayer:Player = new Player();
+			createStatusEffect(StatusEffects.BlackNipples, sandTrapPlayer);
+			createStatusEffect(StatusEffects.Uniball, sandTrapPlayer);
+			sandTrapPlayer.createVagina();
+			sandTrapPlayer.vaginaType(5);
+			sandTrapPlayer.eyes.type = Eyes.BLACK_EYES_SAND_TRAP;
+			sandTrapPlayer.wings.type = Wings.GIANT_DRAGONFLY;
+
+			assertThat(sandTrapPlayer.sandTrapScore(), greaterThan(0));
 		}
 
 		[Test]

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -5,6 +5,7 @@ package classes
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.PerkLib;
 	import classes.Player;
+	import classes.Scenes.Areas.VolcanicCrag.BehemothScene;
 	import classes.helper.StageLocator;
 	import classes.internals.IRandomNumber;
 	import classes.internals.RandomNumber;
@@ -21,14 +22,17 @@ package classes
 	public class PlayerTest 
 	{
 		private const MAX_SUPPORTED_VAGINAS:Number = 2;
+		private const MAX_SUPPORTED_BREAST_ROWS:Number = 10;
 
 		private var impPlayer:Player;
 		private var minoPlayer:Player;
 		private var cowPlayer:Player;
+		private var wolfPlayer:Player;
+		private var dogPlayer:Player;
 
 		private function createVaginas(numberOfVaginas:Number, instance:Player):void
 		{
-			for(var i:Number = 0; i < numberOfVaginas; i++) {
+			for (var i:Number = 0; i < numberOfVaginas; i++) {
 				instance.createVagina();
 			}
 		}
@@ -36,6 +40,19 @@ package classes
 		private function createMaxVaginas(instance:Player):void
 		{
 			createVaginas(MAX_SUPPORTED_VAGINAS, instance);
+		}
+
+		private function createBreastRows(numberOfRows:Number, instance:Player):void
+		{
+			removeAllBreasts(instance);
+			for (var i:Number = 1; i < numberOfRows; i++) {
+				instance.createBreastRow();
+			}
+		}
+
+		private function createMaxBreastRows(instance:Player):void
+		{
+			createBreastRows(MAX_SUPPORTED_BREAST_ROWS, instance);
 		}
 
 		private function removeExtraBreastRows(instance:Player):void
@@ -126,6 +143,23 @@ package classes
 			cowPlayer.createVagina();
 			cowPlayer.createBreastRow(5);
 			cowPlayer.breastRows[0].lactationMultiplier = 3;
+
+			wolfPlayer = new Player();
+			createCock(CockTypesEnum.WOLF, wolfPlayer);
+			wolfPlayer.face.type = Face.WOLF;
+			wolfPlayer.ears.type = Ears.WOLF;
+			wolfPlayer.tail.type = Tail.WOLF;
+			wolfPlayer.lowerBody.type = LowerBody.WOLF;
+			wolfPlayer.eyes.type = Eyes.WOLF;
+			wolfPlayer.skin.type = Skin.FUR;
+
+			dogPlayer = new Player();
+			createCock(CockTypesEnum.DOG, dogPlayer);
+			dogPlayer.face.type = Face.DOG;
+			dogPlayer.ears.type = Ears.DOG;
+			dogPlayer.tail.type = Tail.DOG;
+			dogPlayer.lowerBody.type = LowerBody.DOG;
+			dogPlayer.skin.type = Skin.FUR;
 		}
 
 		[Test]
@@ -282,6 +316,126 @@ package classes
 			beePlayer.wings.type = Wings.BEE_LIKE_SMALL;
 
 			assertThat(beePlayer.beeScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testFerretScore():void
+		{
+			var ferretPlayer:Player = new Player();
+			ferretPlayer.face.type = Face.FERRET;
+			ferretPlayer.ears.type = Ears.FERRET;
+			ferretPlayer.tail.type = Tail.FERRET;
+			ferretPlayer.lowerBody.type = LowerBody.FERRET;
+			ferretPlayer.skin.type = Skin.FUR;
+
+			assertThat(ferretPlayer.ferretScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testMaleWolfScore():void
+		{
+			removeAllBreasts(wolfPlayer);
+
+			assertThat(wolfPlayer.wolfScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testHermWolfScore():void
+		{
+			createBreastRows(4, wolfPlayer);
+
+			assertThat(wolfPlayer.wolfScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testHermLottaBreastRowsWolfScore():void
+		{
+			createMaxBreastRows(wolfPlayer);
+
+			assertThat(wolfPlayer.wolfScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testMaleDogScore():void
+		{
+			removeAllBreasts(dogPlayer);
+
+			assertThat(dogPlayer.dogScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testHermDogScore():void
+		{
+			createBreastRows(3, dogPlayer);
+
+			assertThat(dogPlayer.dogScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testHermLottaBreastRowsDogScore():void
+		{
+			createMaxBreastRows(dogPlayer);
+
+			assertThat(dogPlayer.dogScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testMouseScore():void
+		{
+			var mousePlayer:Player = new Player();
+			mousePlayer.ears.type = Ears.MOUSE;
+			mousePlayer.tail.type = Tail.MOUSE;
+			mousePlayer.face.type = Face.MOUSE;
+			mousePlayer.skin.type = Skin.FUR;
+			mousePlayer.tallness = 30;
+
+			assertThat(mousePlayer.mouseScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testRaccoonScore():void
+		{
+			var raccoonPlayer:Player = new Player();
+			raccoonPlayer.face.type = Face.RACCOON;
+			raccoonPlayer.ears.type = Ears.RACCOON;
+			raccoonPlayer.tail.type = Tail.RACCOON;
+			raccoonPlayer.lowerBody.type = LowerBody.RACCOON;
+			raccoonPlayer.balls = 2;
+			raccoonPlayer.skin.type = Skin.FUR;
+
+			assertThat(raccoonPlayer.raccoonScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testFoxScore():void
+		{
+			// No need to test variations of breastrow-count yet
+			var foxPlayer:Player = new Player();
+			createBreastRows(4, foxPlayer);
+			createCock(CockTypesEnum.FOX, foxPlayer);
+			foxPlayer.face.type = Face.FOX;
+			foxPlayer.ears.type = Ears.FOX;
+			foxPlayer.tail.type = Tail.FOX;
+			foxPlayer.lowerBody.type = LowerBody.FOX;
+			foxPlayer.skin.type = Skin.FUR;
+
+			assertThat(foxPlayer.foxScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testCatScore():void
+		{
+			// No need to test variations of breastrow-count yet
+			var catPlayer:Player = new Player();
+			createBreastRows(3, catPlayer);
+			createCock(CockTypesEnum.CAT, catPlayer);
+			catPlayer.face.type = Face.CAT;
+			catPlayer.ears.type = Ears.CAT;
+			catPlayer.tail.type = Tail.CAT;
+			catPlayer.lowerBody.type = LowerBody.CAT;
+			catPlayer.skin.type = Skin.FUR;
+
+			assertThat(catPlayer.catScore(), greaterThan(0));
 		}
 
 		[Test]

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -1,0 +1,204 @@
+package classes
+{
+	import classes.BodyParts.*;
+	import classes.CoC;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.PerkLib;
+	import classes.Player;
+	import classes.helper.StageLocator;
+	import classes.internals.IRandomNumber;
+	import classes.internals.RandomNumber;
+	import classes.lists.BreastCup;
+	import classes.lists.Gender;
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.collection.*;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+
+	public class PlayerTest 
+	{
+		private const MAX_SUPPORTED_VAGINAS:Number = 2;
+
+		private var impPlayer:Player;
+
+		private function createVaginas(numberOfVaginas:Number, instance:Player):void
+		{
+			for(var i:Number = 0; i < numberOfVaginas; i++) {
+				instance.createVagina();
+			}
+		}
+		
+		private function createMaxVaginas(instance:Player):void
+		{
+			createVaginas(MAX_SUPPORTED_VAGINAS, instance);
+		}
+		
+		private function createPerk(perk:PerkType, instance:Player):void
+		{
+			instance.createPerk(perk, 1, 1, 1, 1);
+		}
+
+		private function removeExtraBreastRows(instance:Player):void
+		{
+			if (instance.breastRows.length <= 1)
+				return;
+
+			instance.removeBreastRow(1, instance.breastRows.length - 1);
+		}
+
+		private function removeAllBreasts(instance:Player):void
+		{
+			if (instance.breastRows.length === 0) {
+				instance.createBreastRow();
+				return;
+			}
+
+			removeExtraBreastRows(instance);
+			instance.breastRows[0].breastRating = BreastCup.FLAT;
+		}
+
+		[BeforeClass]
+		public static function setUpClass():void
+		{
+			/* Hidden dependencies on global variables can cause tests to fail spectacularly.
+			 * 
+			 * Seriously people, DONT use global variables.
+			 */
+
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+
+		[Before]
+		public function setUp():void
+		{
+			impPlayer = new Player();
+			impPlayer.createBreastRow();
+			impPlayer.ears.type = Ears.IMP;
+			impPlayer.tail.type = Tail.IMP;
+			impPlayer.wings.type = Wings.IMP;
+			impPlayer.wings.type = Wings.IMP_LARGE;
+			impPlayer.lowerBody.type = LowerBody.IMP;
+			impPlayer.skin.type = Skin.PLAIN;
+			impPlayer.skin.tone = "red";
+			impPlayer.horns.type = Horns.IMP;
+			impPlayer.arms.type = Arms.PREDATOR;
+			impPlayer.claws.type = Claws.IMP;
+		}
+
+		[Test]
+		public function testRedPandaScore():void
+		{
+			var redPandaPlayer:Player = new Player();
+			redPandaPlayer.ears.type = Ears.RED_PANDA;
+			redPandaPlayer.tail.type = Tail.RED_PANDA;
+			redPandaPlayer.arms.type = Arms.RED_PANDA;
+			redPandaPlayer.face.type = Face.RED_PANDA;
+			redPandaPlayer.lowerBody.type = LowerBody.RED_PANDA;
+			redPandaPlayer.skin.type = Skin.FUR;
+			redPandaPlayer.underBody.type = UnderBody.FURRY;
+			redPandaPlayer.underBody.skin.type = Skin.FUR;
+
+			assertThat(redPandaPlayer.redPandaScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testCockatriceScore():void
+		{
+			var cockatricePlayer:Player = new Player();
+			cockatricePlayer.ears.type = Ears.COCKATRICE;
+			cockatricePlayer.tail.type = Tail.COCKATRICE;
+			cockatricePlayer.lowerBody.type = LowerBody.COCKATRICE;
+			cockatricePlayer.face.type = Face.COCKATRICE;
+			cockatricePlayer.eyes.type = Eyes.COCKATRICE;
+			cockatricePlayer.arms.type = Arms.COCKATRICE;
+			cockatricePlayer.antennae.type = Antennae.COCKATRICE;
+			cockatricePlayer.neck.type = Neck.COCKATRICE;
+			cockatricePlayer.tongue.type = Tongue.LIZARD;
+			cockatricePlayer.wings.type = Wings.FEATHERED_LARGE;
+			cockatricePlayer.skin.type = Skin.LIZARD_SCALES;
+			cockatricePlayer.underBody.type = UnderBody.COCKATRICE;
+			cockatricePlayer.createCock(5.5, 1, CockTypesEnum.LIZARD);
+
+			assertThat(cockatricePlayer.cockatriceScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testNormalImpScore():void
+		{
+			removeAllBreasts(impPlayer);
+			impPlayer.tallness = 30;
+
+			assertThat(impPlayer.impScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testTitsImpScore():void
+		{
+			removeAllBreasts(impPlayer);
+			impPlayer.tallness = 50;
+			impPlayer.breastRows[0].breastRating = 5;
+			impPlayer.createBreastRow(5);
+			impPlayer.createBreastRow(5);
+			impPlayer.createBreastRow(5);
+
+			assertThat(impPlayer.impScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testDemonScore():void
+		{
+			var demonPlayer:Player = new Player();
+			demonPlayer.horns.type = Horns.DEMON;
+			demonPlayer.horns.value = 12;
+			demonPlayer.tail.type = Tail.DEMONIC;
+			demonPlayer.wings.type = Wings.BAT_LIKE_LARGE;
+			demonPlayer.skin.type = Skin.PLAIN;
+			demonPlayer.cor = 100;
+			demonPlayer.face.type = Face.HUMAN;
+			demonPlayer.lowerBody.type = LowerBody.DEMONIC_CLAWS;
+			demonPlayer.createCock(5.5, 1, CockTypesEnum.DEMON);
+
+			assertThat(demonPlayer.demonScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testHumanScore():void
+		{
+			var humanPlayer:Player = new Player();
+			humanPlayer.face.type = Face.HUMAN;
+			humanPlayer.skin.type = Skin.PLAIN;
+			humanPlayer.horns.type = Horns.NONE;
+			humanPlayer.tail.type = Tail.NONE;
+			humanPlayer.wings.type = Wings.NONE;
+			humanPlayer.lowerBody.type = LowerBody.HUMAN;
+			humanPlayer.skin.type = Skin.PLAIN;
+			humanPlayer.createCock(5.5, 1, CockTypesEnum.HUMAN);
+			removeAllBreasts(humanPlayer); // auto-creates a breast row, if none exists
+
+			assertThat(humanPlayer.humanScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testLizardScore():void
+		{
+			var lizardPlayer:Player = new Player();
+			lizardPlayer.face.type = Face.LIZARD;
+			lizardPlayer.ears.type = Ears.LIZARD;
+			lizardPlayer.tail.type = Tail.LIZARD;
+			lizardPlayer.lowerBody.type = LowerBody.LIZARD;
+			lizardPlayer.horns.type = Horns.DRACONIC_X4_12_INCH_LONG;
+			lizardPlayer.arms.type = Arms.PREDATOR;
+			lizardPlayer.claws.type = Claws.LIZARD;
+			lizardPlayer.tongue.type = Tongue.LIZARD;
+			lizardPlayer.createCock(5.5, 1, CockTypesEnum.LIZARD);
+			lizardPlayer.createCock(5.5, 1, CockTypesEnum.LIZARD);
+			lizardPlayer.eyes.type = Eyes.LIZARD;
+			lizardPlayer.skin.type = Skin.LIZARD_SCALES;
+
+			assertThat(lizardPlayer.lizardScore(), greaterThan(0));
+		}
+	}
+}

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -30,6 +30,7 @@ package classes
 		private var cowPlayer:Player;
 		private var wolfPlayer:Player;
 		private var dogPlayer:Player;
+		private var mutantPlayer:Player;
 
 		private function createVaginas(numberOfVaginas:Number, instance:Player):void
 		{
@@ -161,6 +162,13 @@ package classes
 			dogPlayer.tail.type = Tail.DOG;
 			dogPlayer.lowerBody.type = LowerBody.DOG;
 			dogPlayer.skin.type = Skin.FUR;
+
+			mutantPlayer = new Player();
+			createBreastRows(2, mutantPlayer);
+			mutantPlayer.breastRows[0].fuckable = true;
+			mutantPlayer.createCock();
+			mutantPlayer.createCock();
+			mutantPlayer.createVagina();
 		}
 
 		[Test]
@@ -527,6 +535,208 @@ package classes
 			dragonPlayer.rearBody.type = RearBody.DRACONIC_SPIKES;
 
 			assertThat(dragonPlayer.dragonScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testGoblinScore():void
+		{
+			var goblinPlayer:Player = new Player();
+			goblinPlayer.createVagina();
+			goblinPlayer.ears.type = Ears.ELFIN;
+			goblinPlayer.skin.tone = "pale yellow"; // TODO: Move that to the ColorLists
+			goblinPlayer.face.type = Face.HUMAN;
+			goblinPlayer.tallness = 40;
+			goblinPlayer.lowerBody.type = LowerBody.HUMAN;
+
+			assertThat(goblinPlayer.goblinScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testGooScore():void
+		{
+			var gooPlayer:Player = new Player();
+			gooPlayer.hair.type = Hair.GOO;
+			gooPlayer.skin.adj = "slimy";
+			gooPlayer.lowerBody.type = LowerBody.GOO;
+			gooPlayer.createVagina();
+			gooPlayer.createStatusEffect(StatusEffects.BonusVCapacity, 9000, 0, 0, 0);
+			gooPlayer.createStatusEffect(StatusEffects.SlimeCraving, 0, 0, 0, 1);
+
+			assertThat(gooPlayer.gooScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testNagaScore():void
+		{
+			var nagaPlayer:Player = new Player();
+			nagaPlayer.face.type = Face.SNAKE_FANGS;
+			nagaPlayer.tongue.type = Tongue.SNAKE;
+			nagaPlayer.lowerBody.type = LowerBody.NAGA; // Not included in nagaScore, but just in case ...
+
+			assertThat(nagaPlayer.nagaScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testBunnyScore():void
+		{
+			var bunnyPlayer:Player = new Player();
+			bunnyPlayer.face.type = Face.BUNNY;
+			bunnyPlayer.tail.type = Tail.RABBIT;
+			bunnyPlayer.ears.type = Ears.BUNNY;
+			bunnyPlayer.lowerBody.type = LowerBody.BUNNY;
+
+			assertThat(bunnyPlayer.bunnyScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testHarpyScore():void
+		{
+			var harpyPlayer:Player = new Player();
+			harpyPlayer.arms.type = Arms.HARPY;
+			harpyPlayer.hair.type = Hair.FEATHER;
+			harpyPlayer.wings.type = Wings.FEATHERED_LARGE;
+			harpyPlayer.tail.type = Tail.HARPY;
+			harpyPlayer.lowerBody.type = LowerBody.HARPY;
+
+			assertThat(harpyPlayer.harpyScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testKangaScore():void
+		{
+			var kangaPlayer:Player = new Player();
+			createCock(CockTypesEnum.KANGAROO, kangaPlayer);
+			kangaPlayer.ears.type = Ears.KANGAROO;
+			kangaPlayer.tail.type = Tail.KANGAROO;
+			kangaPlayer.face.type = Face.KANGAROO;
+			kangaPlayer.lowerBody.type = LowerBody.KANGAROO;
+			kangaPlayer.skin.type = Skin.FUR;
+
+			assertThat(kangaPlayer.kangaScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testSheepScore():void
+		{
+			var sheepPlayer:Player = new Player();
+			sheepPlayer.ears.type = Ears.SHEEP;
+			sheepPlayer.horns.type = Horns.SHEEP;
+			sheepPlayer.tail.type = Tail.SHEEP;
+			sheepPlayer.lowerBody.setProps({type: LowerBody.CLOVEN_HOOFED, legCount: 2});
+			sheepPlayer.hair.type = Hair.WOOL;
+			sheepPlayer.skin.type = Skin.WOOL;
+
+			assertThat(sheepPlayer.sheepScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testSharkScore():void
+		{
+			var sharkPlayer:Player = new Player();
+			sharkPlayer.face.type = Face.SHARK_TEETH;
+			sharkPlayer.gills.type = Gills.FISH;
+			sharkPlayer.rearBody.type = RearBody.SHARK_FIN;
+			sharkPlayer.tail.type = Tail.SHARK;
+
+			assertThat(sharkPlayer.sharkScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testMutantScore():void
+		{
+			mutantPlayer.face.type = Face.WOLF;
+			mutantPlayer.tail.type = Tail.DRACONIC;
+			mutantPlayer.skin.type = Skin.PLAIN;
+
+			assertThat(mutantPlayer.mutantScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testHorseMutantScore():void
+		{
+			mutantPlayer.face.type = Face.HORSE;
+			mutantPlayer.tail.type = Tail.HORSE;
+			mutantPlayer.skin.type = Skin.FUR;
+
+			assertThat(mutantPlayer.mutantScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testDogMutantScore():void
+		{
+			mutantPlayer.face.type = Face.DOG;
+			mutantPlayer.tail.type = Tail.DOG;
+			mutantPlayer.skin.type = Skin.FUR;
+
+			assertThat(mutantPlayer.mutantScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testSalamanderScore():void
+		{
+			var salamanderPlayer:Player = new Player();
+			createPerk(PerkLib.Lustzerker, salamanderPlayer);
+			createCock(CockTypesEnum.LIZARD, salamanderPlayer);
+			salamanderPlayer.arms.type = Arms.SALAMANDER;
+			salamanderPlayer.lowerBody.type = LowerBody.SALAMANDER;
+			salamanderPlayer.tail.type = Tail.SALAMANDER;
+
+			assertThat(salamanderPlayer.salamanderScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testSirenScore():void
+		{
+			var sirenPlayer:Player = new Player();
+			sirenPlayer.createVagina();
+			sirenPlayer.face.type = Face.SHARK_TEETH;
+			sirenPlayer.tail.type = Tail.SHARK;
+			sirenPlayer.wings.type = Wings.FEATHERED_LARGE;
+			sirenPlayer.arms.type = Arms.HARPY;
+
+			assertThat(sirenPlayer.sirenScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testPigScore():void
+		{
+			var pigPlayer:Player = new Player();
+			createCock(CockTypesEnum.PIG, pigPlayer);
+			pigPlayer.ears.type = Ears.PIG;
+			pigPlayer.tail.type = Tail.PIG;
+			pigPlayer.face.type = Face.PIG;
+			pigPlayer.lowerBody.type = LowerBody.CLOVEN_HOOFED;
+
+			assertThat(pigPlayer.pigScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testSatyrScore():void
+		{
+			var satyrPlayer:Player = new Player();
+			satyrPlayer.lowerBody.type = LowerBody.CLOVEN_HOOFED;
+			satyrPlayer.tail.type = Tail.GOAT;
+			satyrPlayer.ears.type = Ears.ELFIN;
+			satyrPlayer.face.type = Face.HUMAN;
+			satyrPlayer.createCock();
+			satyrPlayer.balls = 2;
+			satyrPlayer.ballSize = 3;
+
+			assertThat(satyrPlayer.satyrScore(), greaterThanOrEqualTo(4)); // There was an issue with the satyrScore producing a too low score
+		}
+
+		[Test]
+		public function testRhinoScore():void
+		{
+			var rhinoPlayer:Player = new Player();
+			createCock(CockTypesEnum.RHINO, rhinoPlayer);
+			rhinoPlayer.ears.type = Ears.RHINO;
+			rhinoPlayer.tail.type = Tail.RHINO;
+			rhinoPlayer.face.type = Face.RHINO;
+			rhinoPlayer.horns.type = Horns.RHINO;
+			rhinoPlayer.skin.tone = "gray";
+
+			assertThat(rhinoPlayer.rhinoScore(), greaterThan(0));
 		}
 	}
 }

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -2,16 +2,12 @@ package classes
 {
 	import classes.BodyParts.*;
 	import classes.CoC;
+	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.PerkLib;
 	import classes.Player;
-	import classes.Scenes.Areas.VolcanicCrag.BehemothScene;
 	import classes.helper.StageLocator;
-	import classes.internals.IRandomNumber;
-	import classes.internals.RandomNumber;
-	import classes.lists.BreastCup;
 	import classes.lists.ColorLists;
-	import classes.lists.Gender;
 	import org.flexunit.asserts.*;
 	import org.hamcrest.assertThat;
 	import org.hamcrest.collection.*;
@@ -797,6 +793,26 @@ package classes
 			manticorePlayer.skin.type = Skin.FUR;
 
 			assertThat(manticorePlayer.manticoreScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testBimboScore():void
+		{
+			var bimboPlayer:Player = new Player();
+			createPerk(PerkLib.BimboBrains, bimboPlayer);
+			createPerk(PerkLib.BimboBody, bimboPlayer);
+			bimboPlayer.createVagina(true, VaginaClass.WETNESS_SLICK);
+			bimboPlayer.createBreastRow(10);
+			bimboPlayer.setArmor(kGAMECLASS.armors.BIMBOSK);
+			kGAMECLASS.flags[kFLAGS.BIMBOSKIRT_MINIMUM_LUST] = 30;
+			bimboPlayer.femininity = 100;
+			bimboPlayer.hips.rating = 10;
+			bimboPlayer.butt.rating = 10;
+			bimboPlayer.tone = 10;
+			bimboPlayer.hair.setProps({color: "platinum blonde", length: 12});
+			bimboPlayer.inte = 10;
+
+			assertThat(bimboPlayer.bimboScore(), greaterThan(0));
 		}
 	}
 }

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -738,5 +738,65 @@ package classes
 
 			assertThat(rhinoPlayer.rhinoScore(), greaterThan(0));
 		}
+
+		[Test]
+		public function testEchidnaScore():void
+		{
+			var echidnaPlayer:Player = new Player();
+			createCock(CockTypesEnum.ECHIDNA, echidnaPlayer);
+			echidnaPlayer.ears.type = Ears.ECHIDNA;
+			echidnaPlayer.tail.type = Tail.ECHIDNA;
+			echidnaPlayer.face.type = Face.ECHIDNA;
+			echidnaPlayer.tongue.type = Tongue.ECHIDNA;
+			echidnaPlayer.lowerBody.type = LowerBody.ECHIDNA;
+			echidnaPlayer.skin.type = Skin.FUR;
+
+			assertThat(echidnaPlayer.echidnaScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testDeerScore():void
+		{
+			var deerPlayer:Player = new Player();
+			createCock(CockTypesEnum.HORSE, deerPlayer);
+			deerPlayer.ears.type = Ears.DEER;
+			deerPlayer.tail.type = Tail.DEER;
+			deerPlayer.face.type = Face.DEER;
+			deerPlayer.lowerBody.type = LowerBody.CLOVEN_HOOFED;
+			deerPlayer.horns.setProps({type: Horns.ANTLERS, value: 4});
+			deerPlayer.skin.type = Skin.FUR;
+
+			assertThat(deerPlayer.deerScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testDragonneScore():void
+		{
+			var dragonnePlayer:Player = new Player();
+			dragonnePlayer.face.type = Face.CAT;
+			dragonnePlayer.ears.type = Ears.CAT;
+			dragonnePlayer.tail.type = Tail.CAT;
+			dragonnePlayer.tongue.type = Tongue.DRACONIC;
+			dragonnePlayer.wings.type = Wings.DRACONIC_LARGE;
+			dragonnePlayer.lowerBody.type = LowerBody.CAT;
+			dragonnePlayer.skin.type = Skin.DRAGON_SCALES;
+
+			assertThat(dragonnePlayer.dragonneScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testManticoreScore():void
+		{
+			var manticorePlayer:Player = new Player();
+			manticorePlayer.face.type = Face.CAT;
+			manticorePlayer.ears.type = Ears.CAT;
+			manticorePlayer.tail.type = Tail.SCORPION;
+			manticorePlayer.lowerBody.type = LowerBody.CAT;
+			manticorePlayer.horns.type = Horns.DEMON;
+			manticorePlayer.wings.type = Wings.BAT_LIKE_LARGE;
+			manticorePlayer.skin.type = Skin.FUR;
+
+			assertThat(manticorePlayer.manticoreScore(), greaterThan(0));
+		}
 	}
 }

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -10,6 +10,7 @@ package classes
 	import classes.internals.IRandomNumber;
 	import classes.internals.RandomNumber;
 	import classes.lists.BreastCup;
+	import classes.lists.ColorLists;
 	import classes.lists.Gender;
 	import org.flexunit.asserts.*;
 	import org.hamcrest.assertThat;
@@ -484,6 +485,25 @@ package classes
 			horsePlayer.skin.type = Skin.FUR;
 
 			assertThat(horsePlayer.horseScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testKitsuneScore():void
+		{
+			// Avoiding randomness for hair and fur colors now. Maybe later?
+			var kitsunePlayer:Player = new Player();
+			kitsunePlayer.createVagina();
+			kitsunePlayer.createStatusEffect(StatusEffects.BonusVCapacity, 8000, 0, 0, 0);
+			kitsunePlayer.ears.type = Ears.FOX;
+			kitsunePlayer.tail.setProps({type: Tail.FOX, venom: 9});
+			kitsunePlayer.face.type = Face.FOX;
+			kitsunePlayer.hair.color = ColorLists.ELDER_KITSUNE[0];
+			kitsunePlayer.skin.type = Skin.FUR;
+			kitsunePlayer.setFurColor([ColorLists.ELDER_KITSUNE[0]], {type: UnderBody.FURRY}, true);
+			kitsunePlayer.femininity = 40;
+			kitsunePlayer.lowerBody.type = LowerBody.FOX;
+
+			assertThat(kitsunePlayer.kitsuneScore(), greaterThan(0));
 		}
 	}
 }

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -23,6 +23,8 @@ package classes
 		private const MAX_SUPPORTED_VAGINAS:Number = 2;
 
 		private var impPlayer:Player;
+		private var minoPlayer:Player;
+		private var cowPlayer:Player;
 
 		private function createVaginas(numberOfVaginas:Number, instance:Player):void
 		{
@@ -60,6 +62,14 @@ package classes
 			instance.breastRows[0].breastRating = BreastCup.FLAT;
 		}
 
+		private function removeAllVags(instance:Player):void
+		{
+			if (instance.vaginas.length === 0)
+				return;
+
+			instance.removeVagina(0, instance.vaginas.length);
+		}
+
 		[BeforeClass]
 		public static function setUpClass():void
 		{
@@ -86,6 +96,25 @@ package classes
 			impPlayer.horns.type = Horns.IMP;
 			impPlayer.arms.type = Arms.PREDATOR;
 			impPlayer.claws.type = Claws.IMP;
+
+			minoPlayer = new Player();
+			minoPlayer.face.type = Face.COW_MINOTAUR;
+			minoPlayer.ears.type = Ears.COW;
+			minoPlayer.tail.type = Tail.COW;
+			minoPlayer.horns.type = Horns.COW_MINOTAUR;
+			minoPlayer.lowerBody.type = LowerBody.HOOFED;
+			minoPlayer.tallness = 100;
+			minoPlayer.createCock(5.5, 1, CockTypesEnum.HORSE);
+
+			cowPlayer = new Player();
+			cowPlayer.ears.type = Ears.COW;
+			cowPlayer.tail.type = Tail.COW;
+			cowPlayer.horns.type = Horns.COW_MINOTAUR;
+			cowPlayer.lowerBody.type = LowerBody.HOOFED;
+			cowPlayer.tallness = 73;
+			cowPlayer.createVagina();
+			cowPlayer.createBreastRow(5);
+			cowPlayer.breastRows[0].lactationMultiplier = 3;
 		}
 
 		[Test]
@@ -179,6 +208,39 @@ package classes
 			removeAllBreasts(humanPlayer); // auto-creates a breast row, if none exists
 
 			assertThat(humanPlayer.humanScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testMinoScore():void
+		{
+			removeAllVags(minoPlayer);
+
+			assertThat(minoPlayer.minoScore(), greaterThan(0));
+		}
+
+
+		[Test]
+		public function testVagMinoScore():void
+		{
+			minoPlayer.createVagina();
+
+			assertThat(minoPlayer.minoScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testCowScore():void
+		{
+			cowPlayer.face.type = Face.HUMAN;
+
+			assertThat(cowPlayer.cowScore(), greaterThan(0));
+		}
+
+		[Test]
+		public function testCowFaceCowScore():void
+		{
+			cowPlayer.face.type = Face.COW_MINOTAUR;
+
+			assertThat(cowPlayer.cowScore(), greaterThan(0));
 		}
 
 		[Test]

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -54,7 +54,7 @@ package classes
 			}
 
 			removeExtraBreastRows(instance);
-			instance.breastRows[0].breastRating = BreastCup.FLAT;
+			instance.breastRows[0].restore();
 		}
 
 		private function removeAllVags(instance:Player):void
@@ -63,6 +63,11 @@ package classes
 				return;
 
 			instance.removeVagina(0, instance.vaginas.length);
+		}
+
+		private function createCock(ctype:CockTypesEnum, instance:Player):void
+		{
+			instance.createCock(5.5, 1, ctype);
 		}
 
 		private function createPerk(perk:PerkType, instance:Player):void
@@ -110,7 +115,7 @@ package classes
 			minoPlayer.horns.type = Horns.COW_MINOTAUR;
 			minoPlayer.lowerBody.type = LowerBody.HOOFED;
 			minoPlayer.tallness = 100;
-			minoPlayer.createCock(5.5, 1, CockTypesEnum.HORSE);
+			createCock(CockTypesEnum.HORSE, minoPlayer);
 
 			cowPlayer = new Player();
 			cowPlayer.ears.type = Ears.COW;
@@ -155,7 +160,7 @@ package classes
 			cockatricePlayer.wings.type = Wings.FEATHERED_LARGE;
 			cockatricePlayer.skin.type = Skin.LIZARD_SCALES;
 			cockatricePlayer.underBody.type = UnderBody.COCKATRICE;
-			cockatricePlayer.createCock(5.5, 1, CockTypesEnum.LIZARD);
+			createCock(CockTypesEnum.LIZARD, cockatricePlayer);
 
 			assertThat(cockatricePlayer.cockatriceScore(), greaterThan(0));
 		}
@@ -194,7 +199,7 @@ package classes
 			demonPlayer.cor = 100;
 			demonPlayer.face.type = Face.HUMAN;
 			demonPlayer.lowerBody.type = LowerBody.DEMONIC_CLAWS;
-			demonPlayer.createCock(5.5, 1, CockTypesEnum.DEMON);
+			createCock(CockTypesEnum.DEMON, demonPlayer);
 
 			assertThat(demonPlayer.demonScore(), greaterThan(0));
 		}
@@ -210,7 +215,7 @@ package classes
 			humanPlayer.wings.type = Wings.NONE;
 			humanPlayer.lowerBody.type = LowerBody.HUMAN;
 			humanPlayer.skin.type = Skin.PLAIN;
-			humanPlayer.createCock(5.5, 1, CockTypesEnum.HUMAN);
+			createCock(CockTypesEnum.HUMAN, humanPlayer);
 			removeAllBreasts(humanPlayer); // auto-creates a breast row, if none exists
 
 			assertThat(humanPlayer.humanScore(), greaterThan(0));
@@ -275,8 +280,8 @@ package classes
 			lizardPlayer.arms.type = Arms.PREDATOR;
 			lizardPlayer.claws.type = Claws.LIZARD;
 			lizardPlayer.tongue.type = Tongue.LIZARD;
-			lizardPlayer.createCock(5.5, 1, CockTypesEnum.LIZARD);
-			lizardPlayer.createCock(5.5, 1, CockTypesEnum.LIZARD);
+			createCock(CockTypesEnum.LIZARD, lizardPlayer);
+			createCock(CockTypesEnum.LIZARD, lizardPlayer);
 			lizardPlayer.eyes.type = Eyes.LIZARD;
 			lizardPlayer.skin.type = Skin.LIZARD_SCALES;
 


### PR DESCRIPTION
### Description
To avoid future errors caused by typos or other mistakes in the raceScore-functions I've added the PlayerTest-testsuite. In most cases I've maxed out the score and then checked against it. If that succeede I've changed the assertion to `greaterThan(0)` since the raceScore-functions are stc and the main purpose of that test suite is to see, if it runs without failing and not, if it returns a certain score.

### Unrelated changes
- `player.neck.nlMax` is now readonly instead of private, so that things, like
  `player.neck.len = player.neck.nlMax[Neck.DRACONIC];` are now possible.
  Although its recommended to use `player.neck.modify()`.
- Added the functions `restore()`, `setProps()` and `setAllProps()` to the `BreastRowClass`. Usage is the same, as in the BodyParts-classes

PS: Feel free to change, improve or enhance the PlayerTest-suite. the more testing, the merrier :-)