### PR TITLE
Rename Travis-CI Sonar plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 addons:
   # service for code quality analysis
-  sonarqube:
+  sonarcloud:
     organization: "kitteh6660-github"
 
 # travis-ci does not support actionscript.


### PR DESCRIPTION
Per the build log on Travis-CI:
`sonarqube addon has been renamed to sonarcloud. Please update your configuration.`