### PR TITLE
Tidying output functions

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -219,19 +219,19 @@
 
 		protected function displayHeader(text:String):void
 		{
-			kGAMECLASS.displayHeader(text);
+			kGAMECLASS.output.header(text);
 		}
 		
 		// Needed in a few rare cases for dumping text coming from a source that can't properly escape it's brackets
 		// (Mostly traceback printing, etc...)
-		protected function rawOutputText(output:String, purgeText:Boolean = false):void
+		protected function rawOutputText(text:String):void
 		{
-			kGAMECLASS.rawOutputText(output, purgeText);
+			kGAMECLASS.output.raw(text);
 		}
 
 		protected function outputText(output:String):void
 		{
-			kGAMECLASS.outputText(output);
+			kGAMECLASS.output.text(output);
 		}
 		
 		protected function clearOutput():void

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -345,7 +345,32 @@ package classes
 		
 		public var kFLAGS_REF:*;
 		public var kACHIEVEMENTS_REF:*;
-		
+
+		public function clearOutput():void
+		{
+			output.clear(true);
+		}
+
+		public function rawOutputText(text:String):void
+		{
+			output.raw(text);
+		}
+
+		public function outputText(text:String):void
+		{
+			output.text(text);
+		}
+
+		public function displayHeader(string:String):void
+		{
+			output.text(output.formatHeader(string));
+		}
+
+		public function formatHeader(string:String):String
+		{
+			return output.formatHeader(string);
+		}
+
 		public function get inCombat():Boolean
 		{
 			return _gameState == 1;

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -47,7 +47,7 @@ package classes
 		 * @param   text    The text to be added
 		 * @return  The instance of the class to support the 'Fluent interface' aka method-chaining
 		 */
-		protected function _addText(text:String):Output
+		public function text(text:String):Output
 		{
 			// This is cleaup in case someone hits the Data or new-game button when the event-test window is shown. 
 			// It's needed since those buttons are available even when in the event-tester
@@ -59,19 +59,6 @@ package classes
 			//if (debug) mainView.setOutputText(_currentText);
 
 			return this;
-		}
-
-		/**
-		 * Add text to the output-buffer
-		 *
-		 * Actually this is a wrapper around _addText(text)
-		 *
-		 * @param   text    The text to be added
-		 * @return  The instance of the class to support the 'Fluent interface' aka method-chaining
-		 */
-		public function text(text:String):Output
-		{
-			return _addText(text);
 		}
 
 		/**

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -84,7 +84,18 @@ package classes
 		 */
 		public function header(headLine:String):Output
 		{
-			return text("<font size=\"36\" face=\"Georgia\"><u>" + headLine + "</u></font>\n");
+			return text(formatHeader(headLine));
+		}
+
+		/**
+		 * Returns the formatted headline
+		 *
+		 * @param	headLine    The headline to be formatted
+		 * @return  The formatted headline
+		 */
+		public function formatHeader(headLine:String):String
+		{
+			return "<font size=\"36\" face=\"Georgia\"><u>" + headLine + "</u></font>\n";
 		}
 
 		/**

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -92,39 +92,6 @@ public function clone(source:Object):* {
 	return(copier.readObject());
 }
 
-/**
- * Clear the text on screen.
- */
-public function clearOutput():void {
-	output.clear(true);
-}
-
-/**
- * Basically the same as outputText() but without the parser tags. Great for displaying square brackets on text.
- * @param	output The text to show. It can be formatted such as bold, italics, and underline tags.
- */
-public function rawOutputText(text:String):void
-{
-	output.raw(text);
-}
-
-/**
- * Output the text on main text interface.
- * @param	output The text to show. It can be formatted such as bold, italics, and underline tags.
- * @param	purgeText Clear the old text.
- */
-public function outputText(text:String):void
-{
-	output.text(text);
-}
-
-public function displayHeader(string:String):void {
-	outputText(formatHeader(string));
-}
-public function formatHeader(string:String):String {
-	return "<font size=\"36\" face=\"Georgia\"><u>" + string + "</u></font>\n";
-}
-
 public function buttonIsVisible(index:int):Boolean {
 	if ( index < 0 || index > MAX_BUTTON_INDEX ) {
 		return undefined;

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -96,43 +96,16 @@ public function clone(source:Object):* {
  * Clear the text on screen.
  */
 public function clearOutput():void {
-	forceUpdate();
-	output.clear();
-	mainView.clearOutputText();
-	if (_gameState != 3) mainView.hideMenuButton( MainView.MENU_DATA );
-	mainView.hideMenuButton( MainView.MENU_APPEARANCE );
-	mainView.hideMenuButton( MainView.MENU_LEVEL );
-	mainView.hideMenuButton( MainView.MENU_PERKS );
-	mainView.hideMenuButton( MainView.MENU_STATS );
+	output.clear(true);
 }
 
 /**
  * Basically the same as outputText() but without the parser tags. Great for displaying square brackets on text.
  * @param	output The text to show. It can be formatted such as bold, italics, and underline tags.
- * @param	purgeText Clear the old text.
  */
-public function rawOutputText(output:String, purgeText:Boolean = false):void
+public function rawOutputText(text:String):void
 {
-	
-	//OUTPUT!
-	if (purgeText) {
-		//if (!debug) mainText.htmlText = output;
-		//trace("Purging and writing Text", output);
-		clearOutput();
-		this.output.raw(output);
-		//mainView.setOutputText( output );
-		// mainText.htmlText = output;
-	}
-	else
-	{
-		//trace("Adding Text");
-		this.output.raw(output);
-		//mainView.appendOutputText( output );
-		// mainText.htmlText += output;
-	}
-	// trace(getCurrentStackTrace())
-	// scrollBar.update();
-
+	output.raw(text);
 }
 
 /**
@@ -140,23 +113,9 @@ public function rawOutputText(output:String, purgeText:Boolean = false):void
  * @param	output The text to show. It can be formatted such as bold, italics, and underline tags.
  * @param	purgeText Clear the old text.
  */
-public function outputText(output:String):void
+public function outputText(text:String):void
 {
-	// we have to purge the output text BEFORE calling parseText, because if there are scene commands in 
-	// the parsed text, parseText() will write directly to the output
-
-
-	// This is cleaup in case someone hits the Data or new-game button when the event-test window is shown. 
-	// It's needed since those buttons are available even when in the event-tester
-	mainView.hideTestInputPanel();
-
-	this.output.text(output);
-		//if (!debug) mainText.htmlText = currentText;
-	/*if (debug)
-	{
-		mainView.setOutputText( currentText );
-	}*/
-
+	output.text(text);
 }
 
 public function displayHeader(string:String):void {

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -100,7 +100,8 @@ public function getCurrentStackTrace():String		// Fuck, stack-traces only work i
 
 public function errorPrint(details:* = null):void
 {
-	rawOutputText("<b>Congratulations, you've found a bug!</b>", true);
+	clearOutput();
+	rawOutputText("<b>Congratulations, you've found a bug!</b>");
 	rawOutputText("\nError: Unknown event!");
 	rawOutputText("\n\nPlease report that you had an issue with code: \"" + details + "\" ");
 	rawOutputText("\nGame version: \"" + ver + "\" (<b>THIS IS IMPORTANT! Please be sure you include it!</b>) ");


### PR DESCRIPTION
Basically I've just tidied up the output functions in `engineCore.as` and moved them the CoC.as
In addition to that I've renamed `Output._addText()` to `Output.text()`, made it public and remove the old wrapper, because its not needed at all anymore.

Probably the ASDoc-comments in `Output.as` could be tidied later too, because ... well, who needs a history lessen of old code mechanics?

PS: This is mainly, if not exclusively to get `engineCore.as` smaller and smaller till we finally can ditch that include, too.