### PR TITLE
Do not use initializeObject method

### DIFF
--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -161,21 +161,6 @@ package classes.internals
 		}
 		
 		/**
-		 * Check that the passed object is defined.
-		 * Will initalize with a empty array if undefined or null.
-		 * If the object is defined, then it will be returned.
-		 * @param	object to check and initialize
-		 * @return a valid object. Needed because of how ActionScript handles references
-		 */
-		public static function initializeObject(object:*):* {
-			if (object === undefined || object === null) {
-				object = [];
-			}
-			
-			return object;
-		}
-		
-		/**
 		 * Deserialize a class. This method is intended to automate deserialization, in order to avoid
 		 * a lot of code duplication.
 		 * @param	relativeRootObject the object that contains the serialized classes data

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -183,7 +183,9 @@ package classes.internals
 		 */
 		public static function deserialize(relativeRootObject:*, serialized:ISerializable):void {
 			LOGGER.debug("Deserializing  {0}...", serialized);
-			relativeRootObject = SerializationUtils.initializeObject(relativeRootObject);
+
+			objectDefinedCheck(relativeRootObject, "Object passed for deserialization must be defined. Does the loaded property exist?")
+			objectDefinedCheck(relativeRootObject, "Instance of class to load is not defined. Did you call the class constructor?");
 			
 			SerializationUtils.serializedVersionCheckThrowError(relativeRootObject, serialized.currentSerializationVerison());
 			var serializedObjectVersion:int = SerializationUtils.serializationVersion(relativeRootObject);
@@ -204,8 +206,6 @@ package classes.internals
 			objectDefinedCheck(toSerialize, "Instance of class to store is not defined. Did you call the class constructor?");
 			
 			LOGGER.debug("Serializing {0}...", toSerialize);
-			
-			relativeRootObject = SerializationUtils.initializeObject(relativeRootObject);
 			relativeRootObject[SERIALIZATION_VERSION_PROPERTY] = toSerialize.currentSerializationVerison();
 			
 			toSerialize.serialize(relativeRootObject);

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -213,31 +213,6 @@ package classes.internals
 			assertThat(SerializationUtils.serializedVersionCheck(serializedObject, 3), equalTo(true));
 		}
 		
-		[Test]
-		public function checkAndInitializeObjectNull():void {
-			serializedObject = null;
-			
-			serializedObject = SerializationUtils.initializeObject(serializedObject);
-			
-			assertThat(serializedObject, notNullValue());
-		}
-		
-		[Test]
-		public function checkAndInitializeObjectUndefined():void {
-			serializedObject = undefined;
-			
-			serializedObject = SerializationUtils.initializeObject(serializedObject);
-			
-			assertThat(serializedObject, notNullValue());
-		}
-		
-		[Test]
-		public function checkAndInitializeObjectDefined():void {
-			serializedObject = SerializationUtils.initializeObject(serializedObject);
-			
-			assertThat(serializedObject, hasProperties({serializationVersion: SERIAL_VERSION}));
-		}
-
 		[Test(expected="RangeError")]
 		public function serializedVersionCheckThrowErrorGreater():void {
 			SerializationUtils.serializedVersionCheckThrowError(serializedObject, 1);

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -263,7 +263,7 @@ package classes.internals
 			assertThat(serializedObject, hasProperties({foo: 42}));
 		}
 		
-		[Test]
+		[Test(expected="ArgumentError")]
 		public function deserializeUndefined():void {
 			serializedObject = undefined;
 			


### PR DESCRIPTION
Removed the `SerializationUtils.initializeObject` method.
Replaced with null / undefined using `objectDefinedCheck` checks instead. This was done because `initializeObject` silently hides errors.