### PR TITLE
Move claws instance into arms

### DIFF
--- a/classes/classes/Appearance.as
+++ b/classes/classes/Appearance.as
@@ -1888,7 +1888,7 @@ package classes {
 					if (text !== "")
 						comma = ", ";
 
-					switch (i_creature.claws.type) {
+					switch (i_creature.arms.claws.type) {
 						case Claws.NORMAL:
 							break;
 

--- a/classes/classes/BodyParts/Arms.as
+++ b/classes/classes/BodyParts/Arms.as
@@ -78,6 +78,10 @@ package classes.BodyParts
 						default:            clawTone = "gray";        break;
 					}
 					break;
+				case Claws.IMP:
+					if (_creature !== null)
+						clawTone = _creature.skin.tone;
+					break;
 				default:
 					clawTone = "";
 			}

--- a/classes/classes/BodyParts/Arms.as
+++ b/classes/classes/BodyParts/Arms.as
@@ -1,5 +1,7 @@
 package classes.BodyParts 
 {
+	import classes.Creature;
+	import classes.GlobalFlags.kGAMECLASS;
 	/**
 	 * Container class for the players arms
 	 * @since November 07, 2017
@@ -18,16 +20,84 @@ package classes.BodyParts
 		public static const RED_PANDA:int  =   8;
 		public static const FERRET:int     =   9;
 
+		private var _creature:Creature;
 		public var type:Number = HUMAN;
+		public var claws:Claws = new Claws();
+
+		public function Arms(i_creature:Creature = null)
+		{
+			_creature = i_creature;
+		}
+
+		public function setType(armType:Number, clawType:Number = Claws.NORMAL):void
+		{
+			type = armType;
+
+			switch (armType) {
+				case PREDATOR:   updateClaws(clawType);         break;
+				case SALAMANDER: updateClaws(Claws.SALAMANDER); break;
+				case COCKATRICE: updateClaws(Claws.COCKATRICE); break;
+				case RED_PANDA:  updateClaws(Claws.RED_PANDA);  break;
+				case FERRET:     updateClaws(Claws.FERRET);     break;
+
+				case HUMAN:
+				case HARPY:
+				case SPIDER:
+				case BEE:
+				case WOLF:
+				default:         updateClaws(clawType);
+			}
+		}
+
+		public function updateClaws(clawType:int = Claws.NORMAL):String
+		{
+			var clawTone:String = "";
+			var oldClawTone:String = claws.tone;
+
+			switch (clawType) {
+				case Claws.DRAGON:     clawTone = "steel-gray"; break;
+				case Claws.SALAMANDER: clawTone = "fiery-red";  break;
+				case Claws.LIZARD:
+					if (_creature === null)
+						break;
+					// See http://www.bergenbattingcenter.com/lizard-skins-bat-grip/ for all those NYI! lizard skin colors
+					// I'm still not that happy with these claw tones. Any suggestion would be nice.
+					switch (_creature.skin.tone) {
+						case "red":         clawTone = "reddish";     break;
+						case "green":       clawTone = "greenish";    break;
+						case "white":       clawTone = "light-gray";  break;
+						case "blue":        clawTone = "bluish";      break;
+						case "black":       clawTone = "dark-gray";   break;
+						case "purple":      clawTone = "purplish";    break;
+						case "silver":      clawTone = "silvery";     break;
+						case "pink":        clawTone = "pink";        break;
+						case "orange":      clawTone = "orangey";     break;
+						case "yellow":      clawTone = "yellowish";   break;
+						case "desert-camo": clawTone = "pale-yellow"; break; // NYI!
+						case "gray-camo":   clawTone = "gray";        break; // NYI!
+						default:            clawTone = "gray";        break;
+					}
+					break;
+				default:
+					clawTone = "";
+			}
+
+			claws.type = clawType;
+			claws.tone = clawTone;
+
+			return oldClawTone;
+		}
 
 		public function restore():void
 		{
 			type = HUMAN;
+			claws.restore();
 		}
 
 		public function setProps(p:Object):void
 		{
 			if (p.hasOwnProperty('type')) type = p.type;
+			if (p.hasOwnProperty('claws')) claws.setProps(p.claws);
 		}
 
 		public function setAllProps(p:Object):void

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -187,7 +187,7 @@
 			if (player.eyes.type === Eyes.BASILISK) player.eyes.type = Eyes.LIZARD; //Silently change them to be lizard eyes again. Simple and stupid ;)
 			//Default
 			player.skin.tone = "light";
-			player.claws.tone = "";
+			player.arms.claws.tone = "";
 			player.hair.color = "brown";
 			player.hair.type = Hair.NORMAL;
 			player.beard.length = 0;
@@ -669,7 +669,7 @@
 		}
 		private function setComplexion(choice:String):void {
 			player.skin.tone = choice;
-			player.claws.tone = "";
+			player.arms.claws.tone = "";
 			clearOutput();
 			outputText(images.showImage("event-question"));
 			outputText("You selected a " + choice + " complexion.\n\nWhat color is your hair?");

--- a/classes/classes/CharSpecial.as
+++ b/classes/classes/CharSpecial.as
@@ -1623,8 +1623,8 @@ package classes
 			
 			player.face.type = Face.FOX;
 			player.ears.type = Ears.FOX;
-			player.claws.type = Claws.DOG;
-			player.claws.tone = "ivory";
+			player.arms.claws.type = Claws.DOG;
+			player.arms.claws.tone = "ivory";
 			player.eyes.type = Eyes.DRAGON;
 			player.lowerBody.type = LowerBody.FOX;
 			player.tail.type = Tail.FOX; // soft fur feels so lovely...

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -375,10 +375,9 @@ package classes
 		public function set tallness(value:Number):void { _tallness = value; }
 
 		public var antennae:Antennae = new Antennae();
-		public var arms:Arms = new Arms();
+		public var arms:Arms; // Set in the constructor ...
 		public var beard:Beard = new Beard();
 		public var butt:Butt = new Butt();
-		public var claws:Claws = new Claws();
 		public var ears:Ears = new Ears();
 		public var eyes:Eyes = new Eyes();
 		public var face:Face = new Face();
@@ -607,6 +606,7 @@ package classes
 			breastRows = new Vector.<BreastRowClass>();
 			_perks = [];
 			statusEffects = [];
+			arms = new Arms(this);
 			//keyItems = new Array();
 		}
 
@@ -2887,9 +2887,9 @@ package classes
 		// <mod name="Predator arms" author="Stadler76">
 		public function clawsDescript():String
 		{
-			var toneText:String = claws.tone == "" ? " " : (", " + claws.tone + " ");
+			var toneText:String = arms.claws.tone == "" ? " " : (", " + arms.claws.tone + " ");
 
-			switch (claws.type) {
+			switch (arms.claws.type) {
 				case Claws.NORMAL: return "fingernails";
 				case Claws.LIZARD: return "short curved" + toneText + "claws";
 				case Claws.DRAGON: return "powerful, thick curved" + toneText + "claws";

--- a/classes/classes/DebugMenu.as
+++ b/classes/classes/DebugMenu.as
@@ -1297,13 +1297,13 @@ package classes
 			showChangeOptions(bodyPartEditorTorso, page, ARM_TYPE_CONSTANTS, changeArmType);
 		}
 		private function changeClawType(page:int=0,setIdx:int=-1):void {
-			if (setIdx>=0) player.claws.type = setIdx;
+			if (setIdx>=0) player.arms.claws.type = setIdx;
 			menu();
 			dumpPlayerData();
 			showChangeOptions(bodyPartEditorTorso, page, CLAW_TYPE_CONSTANTS, changeClawType);
 		}
 		private function changeClawTone(page:int=0,setIdx:int=-1):void {
-			if (setIdx>=0) player.claws.tone = SKIN_TONE_CONSTANTS[setIdx];
+			if (setIdx>=0) player.arms.claws.tone = SKIN_TONE_CONSTANTS[setIdx];
 			menu();
 			dumpPlayerData();
 			showChangeOptions(bodyPartEditorTorso, page, SKIN_TONE_CONSTANTS, changeClawTone);

--- a/classes/classes/Items/Consumables/BeeHoney.as
+++ b/classes/classes/Items/Consumables/BeeHoney.as
@@ -175,8 +175,7 @@ package classes.Items.Consumables
 					          +" pain fades and you are able to turn your gaze down to your beautiful new arms, covered in shining black chitin from"
 					          +" the upper arm down, and downy yellow fuzz along your upper arm.");
 				}
-				player.arms.type = Arms.BEE;
-				mutations.updateClaws();
+				player.arms.setType(Arms.BEE);
 				changes++;
 			}
 			//-Nipples reduction to 1 per tit.

--- a/classes/classes/Items/Consumables/Ectoplasm.as
+++ b/classes/classes/Items/Consumables/Ectoplasm.as
@@ -93,7 +93,7 @@ package classes.Items.Consumables
 					player.skin.type = Skin.PLAIN;
 				}
 				player.underBody.restore();
-				mutations.updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 				changes++;
 			}
 			//Legs

--- a/classes/classes/Items/Consumables/EmberTFs.as
+++ b/classes/classes/Items/Consumables/EmberTFs.as
@@ -291,14 +291,13 @@ package classes.Items.Consumables
 			if (player.arms.type != Arms.PREDATOR && player.hasDragonScales() && player.lowerBody.type == LowerBody.DRAGON && changes < changeLimit && rand(3) == 0) {
 				output.text("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with shield-shaped " + player.skin.tone + " scales and powerful, thick, curved steel-gray claws replacing your fingernails.");
 				output.text("\n<b>You now have dragon arms.</b>");
-				player.arms.type = Arms.PREDATOR;
-				mutations.updateClaws(Claws.DRAGON);
+				player.arms.setType(Arms.PREDATOR, Claws.DRAGON);
 				changes++
 			}
 			//Claw transition
-			if (player.arms.type == Arms.PREDATOR && player.hasDragonScales() && player.claws.type != Claws.DRAGON && changes < changeLimit && rand(3) == 0) {
+			if (player.arms.type == Arms.PREDATOR && player.hasDragonScales() && player.arms.claws.type != Claws.DRAGON && changes < changeLimit && rand(3) == 0) {
 				output.text("\n\nYour [claws] change  a little to become more dragon-like.");
-				mutations.updateClaws(Claws.DRAGON);
+				player.arms.updateClaws(Claws.DRAGON);
 				output.text(" <b>You now have [claws].</b>");
 				changes++
 			}

--- a/classes/classes/Items/Consumables/FerretFruit.as
+++ b/classes/classes/Items/Consumables/FerretFruit.as
@@ -604,8 +604,7 @@ package classes.Items.Consumables
 				          +" fluffy [if (hasFurryUnderBody)[underBody.furColor]|black-brown] fur. Your hands gain pink, padded paws where your palms"
 				          +" were once, and your nails become short claws, not sharp enough to tear flesh, but nimble enough to make climbing and"
 				          +" exploring much easier. <b>Your arms have become like those of  a ferret!</b>");
-				player.arms.type = Arms.FERRET;
-				mutations.updateClaws(Claws.FERRET);
+				player.arms.setType(Arms.FERRET);
 				changes++;
 			}
 			//If ears are not ferret:

--- a/classes/classes/Items/Consumables/GoblinAle.as
+++ b/classes/classes/Items/Consumables/GoblinAle.as
@@ -171,7 +171,7 @@ package classes.Items.Consumables
 					if (rand(2) === 0) player.skin.tone = "pale yellow";
 					else player.skin.tone = "grayish-blue";
 				}
-				mutations.updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 				changes++;
 				outputText("\n\nWhoah, that was weird.  You just hallucinated that your ");
 				if (player.hasFur()) outputText("skin");

--- a/classes/classes/Items/Consumables/ImpFood.as
+++ b/classes/classes/Items/Consumables/ImpFood.as
@@ -7,6 +7,7 @@ package classes.Items.Consumables
 	import classes.Items.Consumable;
 	import classes.Items.ConsumableLib;
 	import classes.PerkLib;
+	import classes.lists.ColorLists;
 	
 	/**
 	 * Imp transformative item
@@ -43,11 +44,10 @@ package classes.Items.Consumables
 				game.HPChange(30 + player.tou / 3, true);
 				dynStats("lus", 3, "cor", 1);
 				//Red or orange skin!
-				if (rand(30) === 0 && ["red", "orange"].indexOf(player.skin.tone) === -1) {
+				if (rand(30) === 0 && ColorLists.IMP_SKIN.indexOf(player.skin.tone) === -1) {
 					if (player.hasFur()) outputText("\n\nUnderneath your fur, your skin ");
 					else outputText("\n\nYour " + player.skin.desc + " ");
-					if (rand(2) === 0) player.skin.tone = "red";
-					else player.skin.tone = "orange";
+					player.skin.tone = randomChoice(ColorLists.IMP_SKIN);
 					outputText("begins to lose its color, fading until you're as white as an albino.  Then, starting at the crown of your head, a reddish hue rolls down your body in a wave, turning you completely " + player.skin.tone + ".");
 					player.arms.updateClaws(player.arms.claws.type);
 					kGAMECLASS.rathazul.addMixologyXP(20);
@@ -60,14 +60,14 @@ package classes.Items.Consumables
 				dynStats("lus", 3, "cor", 1);
 			}
 			//Red or orange skin!
-			if (rand(5) === 0 && ["red", "orange"].indexOf(player.skin.tone) === -1 && changes < changeLimit) {
+			if (rand(5) === 0 && ColorLists.IMP_SKIN.indexOf(player.skin.tone) === -1 && changes < changeLimit) {
 				if (player.hasFur()) outputText("\n\nUnderneath your fur, your skin ");
 				else outputText("\n\nYour " + player.skin.desc + " ");
-				if (rand(2) === 0) player.skin.tone = "red";
-				else player.skin.tone = "orange";
+				player.skin.tone = randomChoice(ColorLists.IMP_SKIN);
 				outputText("begins to lose its color, fading until you're as white as an albino.  Then, starting at the crown of your head, a reddish hue rolls down your body in a wave, turning you completely " + player.skin.tone + ".");
 				dynStats("cor", 2);
 				player.skin.type = Skin.PLAIN;
+				player.arms.updateClaws(player.arms.claws.type);
 				kGAMECLASS.rathazul.addMixologyXP(20);
 				changes++;
 			}

--- a/classes/classes/Items/Consumables/ImpFood.as
+++ b/classes/classes/Items/Consumables/ImpFood.as
@@ -49,7 +49,7 @@ package classes.Items.Consumables
 					if (rand(2) === 0) player.skin.tone = "red";
 					else player.skin.tone = "orange";
 					outputText("begins to lose its color, fading until you're as white as an albino.  Then, starting at the crown of your head, a reddish hue rolls down your body in a wave, turning you completely " + player.skin.tone + ".");
-					mutations.updateClaws(player.claws.type);
+					player.arms.updateClaws(player.arms.claws.type);
 					kGAMECLASS.rathazul.addMixologyXP(20);
 				}
 			}
@@ -166,18 +166,18 @@ package classes.Items.Consumables
 			}
 			
 			//Imp claws, needs orange/red skin. Also your hands turn human.
-			if (["red", "orange"].indexOf(player.skin.tone) !== -1 && player.claws.type !== Claws.IMP && rand(3) === 0 && changes < changeLimit) {
+			if (["red", "orange"].indexOf(player.skin.tone) !== -1 && player.arms.claws.type !== Claws.IMP && rand(3) === 0 && changes < changeLimit) {
 				if (player.arms.type !== Arms.HUMAN) {
 					outputText("\n\nYour arms twist and mangle, warping back into human-like arms. But that, you realize, is just the beginning.");
 				}
-				if (player.claws.type === Claws.NORMAL) {
+				if (player.arms.claws.type === Claws.NORMAL) {
 					outputText("\n\nYour hands suddenly ache in pain, and all you can do is curl them up to you. Against your body, you feel them form into three long claws, with a smaller one replacing your thumb but just as versatile. <b>You have imp claws!</b>");
 				} else { //has claws
 					outputText("\n\nYour claws suddenly begin to shift and change, starting to turn back into normal hands. But just before they do, they stretch out into three long claws, with a smaller one coming to form a pointed thumb. <b>You have imp claws!</b>");
 				}
 				player.arms.type = Arms.PREDATOR;
-				player.claws.type = Claws.IMP;
-				player.claws.tone = player.skin.tone;
+				player.arms.claws.type = Claws.IMP;
+				player.arms.claws.tone = player.skin.tone;
 				dynStats("cor", 2);
 				changes++;
 			}

--- a/classes/classes/Items/Consumables/ImpFood.as
+++ b/classes/classes/Items/Consumables/ImpFood.as
@@ -175,9 +175,7 @@ package classes.Items.Consumables
 				} else { //has claws
 					outputText("\n\nYour claws suddenly begin to shift and change, starting to turn back into normal hands. But just before they do, they stretch out into three long claws, with a smaller one coming to form a pointed thumb. <b>You have imp claws!</b>");
 				}
-				player.arms.type = Arms.PREDATOR;
-				player.arms.claws.type = Claws.IMP;
-				player.arms.claws.tone = player.skin.tone;
+				player.arms.setType(Arms.PREDATOR, Claws.IMP);
 				dynStats("cor", 2);
 				changes++;
 			}

--- a/classes/classes/Items/Consumables/PigTruffle.as
+++ b/classes/classes/Items/Consumables/PigTruffle.as
@@ -153,7 +153,7 @@ package classes.Items.Consumables
 				}
 				outputText("\n\nYour skin tingles ever so slightly as you skin’s color changes before your eyes. As the tingling diminishes, you find that your skin has turned " + skinToBeChosen + ".");
 				player.skin.tone = skinToBeChosen;
-				mutations.updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 				getGame().rathazul.addMixologyXP(20);
 				changes++;
 			}

--- a/classes/classes/Items/Consumables/RedRiverRoot.as
+++ b/classes/classes/Items/Consumables/RedRiverRoot.as
@@ -386,8 +386,7 @@ package classes.Items.Consumables
 				          +" Your hands gain pink, padded paws where your palms were once, and your nails become short claws,"
 				          +" not sharp enough to tear flesh, but nimble enough to make climbing and exploring much easier."
 				          +" <b>Your arms have become like those of  a red-panda!</b>");
-				player.arms.type = Arms.RED_PANDA;
-				mutations.updateClaws(Claws.RED_PANDA);
+				player.arms.setType(Arms.RED_PANDA, Claws.RED_PANDA);
 			}
 
 			// Legs

--- a/classes/classes/Items/Consumables/RegularHummus.as
+++ b/classes/classes/Items/Consumables/RegularHummus.as
@@ -74,7 +74,7 @@ package classes.Items.Consumables
 				player.skin.tone = randomChoice(ColorLists.HUMAN_SKIN);
 				outputText(player.skin.tone + " colored.</b>");
 				player.underBody.skin.tone = player.skin.tone;
-				mutations.updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 			}
 			//Change skin to normal
 			if (!player.hasPlainSkin() && (player.ears.type === Ears.HUMAN || player.ears.type === Ears.ELFIN) && rand(4) === 0 && changes < changeLimit) {

--- a/classes/classes/Items/Consumables/Reptilum.as
+++ b/classes/classes/Items/Consumables/Reptilum.as
@@ -273,16 +273,15 @@ package classes.Items.Consumables
 			// <mod name="Predator arms" author="Stadler76">
 			//Gain predator arms
 			if (player.arms.type !== Arms.PREDATOR && player.hasReptileScales() && player.lowerBody.type === LowerBody.LIZARD && changes < changeLimit && rand(3) === 0) {
-				player.arms.type = Arms.PREDATOR;
-				mutations.updateClaws(Claws.LIZARD);
-				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with " + player.skinFurScales() + " and short " + player.claws.tone + " claws replacing your fingernails.");
+				player.arms.setType(Arms.PREDATOR, Claws.LIZARD);
+				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of some reptilian killer with " + player.skinFurScales() + " and short " + player.arms.claws.tone + " claws replacing your fingernails.");
 				outputText("\n<b>You now have reptilian arms.</b>");
 				changes++
 			}
 			//Claw transition
-			if (player.arms.type === Arms.PREDATOR && player.hasLizardScales() && player.claws.type !== Claws.LIZARD && changes < changeLimit && rand(3) === 0) {
+			if (player.arms.type === Arms.PREDATOR && player.hasLizardScales() && player.arms.claws.type !== Claws.LIZARD && changes < changeLimit && rand(3) === 0) {
 				outputText("\n\nYour [claws] change a little to become reptilian.");
-				mutations.updateClaws(Claws.LIZARD);
+				player.arms.updateClaws(Claws.LIZARD);
 				outputText(" <b>You now have [claws].</b>");
 				changes++
 			}
@@ -322,7 +321,7 @@ package classes.Items.Consumables
 				var newSkinTones:Array = mutations.newLizardSkinTone();
 				if (player.hasFur()) {
 					player.skin.tone = newSkinTones[0];
-					mutations.updateClaws(player.claws.type);
+					player.arms.updateClaws(player.arms.claws.type);
 					outputText("\n\nYou scratch yourself, and come away with a large clump of " + player.skin.furColor + " fur.  Panicked, you look down"
 					          +" and realize that your fur is falling out in huge clumps.  It itches like mad, and you scratch your body"
 					          +" relentlessly, shedding the remaining fur with alarming speed.  Underneath the fur your skin feels incredibly"
@@ -336,7 +335,7 @@ package classes.Items.Consumables
 					          +" scratch yourself, and when you're finally done, you look yourself over. New scales have grown to replace your"
 					          +" peeled off [skinFurScales].");
 					player.skin.tone = newSkinTones[0];
-					mutations.updateClaws(player.claws.type);
+					player.arms.updateClaws(player.arms.claws.type);
 				}
 				//(no fur)
 				else {
@@ -346,7 +345,7 @@ package classes.Items.Consumables
 					          +" well that they may as well be seamless.  You peel back your " + player.armorName + " and the transformation has"
 					          +" already finished on the rest of your body.");
 					player.skin.tone = newSkinTones[0];
-					mutations.updateClaws(player.claws.type);
+					player.arms.updateClaws(player.arms.claws.type);
 				}
 				player.skin.setProps({
 					type: Skin.LIZARD_SCALES,

--- a/classes/classes/Items/Consumables/Salamanderfirewater.as
+++ b/classes/classes/Items/Consumables/Salamanderfirewater.as
@@ -231,8 +231,7 @@ package classes.Items.Consumables
 			//Arms
 			if (player.arms.type !== Arms.SALAMANDER && player.lowerBody.type === LowerBody.SALAMANDER && changes < changeLimit && rand(3) === 0) {
 				outputText("\n\nYou scratch your biceps absentmindedly, but no matter how much you scratch, you can't get rid of the itch.  After a longer moment of ignoring it you finally glance down in irritation, only to discover that your arms former appearance has changed into those of a salamander with leathery, red scales and short, fiery-red claws replacing your fingernails.  <b>You now have salamander arms.</b>");
-				player.arms.type = Arms.SALAMANDER;
-				mutations.updateClaws(Claws.SALAMANDER);
+				player.arms.setType(Arms.SALAMANDER, Claws.SALAMANDER);
 				changes++;
 			}
 			//Remove odd eyes
@@ -268,7 +267,7 @@ package classes.Items.Consumables
 				if (player.hasFur()) outputText("the skin under your " + player.skin.furColor + " " + player.skin.desc + " has ");
 				else outputText("your " + player.skin.desc + (player.skin.desc.indexOf("scales") !== -1 ? " have " : " has "));
 				player.skin.tone = randomChoice(ColorLists.SALAMANDER_SKIN);
-				mutations.updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 				outputText("changed to become " + player.skin.tone + " colored.</b>");
 			}
 			//Change skin to normal

--- a/classes/classes/Items/Consumables/SharkTooth.as
+++ b/classes/classes/Items/Consumables/SharkTooth.as
@@ -168,7 +168,7 @@ package classes.Items.Consumables
 					player.skin.desc = "skin";
 					player.skin.tone = "rough gray";
 					player.underBody.restore();
-					mutations.updateClaws(player.claws.type);
+					player.arms.updateClaws(player.arms.claws.type);
 					getGame().rathazul.addMixologyXP(20);
 					changes++;
 				}
@@ -178,7 +178,7 @@ package classes.Items.Consumables
 					player.skin.desc = "skin";
 					player.skin.tone = "orange and black striped";
 					player.underBody.restore();
-					mutations.updateClaws(player.claws.type);
+					player.arms.updateClaws(player.arms.claws.type);
 					kGAMECLASS.rathazul.addMixologyXP(20);
 					changes++;
 				}

--- a/classes/classes/Items/Consumables/ShriveledTentacle.as
+++ b/classes/classes/Items/Consumables/ShriveledTentacle.as
@@ -100,7 +100,7 @@ package classes.Items.Consumables
 			if (rand(5) === 0 && changes < changeLimit && player.skin.tone !== "aphotic blue-black") {
 				outputText("\n\nYou absently bite down on the last of the tentacle, then pull your hand away, wincing in pain.  How did you bite your finger so hard?  Looking down, the answer becomes obvious; <b>your hand, along with the rest of your skin, is now the same aphotic color as the dormant tentacle was!</b>");
 				player.skin.tone = "aphotic blue-black";
-				mutations.updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 				kGAMECLASS.rathazul.addMixologyXP(20);
 				changes++;
 			}

--- a/classes/classes/Items/Consumables/SkinOil.as
+++ b/classes/classes/Items/Consumables/SkinOil.as
@@ -48,7 +48,7 @@ package classes.Items.Consumables
 			else {
 				if (!game.player.hasGooSkin()) {
 					game.player.skin.tone = _color;
-					mutations.updateClaws(game.player.claws.type);
+					game.player.arms.updateClaws(game.player.arms.claws.type);
 				}
 				switch (game.player.skin.type) {
 					case Skin.PLAIN: //Plain

--- a/classes/classes/Items/Consumables/SnakeOil.as
+++ b/classes/classes/Items/Consumables/SnakeOil.as
@@ -137,7 +137,7 @@ package classes.Items.Consumables
 					});
 				}
 				
-				mutations.updateClaws(player.claws.type); // Just auto-fix the clawTone
+				player.arms.updateClaws(player.arms.claws.type); // Just auto-fix the clawTone
 				changes++;
 			}
 			// Remove gills

--- a/classes/classes/Items/Consumables/SuperHummus.as
+++ b/classes/classes/Items/Consumables/SuperHummus.as
@@ -43,8 +43,7 @@ package classes.Items.Consumables
 			else {
 				outputText("\n\nYou cry out as the world spins around you.  You're aware of your entire body sliding and slipping, changing and morphing, but in the sea of sensation you have no idea exactly what's changing.  You nearly black out, and then it's over.  Maybe you had best have a look at yourself and see what changed?");
 			}
-			player.arms.type = Arms.HUMAN;
-			mutations.updateClaws();
+			player.arms.restore();
 			player.eyes.type = Eyes.HUMAN;
 			player.antennae.type = Antennae.NONE;
 			player.face.type = Face.HUMAN;

--- a/classes/classes/Items/Consumables/TonOTrice.as
+++ b/classes/classes/Items/Consumables/TonOTrice.as
@@ -488,8 +488,7 @@ package classes.Items.Consumables
 				          +" scales and dangerous looking talons tip your fingers. As suddenly as the itching came it fades, leaving you to marvel"
 				          +" over your new arms.");
 				outputText("\n<b>You now have cockatrice arms!</b>");
-				player.arms.type = Arms.COCKATRICE;
-				mutations.updateClaws(Claws.COCKATRICE);
+				player.arms.setType(Arms.COCKATRICE, Claws.COCKATRICE);
 				changes++;
 			}
 			//Neck loss, if not cockatrice neck

--- a/classes/classes/Items/Consumables/WetCloth.as
+++ b/classes/classes/Items/Consumables/WetCloth.as
@@ -109,7 +109,7 @@ package classes.Items.Consumables
 					else if (blaht <= 8) player.skin.tone = "cerulean";
 					else player.skin.tone = "emerald";
 					outputText(player.skin.tone + "!");
-					if (player.arms.type !== Arms.HUMAN || player.claws.type !== Claws.NORMAL) {
+					if (player.arms.type !== Arms.HUMAN || player.arms.claws.type !== Claws.NORMAL) {
 						mutations.restoreArms(tfSource);
 					}
 				}

--- a/classes/classes/Items/Consumables/WolfPepper.as
+++ b/classes/classes/Items/Consumables/WolfPepper.as
@@ -66,7 +66,7 @@ package classes.Items.Consumables
 			//PRE-CHANGES: become biped, remove horns, remove wings, give human tongue, remove claws, remove antennea
 			//no claws
 			if (rand(4) === 0) {
-				mutations.updateClaws();
+				player.arms.claws.restore();
 			}
 			//remove antennae
 			if (player.antennae.type !== Antennae.NONE && rand(3) === 0 && changes < changeLimit) {

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -474,7 +474,7 @@ package classes.Items
 					if (temp == 3 || temp == 4 || temp == 5) player.skin.tone = "purple";
 					if (temp > 5) player.skin.tone = "blue";
 					outputText("\n\nA tingling sensation runs across your skin in waves, growing stronger as <b>your skin's tone slowly shifts, darkening to become " + player.skin.tone + " in color.</b>");
-					updateClaws(player.claws.type);
+					player.arms.updateClaws(player.arms.claws.type);
 					if (tainted) dynStats("cor", 1);
 					else dynStats("cor", 0);
 					kGAMECLASS.rathazul.addMixologyXP(20);
@@ -898,7 +898,7 @@ package classes.Items
 					if (player.skin.tone == "rough gray") player.skin.tone = "gray";
 					player.skin.type = Skin.PLAIN;
 					player.underBody.restore();
-					updateClaws(player.claws.type);
+					player.arms.updateClaws(player.arms.claws.type);
 				}
 				//chance of hair change
 				else {
@@ -953,7 +953,7 @@ package classes.Items
 					if (player.skin.tone == "rough gray") player.skin.tone = "gray";
 					player.skin.type = Skin.PLAIN;
 					player.underBody.restore();
-					updateClaws(player.claws.type);
+					player.arms.updateClaws(player.arms.claws.type);
 				}
 				//chance of hair change
 				else {
@@ -1978,7 +1978,7 @@ package classes.Items
 				else if (temp == 2) player.skin.tone = "dark";
 				else if (temp == 3) player.skin.tone = "light";
 				outputText(player.skin.tone + " colored.</b>");
-				updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 			}
 			//-Grow hips out if narrow.
 			if (player.hips.rating < 10 && changes < changeLimit && rand(3) === 0) {
@@ -2074,8 +2074,7 @@ package classes.Items
 			if (player.arms.type !== Arms.HARPY && changes < changeLimit && (type == 1 || player.hair.type == 1) && rand(4) === 0) {
 				outputText("\n\nYou smile impishly as you lick the last bits of the nut from your teeth, but when you go to wipe your mouth, instead of the usual texture of your " + player.skin.desc + " on your lips, you feel feathers! You look on in horror while more of the avian plumage sprouts from your " + player.skin.desc + ", covering your forearms until <b>your arms look vaguely like wings</b>. Your hands remain unchanged thankfully. It'd be impossible to be a champion without hands! The feathery limbs might help you maneuver if you were to fly, but there's no way they'd support you alone.");
 				changes++;
-				player.arms.type = Arms.HARPY;
-				updateClaws();
+				player.arms.setType(Arms.HARPY);
 			}
 			//-Feathery Hair
 			if (player.hair.type !== Hair.FEATHER && changes < changeLimit && (type == 1 || player.face.type == Face.HUMAN) && rand(4) === 0) {
@@ -2522,7 +2521,7 @@ package classes.Items
 				player.skin.type = Skin.PLAIN;
 				player.skin.desc = "skin";
 				player.underBody.restore();
-				updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 				changes++;
 			}
 			//(Gain human face)
@@ -2572,8 +2571,7 @@ package classes.Items
 				//(Bird pretext)
 				if (player.arms.type == Arms.HARPY) outputText("The feathers covering your arms fall away, leaving them to return to a far more human appearance.  ");
 				outputText("You watch, spellbound, while your forearms gradually become shiny.  The entire outer structure of your arms tingles while it divides into segments, <b>turning the " + player.skinFurScales() + " into a shiny black carapace</b>.  You touch the onyx exoskeleton and discover to your delight that you can still feel through it as naturally as your own skin.");
-				player.arms.type = Arms.SPIDER;
-				updateClaws();
+				player.arms.setType(Arms.SPIDER);
 				changes++;
 			}
 			if (rand(4) === 0 && changes < changeLimit && player.lowerBody.type !== LowerBody.DRIDER && player.lowerBody.type !== LowerBody.CHITINOUS_SPIDER_LEGS) restoreLegs(tfSource);
@@ -3206,7 +3204,7 @@ package classes.Items
 				if (!InCollection(player.skin.tone, tone)) player.skin.tone = randomChoice(tone);
 				outputText(player.skin.tone + " complexion.");
 				outputText("  <b>You now have [skin]!</b>");
-				updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 				changes++;
 			}
 			//Change skin tone if not changed you!
@@ -3214,7 +3212,7 @@ package classes.Items
 				outputText("\n\nYou feel a crawling sensation on the surface of your skin, starting at the small of your back and spreading to your extremities, ultimately reaching your face.  Holding an arm up to your face, you discover that <b>you now have ");
 				player.skin.tone = randomChoice(tone);
 				outputText("[skin]!</b>");
-				updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 				changes++;
 			}
 			//[Change Skin Color: add "Tattoos"]

--- a/classes/classes/Items/MutationsHelper.as
+++ b/classes/classes/Items/MutationsHelper.as
@@ -29,7 +29,7 @@ package classes.Items
 
 			if (tfSource == "gooGasmic") {
 				// skin just turned gooey. Now lets fix unusual arms.
-				var hasClaws:Boolean = player.claws.type != Claws.NORMAL;
+				var hasClaws:Boolean = player.arms.claws.type != Claws.NORMAL;
 
 				message = "\n\n";
 				if (player.arms.type == Arms.HARPY) {
@@ -42,8 +42,7 @@ package classes.Items
 				if (hasClaws) message += " Well, who cares, gooey claws aren't very useful in combat to begin with.";
 				if (hasClaws || player.arms.type == Arms.HARPY) output.text(message + "  <b>You have normal human arms again.</b>");
 
-				updateClaws();
-				player.arms.type = Arms.HUMAN;
+				player.arms.restore();
 				return 1;
 			}
 
@@ -71,7 +70,7 @@ package classes.Items
 					case Arms.PREDATOR:
 						switch (player.skin.type) {
 							case Skin.GOO:
-								if (player.claws.type != Claws.NORMAL)
+								if (player.arms.claws.type != Claws.NORMAL)
 									message += "\n\nYour gooey claws melt into your fingers."
 									          +" Well, who cares, gooey claws aren't very useful in combat to begin with.";
 								break;
@@ -89,8 +88,7 @@ package classes.Items
 						message += "\n\nYour unusual arms change more and more until they are normal human arms, leaving [skinfurscales] behind.";
 				}
 				output.text(message + "  <b>You have normal human arms again.</b>");
-				updateClaws();
-				player.arms.type = Arms.HUMAN;
+				player.arms.restore();
 				changes++;
 				return 1;
 			}
@@ -345,43 +343,6 @@ package classes.Items
 		public function newCockatriceColors():Array
 		{
 			return randomChoice(ColorLists.COCKATRICE);
-		}
-
-		public function updateClaws(clawType:int = Claws.NORMAL):String
-		{
-			var clawTone:String = "";
-			var oldClawTone:String = player.claws.tone;
-
-			switch (clawType) {
-				case Claws.DRAGON:       clawTone = "steel-gray";   break;
-				case Claws.SALAMANDER:   clawTone = "fiery-red";    break;
-				case Claws.LIZARD:
-					// See http://www.bergenbattingcenter.com/lizard-skins-bat-grip/ for all those NYI! lizard skin colors
-					// I'm still not that happy with these claw tones. Any suggestion would be nice.
-					switch (player.skin.tone) {
-						case "red":          clawTone = "reddish";      break;
-						case "green":        clawTone = "greenish";     break;
-						case "white":        clawTone = "light-gray";   break;
-						case "blue":         clawTone = "bluish";       break;
-						case "black":        clawTone = "dark-gray";    break;
-						case "purple":       clawTone = "purplish";     break;
-						case "silver":       clawTone = "silvery";      break;
-						case "pink":         clawTone = "pink";         break; // NYI! Maybe only with a new Skin Oil?
-						case "orange":       clawTone = "orangey";      break; // NYI!
-						case "yellow":       clawTone = "yellowish";    break; // NYI!
-						case "desert-camo":  clawTone = "pale-yellow";  break; // NYI!
-						case "gray-camo":    clawTone = "gray";         break; // NYI!
-						default:             clawTone = "gray";         break;
-					}
-					break;
-				default:
-					clawTone = "";
-			}
-
-			player.claws.type = clawType;
-			player.claws.tone = clawTone;
-
-			return oldClawTone;
 		}
 
 		public function lizardHairChange(tfSource:String):int

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1132,7 +1132,7 @@
 				impCounter++;
 			if (horns.type == Horns.IMP)
 				impCounter++;
-			if (arms.type == Arms.PREDATOR && claws.type == Claws.IMP)
+			if (arms.type == Arms.PREDATOR && arms.claws.type == Claws.IMP)
 				impCounter++;
 			if (tallness <= 42)
 				impCounter++;
@@ -1489,7 +1489,7 @@
 				lizardCounter++;
 			if (hasDragonHorns(true))
 				lizardCounter++;
-			if (arms.type == Arms.PREDATOR && claws.type == Claws.LIZARD)
+			if (arms.type == Arms.PREDATOR && arms.claws.type == Claws.LIZARD)
 				lizardCounter++;
 			if (lizardCounter > 2) {
 				if ([Tongue.LIZARD, Tongue.SNAKE].indexOf(tongue.type) != -1)
@@ -1625,7 +1625,7 @@
 				dragonCounter++;
 			if (hasDragonfire())
 				dragonCounter++;
-			if (arms.type == Arms.PREDATOR && claws.type == Claws.DRAGON)
+			if (arms.type == Arms.PREDATOR && arms.claws.type == Claws.DRAGON)
 				dragonCounter++;
 			if (eyes.type == Eyes.DRAGON)
 				dragonCounter++;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -909,8 +909,8 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.neck = player.neck.toObject();
 		saveFile.data.rearBody = player.rearBody.toObject();
 		// <mod name="Predator arms" author="Stadler76">
-		saveFile.data.clawTone = player.claws.tone;
-		saveFile.data.clawType = player.claws.type;
+		saveFile.data.clawTone = player.arms.claws.tone;
+		saveFile.data.clawType = player.arms.claws.type;
 		// </mod>
 		saveFile.data.wingType = player.wings.type;
 		saveFile.data.wingColor = player.wings.color;
@@ -1783,8 +1783,8 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		if (isObject(saveFile.data.rearBody))
 			player.rearBody.setAllProps(saveFile.data.rearBody);
 		// <mod name="Predator arms" author="Stadler76">
-		player.claws.tone = (saveFile.data.clawTone == undefined) ? ""               : saveFile.data.clawTone;
-		player.claws.type = (saveFile.data.clawType == undefined) ? Claws.NORMAL : saveFile.data.clawType;
+		player.arms.claws.tone = (saveFile.data.clawTone == undefined) ? ""               : saveFile.data.clawTone;
+		player.arms.claws.type = (saveFile.data.clawType == undefined) ? Claws.NORMAL : saveFile.data.clawType;
 		// </mod>
 
 		player.wings.type = saveFile.data.wingType;

--- a/classes/classes/Scenes/NPCs/Urta.as
+++ b/classes/classes/Scenes/NPCs/Urta.as
@@ -4774,7 +4774,7 @@ private function urtasRuinedOrgasmsFromGooPartII():void {
 	if (player.skin.tone != "milky white") {
 		outputText("\n\nThen you catch sight of your body...  You hold up a hand in surprise.  Your skin has changed color!  Your time inside Urta's balls has taken its toll, it seems.  <b>You now have milky white skin!</b>");
 		player.skin.tone = "milky white";
-		mutations.updateClaws(player.claws.type);
+		player.arms.updateClaws(player.arms.claws.type);
 		player.cumMultiplier += 10;
 	}
 	outputText("\n\nUrta and ");

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -1644,7 +1644,7 @@ package classes.Scenes.Places.Bazaar
 				player.skin.type = Skin.PLAIN;
 				player.skin.desc = "skin";
 				player.underBody.restore();
-				mutations.updateClaws(player.claws.type);
+				player.arms.updateClaws(player.arms.claws.type);
 				changes++;
 			}
 			//Arms change to regular
@@ -1658,8 +1658,7 @@ package classes.Scenes.Places.Bazaar
 						break;
 					default:
 				}
-				player.arms.type = Arms.HUMAN;
-				mutations.updateClaws();
+				player.arms.restore();
 				changes++;
 			}
 			//Change legs to normal

--- a/classes/classes/lists/ColorLists.as
+++ b/classes/classes/lists/ColorLists.as
@@ -24,6 +24,11 @@ package classes.lists
 			"dark green",
 		];
 
+		public static const IMP_SKIN:Array = [
+			"red",
+			"orange",
+		];
+
 		public static const SALAMANDER_SKIN:Array = [
 			"light",
 			"fair",

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -120,8 +120,7 @@ package classes
 			impPlayer.skin.type = Skin.PLAIN;
 			impPlayer.skin.tone = "red";
 			impPlayer.horns.type = Horns.IMP;
-			impPlayer.arms.type = Arms.PREDATOR;
-			impPlayer.arms.claws.type = Claws.IMP;
+			impPlayer.arms.setType(Arms.PREDATOR, Claws.IMP);
 
 			minoPlayer = new Player();
 			minoPlayer.face.type = Face.COW_MINOTAUR;
@@ -453,8 +452,7 @@ package classes
 			lizardPlayer.tail.type = Tail.LIZARD;
 			lizardPlayer.lowerBody.type = LowerBody.LIZARD;
 			lizardPlayer.horns.type = Horns.DRACONIC_X4_12_INCH_LONG;
-			lizardPlayer.arms.type = Arms.PREDATOR;
-			lizardPlayer.arms.claws.type = Claws.LIZARD;
+			lizardPlayer.arms.setType(Arms.PREDATOR, Claws.LIZARD);
 			lizardPlayer.tongue.type = Tongue.LIZARD;
 			createCock(CockTypesEnum.LIZARD, lizardPlayer);
 			createCock(CockTypesEnum.LIZARD, lizardPlayer);
@@ -525,8 +523,7 @@ package classes
 			dragonPlayer.lowerBody.type = LowerBody.DRAGON;
 			dragonPlayer.skin.type = Skin.DRAGON_SCALES;
 			dragonPlayer.horns.type = Horns.DRACONIC_X4_12_INCH_LONG;
-			dragonPlayer.arms.type = Arms.PREDATOR;
-			dragonPlayer.arms.claws.type = Claws.DRAGON;
+			dragonPlayer.arms.setType(Arms.PREDATOR, Claws.DRAGON);
 			dragonPlayer.eyes.type = Eyes.DRAGON;
 			dragonPlayer.neck.modify(Infinity, Neck.DRACONIC);
 			dragonPlayer.rearBody.type = RearBody.DRACONIC_SPIKES;

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -121,7 +121,7 @@ package classes
 			impPlayer.skin.tone = "red";
 			impPlayer.horns.type = Horns.IMP;
 			impPlayer.arms.type = Arms.PREDATOR;
-			impPlayer.claws.type = Claws.IMP;
+			impPlayer.arms.claws.type = Claws.IMP;
 
 			minoPlayer = new Player();
 			minoPlayer.face.type = Face.COW_MINOTAUR;
@@ -454,7 +454,7 @@ package classes
 			lizardPlayer.lowerBody.type = LowerBody.LIZARD;
 			lizardPlayer.horns.type = Horns.DRACONIC_X4_12_INCH_LONG;
 			lizardPlayer.arms.type = Arms.PREDATOR;
-			lizardPlayer.claws.type = Claws.LIZARD;
+			lizardPlayer.arms.claws.type = Claws.LIZARD;
 			lizardPlayer.tongue.type = Tongue.LIZARD;
 			createCock(CockTypesEnum.LIZARD, lizardPlayer);
 			createCock(CockTypesEnum.LIZARD, lizardPlayer);
@@ -526,7 +526,7 @@ package classes
 			dragonPlayer.skin.type = Skin.DRAGON_SCALES;
 			dragonPlayer.horns.type = Horns.DRACONIC_X4_12_INCH_LONG;
 			dragonPlayer.arms.type = Arms.PREDATOR;
-			dragonPlayer.claws.type = Claws.DRAGON;
+			dragonPlayer.arms.claws.type = Claws.DRAGON;
 			dragonPlayer.eyes.type = Eyes.DRAGON;
 			dragonPlayer.neck.modify(Infinity, Neck.DRACONIC);
 			dragonPlayer.rearBody.type = RearBody.DRACONIC_SPIKES;


### PR DESCRIPTION
Since claws tf is mostly linked to the arms TF I've moved the instance into the arms class.
Along with that I've moved updateClaws() into the Arms-class.
You can now use `player.arms.setType()` to set the armType and the clawType along with it.
e. G.
```as3
player.arms.setType(Arms.PREDATOR, Claws.DRAGON);
player.arms.setType(Arms.SALAMANDER); // Sets the arms and the claws to salamander types
player.arms.setType(Arms.FERRET); // Sets the arms and the claws to ferret types
player.arms.restore(); // now restores the claws, too.
```
For an example see e2d19677931f587db24ae0dcbdaa57756a1c865e.