### PR TITLE
Fix phouka scene

### DIFF
--- a/classes/classes/Scenes/Areas/Bog/PhoukaScene.as
+++ b/classes/classes/Scenes/Areas/Bog/PhoukaScene.as
@@ -818,7 +818,6 @@ package classes.Scenes.Areas.Bog
 		
 		protected function phoukaSexPregnate(postCombat:Boolean):void
 		{ //Whether by horse, bunny or (male) faerie sex it all ends up here if the PC has a vagina
-			clearOutput();
 			if (player.isPregnant()) {
 				if (phoukaForm == PHOUKA_FORM_HORSE)
 					outputText("\n\nYou just feel constant pressure against your sealed cervix.  The " + phoukaName() + "’s balls shows no signs of slowing down and the pressure continues to build.  Finally your vagina expands enough to allow an ocean of cum to jet out of you.");

--- a/test/classes/Scenes/Areas/Bog/PhoukaSceneTest.as
+++ b/test/classes/Scenes/Areas/Bog/PhoukaSceneTest.as
@@ -1,0 +1,64 @@
+package classes.Scenes.Areas.Bog
+{
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import classes.CoC;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.helper.StageLocator;
+	
+	public class PhoukaSceneTest
+	{
+		private static const SCENE_TEXT:String = "You scream as the ";
+		
+		private var cut:SceneForTest;
+		private var player:Player;
+		
+		[BeforeClass]
+		public static function setUpClass():void
+		{
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+		
+		[Before]
+		public function setUp():void
+		{
+			player = new Player();
+			player.createVagina();
+			kGAMECLASS.player = player;
+			
+			cut = new SceneForTest();
+		}
+		
+		[Test(description="Exposes bug #1116, sex scene skipped")]
+		public function doNotClearSexScene():void {
+			cut.horseScene();
+			
+			assertThat(cut.collectedOutput, hasItem(startsWith(SCENE_TEXT)));
+		}
+	}
+}
+
+import classes.Scenes.Areas.Bog.PhoukaScene;
+
+class SceneForTest extends PhoukaScene {
+	public var collectedOutput:Vector.<String> = new Vector.<String>(); 
+	
+	public function horseScene():void {
+		this.phoukaSexHorseChoice();
+	}
+	
+	override protected function outputText(output:String):void {
+		collectedOutput.push(output);
+	}
+	
+	override protected function clearOutput():void {
+		collectedOutput = new Vector.<String>();
+	}
+}

--- a/test/classes/Scenes/Areas/BogSuit.as
+++ b/test/classes/Scenes/Areas/BogSuit.as
@@ -1,0 +1,11 @@
+package classes.Scenes.Areas
+{
+	import classes.Scenes.Areas.Bog.PhoukaSceneTest;
+	
+	[Suite]
+	[RunWith("org.flexunit.runners.Suite")]
+	public class BogSuit
+	{
+		public var phoukaSceneTest:PhoukaSceneTest
+	}
+}

--- a/test/classes/Scenes/AreasSuit.as
+++ b/test/classes/Scenes/AreasSuit.as
@@ -1,5 +1,6 @@
 package classes.Scenes 
 {
+	import classes.Scenes.Areas.BogSuit;
 	import classes.Scenes.Areas.ForestSuit;
 	import classes.Scenes.Areas.MountainSuit;
 	
@@ -9,5 +10,6 @@ package classes.Scenes
 	{
 		public var mountainSuit:MountainSuit;
 		public var forestSuit:ForestSuit;
+		public var bogSuit:BogSuit;
 	}
 }


### PR DESCRIPTION
Fixes #1116. The scene is not shown due to a bug introduced in f9b0a3ceaa3205a5ce2de78272e4f179b9cd3ee3, which clears the scene text before it can be shown.