### PR TITLE
Bugfixes to succubimilk and incubidraft

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -292,7 +292,6 @@ package classes.Items
 			var rando:Number = rand(100);
 			if (player.hasPerk(PerkLib.HistoryAlchemist)) rando += 10;
 			if (player.hasPerk(PerkLib.TransformationResistance)) rando -= 10;
-			if (rando >= 90 && !tainted) rando -= 10;
 			clearOutput();
 			if (player.cor < 35) outputText("You wonder why in the gods' names you would drink such a thing, but you have to admit, it is the best thing you have ever tasted.");
 			if (player.cor >= 35 && player.cor < 70) {
@@ -446,7 +445,7 @@ package classes.Items
 				}
 			}
 			if (rando >= 90) {
-				if (player.skin.tone == "blue" || player.skin.tone == "purple" || player.skin.tone == "indigo" || player.skin.tone == "shiny black") {
+				if (!tainted || player.skin.tone == "blue" || player.skin.tone == "purple" || player.skin.tone == "indigo" || player.skin.tone == "shiny black") {
 					if (player.vaginas.length > 0) {
 						outputText("\n\nYour heart begins beating harder and harder as heat floods to your groin.  You feel your clit peeking out from under its hood, growing larger and longer as it takes in more and more blood.");
 						if (player.getClitLength() > 3 && !player.hasPerk(PerkLib.BigClit)) outputText("  After some time it shrinks, returning to its normal aroused size.  You guess it can't get any bigger.");

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -47,7 +47,6 @@ package classes.Items
 					else outputText("\n\nYour " + player.cockDescript(0) + " becomes shockingly hard.  It dribbles hot demon-like cum as it begins to grow.");
 					if (rand(4) === 0) temp = player.increaseCock(0, 3);
 					else temp = player.increaseCock(0, 1);
-					dynStats("int", 1, "lib", 2, "sen", 1, "lust", 5 + temp * 3, "cor", tainted ? 1 : 0);
 					if (temp < .5) outputText("  It stops almost as soon as it starts, growing only a tiny bit longer.");
 					if (temp >= .5 && temp < 1) outputText("  It grows slowly, stopping after roughly half an inch of growth.");
 					if (temp >= 1 && temp <= 2) outputText("  The sensation is incredible as more than an inch of lengthened dick-flesh grows in.");

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -168,6 +168,8 @@ package classes.Items
 					else {
 						growDemonCock(1);
 					}
+					if (tainted) dynStats("lib", 3, "sen", 5, "lus", 10, "cor", 3);
+					else dynStats("lib", 3, "sen", 5, "lus", 10);
 				}
 				if (!flags[kFLAGS.HYPER_HAPPY])
 				{

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -66,7 +66,7 @@ package classes.Items
 							temp2 = temp;
 						}
 					}
-					if (int(Math.random() * 4) === 0) temp3 = player.increaseCock(temp2, 3);
+					if (rand(4) === 0) temp3 = player.increaseCock(temp2, 3);
 					else temp3 = player.increaseCock(temp2, 1);
 					if (tainted) dynStats("int", 1, "lib", 2, "sen", 1, "lus", 5 + temp * 3, "cor", 1);
 					else dynStats("int", 1, "lib", 2, "sen", 1, "lus", 5 + temp * 3);
@@ -159,7 +159,7 @@ package classes.Items
 			//High level change
 			if (rando >= 93) {
 				if (player.cockTotal() < 10) {
-					if (int(Math.random() * 10) < int(player.cor / 25)) {
+					if (rand(10) < int(player.cor / 25)) {
 						outputText("\n\n");
 						growDemonCock(rand(2) + 2);
 						if (tainted) dynStats("lib", 3, "sen", 5, "lus", 10, "cor", 5);
@@ -287,7 +287,7 @@ package classes.Items
 			player.slimeFeed();
 			var temp2:Number = 0;
 			var temp3:Number = 0;
-			var rando:Number = Math.random() * 100;
+			var rando:Number = rand(100);
 			if (player.hasPerk(PerkLib.HistoryAlchemist)) rando += 10;
 			if (player.hasPerk(PerkLib.TransformationResistance)) rando -= 10;
 			if (rando >= 90 && !tainted) rando -= 10;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -451,9 +451,10 @@ package classes.Items
 						if (player.getClitLength() > 3 && !player.hasPerk(PerkLib.BigClit)) outputText("  After some time it shrinks, returning to its normal aroused size.  You guess it can't get any bigger.");
 						if (player.getClitLength() > 5 && player.hasPerk(PerkLib.BigClit)) outputText("  Eventually it shrinks back down to its normal (but still HUGE) size.  You guess it can't get any bigger.");
 						if (((player.hasPerk(PerkLib.BigClit)) && player.getClitLength() < 6)
-								|| player.getClitLength() < 3) {
-							temp += 2;
-							player.changeClitLength((rand(4) + 2) / 10);
+							|| player.getClitLength() < 3) {
+							temp = 2; // minimum growth
+							if (player.hasPerk(PerkLib.BigClit)) temp += 2;
+							player.changeClitLength((rand(4) + temp) / 10);
 						}
 						dynStats("sen", 3, "lus", 8);
 					}

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -440,7 +440,7 @@ package classes.Items
 					temp = player.vaginas.length;
 					while (temp > 0) {
 						temp--;
-						if (player.vaginas[0].vaginalWetness < VaginaClass.WETNESS_SLAVERING) player.vaginas[temp].vaginalWetness++;
+						if (player.vaginas[temp].vaginalWetness < VaginaClass.WETNESS_SLAVERING) player.vaginas[temp].vaginalWetness++;
 					}
 				}
 			}

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -276,7 +276,7 @@ package classes.Items
 					outputText("\n<b>(Lost Perk: Minotaur Cum Addict!)</b>");
 					player.removePerk(PerkLib.MinotaurCumAddict);
 				}
-				
+
 			}
 			player.refillHunger(25);
 		}
@@ -497,8 +497,8 @@ package classes.Items
 			}
 			player.refillHunger(20);
 		}
-		
-	
+
+
 		public function succubisDelight(tainted:Boolean,player:Player):void
 		{
 			player.slimeFeed();
@@ -605,7 +605,7 @@ package classes.Items
 				if (large) outputText(player.modThickness(100, 8));
 				else outputText(player.modThickness(95, 3));
 			}
-			
+
 		}
 
 //hip expansion
@@ -1440,7 +1440,7 @@ package classes.Items
 			outputText("\n\n");
 			player.refillHunger(5);
 		}
-		
+
 		public function neonPinkEgg(pregnantChange:Boolean,player:Player):void
 		{
 			var tfSource:String = "neonPinkEgg";
@@ -2462,15 +2462,15 @@ package classes.Items
 					} else {
 						outputText("them");
 					}
-					
+
 					outputText(" out, you look closely.  ");
-					
+
 					if (player.cockTotal() === 1) {
 						outputText("It's");
 					} else {
 						outputText("They're");
 					}
-					
+
 					outputText(" definitely thicker.");
 					var counter:Number;
 					changes++;
@@ -2500,7 +2500,7 @@ package classes.Items
 			if (rand(5) === 0) {
 				updateOvipositionPerk(tfSource);
 			}
-			
+
 			//***************
 			//Appearance Changes
 			//***************
@@ -2636,7 +2636,7 @@ package classes.Items
 
 		/**
 		 * Transformation for Fox Berry or (enhanced) Vixen's Vigor
-		 * 
+		 *
 		 * @param	enhanced if true, it's Vixen's Vigor
 		 * @param	player affected by the item
 		 */
@@ -3187,7 +3187,7 @@ package classes.Items
 			if (player.hasFur() && player.underBody.type == UnderBody.FURRY && player.skin.furColor !== player.underBody.skin.furColor)
 				theFurColor = player.skin.furColor + " and " + player.underBody.skin.furColor;
 
-			if ((player.hasFur() 
+			if ((player.hasFur()
 					&& player.face.type != Face.FOX
 					&& !InCollection(theFurColor, convertMixedToStringArray(ColorLists.BASIC_KITSUNE_FUR))
 					&& !InCollection(theFurColor, ColorLists.ELDER_KITSUNE)
@@ -3379,10 +3379,10 @@ package classes.Items
 				flags[kFLAGS.TIMES_TRANSFORMED]++;
 			}
 		}
-		
 
-		
 
-		
+
+
+
 	}
 }


### PR DESCRIPTION
This PR fixes 5-6 small bugs I found while studying succubiMilk and incubiDraft in order to write omnibiJuice. Lengthier details are in the individual commit messages; it may be easier to review this PR commit-per-commit rather than diffing files, at least in terms of understanding intent.

My editor cleans up trailing whitespace automatically; rather than turn this off I made a separate commit just for that. While viewing a diff in GitHub you can hide whitespace change by appending &w=1 to the url. (I learned this undocumented feature a few months ago and I'm telling everybody I know :stuck_out_tongue_winking_eye: )

A quick summary of the bug fixes are as follows:
* Remove extra call to dynStats in incubiDraft; the same stats were being applied before and after the outputText
* Change three `Math.random() * n` calls to `rand(n)` calls to be consistent with the 308 existing calls to `rand(n)`
* Add stats changes to high-level incubiDraft changes. It appears to have been omitted; hard to imagine sprouting for new cocks and NOT gaining lust and sensitivity etc
* Fix high-level changes of purified succubus milk. Existing code allowed Alchemists to reach the tier and get corrupted with demon skin, and prevented non-alchemists from receiving clit length gains
* Use unassigned variable when growing clit. My guess is the intent was to grant an additional 0.2" of clit length if you have the BigClick perk. This is how it works now.
* Fix vaginal wettening. Existing code tested vagina[0] before incrementing each vagina's wetness. I have fixed it so it check the vagina in question rather than rechecking the first one each time. Vaginal wetness and descriptions for second vagina appears to be problematic; I couldn't get it to appear in my description properly. I don't think it worked before I touched it but if I broke it feel free to back my change out. My suspicion is Appearance.as needs some tweaks to correctly display secondary vagina information, but I'm treating that as out-of-scope for this PR. This bugfix will support fixing that code later if we decide to.

All of these changes are based on my understanding and assumptions about how the code *should* work, which isn't always obvious from a given code defect. Feedback is very welcome and I'm happy to make changes if I've buggered something up.