### PR TITLE
Interface cleanup

### DIFF
--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -1,12 +1,12 @@
 package classes
 {
 	import classes.CockTypesEnum;
-	import classes.internals.ISerializable;
+	import classes.internals.Serializable;
 	import classes.internals.Utils;
 	import mx.logging.ILogger;
 	import classes.internals.LoggerFactory;
 
-	public class Cock implements ISerializable
+	public class Cock implements Serializable
 	{
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(Cock);
 		

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -31,7 +31,7 @@ package classes
 	import classes.StatusEffects.Combat.CombatStrBuff;
 	import classes.StatusEffects.Combat.CombatTouBuff;
 	import classes.VaginaClass;
-	import classes.internals.IRandomNumber;
+	import classes.internals.RandomNumberGenerator;
 	import classes.internals.LoggerFactory;
 	import classes.internals.Utils;
 	import classes.internals.profiling.Begin;
@@ -66,14 +66,14 @@ package classes
 		 * Normally creatures do not need a unique RNG,
 		 * so to avoid unnecessary memory usage they use the default instance.
 		 */
-		private var _rng:IRandomNumber = Utils.DEFAULT_RNG;
+		private var _rng:RandomNumberGenerator = Utils.DEFAULT_RNG;
 		
 		/**
 		 * Set the RNG this class uses. Intended for testing.
 		 * @param	rng to use for random numbers
 		 * @return the RNG that was set
 		 */
-		public function set rng(rng:IRandomNumber):void {
+		public function set rng(rng:RandomNumberGenerator):void {
 			if (rng === null) {
 				throw new ArgumentError("RNG cannot be null");
 			}
@@ -85,7 +85,7 @@ package classes
 		 * Get the RNG this class uses. Intended for testing.
 		 * @return the RNG used
 		 */
-		public function get rng():IRandomNumber {
+		public function get rng():RandomNumberGenerator {
 			return this._rng;
 		}
 		

--- a/classes/classes/Scenes/Places/Bazaar.as
+++ b/classes/classes/Scenes/Places/Bazaar.as
@@ -18,7 +18,7 @@ package classes.Scenes.Places{
 //Set Up With The Travelling, Tainted Bazaar
 public function Bazaar(){
 }
-		private var rng:RandomNumberGenerator = new RandomNumber();
+		private var rng:RandomNumberGenerator = new ActionScriptRNG();
 
 		public var blackCock:BlackCock = new BlackCock();
 		public var benoit:Benoit = new Benoit();

--- a/classes/classes/Scenes/Places/Bazaar.as
+++ b/classes/classes/Scenes/Places/Bazaar.as
@@ -18,7 +18,7 @@ package classes.Scenes.Places{
 //Set Up With The Travelling, Tainted Bazaar
 public function Bazaar(){
 }
-		private var rng:IRandomNumber = new RandomNumber();
+		private var rng:RandomNumberGenerator = new RandomNumber();
 
 		public var blackCock:BlackCock = new BlackCock();
 		public var benoit:Benoit = new Benoit();

--- a/classes/classes/Scenes/Places/Bazaar/Roxanne.as
+++ b/classes/classes/Scenes/Places/Bazaar/Roxanne.as
@@ -2,7 +2,7 @@ package classes.Scenes.Places.Bazaar{
 	import classes.*;
 	import classes.BodyParts.*;
 	import classes.GlobalFlags.kFLAGS;
-	import classes.internals.IRandomNumber;
+	import classes.internals.RandomNumberGenerator;
 	import classes.internals.RandomNumber;
 	import mx.logging.ILogger;
 	import classes.internals.LoggerFactory;
@@ -12,7 +12,7 @@ package classes.Scenes.Places.Bazaar{
 	public class Roxanne extends BazaarAbstractContent implements TimeAwareInterface {
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(Roxanne);
 		
-		private var randomNumber:IRandomNumber;
+		private var randomNumber:RandomNumberGenerator;
 //Roxanne Poisontail
 //-no hair, 
 //-stand roughly 5'11\" in height, 
@@ -48,7 +48,7 @@ WIN:
 //226 -Is PC losing the Roxanne's drinking contest intentionally?
 //227 -Drinking Contest Bonus Score
 
-		public function Roxanne(randomNumber:IRandomNumber)
+		public function Roxanne(randomNumber:RandomNumberGenerator)
 		{
 			CoC.timeAwareClassAdd(this);
 			this.randomNumber = randomNumber;

--- a/classes/classes/Scenes/Places/Bazaar/Roxanne.as
+++ b/classes/classes/Scenes/Places/Bazaar/Roxanne.as
@@ -3,7 +3,7 @@ package classes.Scenes.Places.Bazaar{
 	import classes.BodyParts.*;
 	import classes.GlobalFlags.kFLAGS;
 	import classes.internals.RandomNumberGenerator;
-	import classes.internals.RandomNumber;
+	import classes.internals.ActionScriptRNG;
 	import mx.logging.ILogger;
 	import classes.internals.LoggerFactory;
 	import classes.display.SpriteDb;

--- a/classes/classes/VaginaClass.as
+++ b/classes/classes/VaginaClass.as
@@ -1,11 +1,11 @@
 ﻿package classes
 {
-	import classes.internals.ISerializable;
+	import classes.internals.Serializable;
 	import classes.internals.Utils;
 	import mx.logging.ILogger;
 	import classes.internals.LoggerFactory;
 
-	public class VaginaClass implements ISerializable
+	public class VaginaClass implements Serializable
 	{
 		private static const SERIALIZATION_VERSION:int = 1;
 		

--- a/classes/classes/internals/ActionScriptRNG.as
+++ b/classes/classes/internals/ActionScriptRNG.as
@@ -3,7 +3,7 @@ package classes.internals
 	/**
 	 * Class that provides random numbers.
 	 */
-	public class RandomNumber implements RandomNumberGenerator
+	public class ActionScriptRNG implements RandomNumberGenerator
 	{
 		/**
 		 * Returns a number that is between 0 and max exclusive.

--- a/classes/classes/internals/ISerializableAMF.as
+++ b/classes/classes/internals/ISerializableAMF.as
@@ -1,9 +1,0 @@
-package classes.internals 
-{
-	/**
-	 * Interface for marking classes that should be serialized with AMF
-	 */
-	public interface ISerializableAMF 
-	{
-	}
-}

--- a/classes/classes/internals/RandomNumber.as
+++ b/classes/classes/internals/RandomNumber.as
@@ -3,7 +3,7 @@ package classes.internals
 	/**
 	 * Class that provides random numbers.
 	 */
-	public class RandomNumber implements IRandomNumber
+	public class RandomNumber implements RandomNumberGenerator
 	{
 		/**
 		 * Returns a number that is between 0 and max exclusive.

--- a/classes/classes/internals/RandomNumberGenerator.as
+++ b/classes/classes/internals/RandomNumberGenerator.as
@@ -4,7 +4,7 @@ package classes.internals
 	/**
 	 * Interface that provides methods for getting random numbers.
 	 */
-	public interface IRandomNumber
+	public interface RandomNumberGenerator
 	{
 		/**
 		 * Returns a number that is between 0 and max - 1 inclusive.

--- a/classes/classes/internals/Serializable.as
+++ b/classes/classes/internals/Serializable.as
@@ -7,7 +7,7 @@ package classes.internals
 	 * to a shared object or file.
 	 * The interface also provides a function to reverse the process.
 	 */
-	public interface ISerializable 
+	public interface Serializable 
 	{
 		/**
 		 * Serialize a class so it can be stored. Any state that is not serialized will be lost and replaced with the

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -4,7 +4,7 @@ package classes.internals
 	import flash.errors.IllegalOperationError;
 	import classes.internals.LoggerFactory;
 	import mx.logging.ILogger;
-	import classes.internals.ISerializable;
+	import classes.internals.Serializable;
 	import ArgumentError;
 	
 	/**
@@ -29,7 +29,7 @@ package classes.internals
 		public static function serializeVector(vector:Vector.<*>):Array {
 			var serialized:Array = [];
 			
-			for each(var element:ISerializable in vector) {
+			for each(var element:Serializable in vector) {
 				var obj:Array = [];
 				serialized.push(obj);
 				
@@ -48,7 +48,7 @@ package classes.internals
 		 */
 		public static function deserializeVector(destinationVector:Vector.<*>, serializedVector:Array, type:Class):void {
 			// 'is' will only work on an instance
-			if (!(new type() is ISerializable)) {
+			if (!(new type() is Serializable)) {
 				throw new ArgumentError("Type must implement Serializable");
 			}
 			
@@ -61,7 +61,7 @@ package classes.internals
 			}
 			
 			for each(var element:Object in serializedVector) {
-				var instance:ISerializable = new type();
+				var instance:Serializable = new type();
 				SerializationUtils.deserialize(element, instance);
 				destinationVector.push(instance);
 			}
@@ -129,7 +129,7 @@ package classes.internals
 		 * @param	relativeRootObject the object that contains the serialized classes data
 		 * @param	serialized class instance that should have it's state restored
 		 */
-		public static function deserialize(relativeRootObject:*, serialized:ISerializable):void {
+		public static function deserialize(relativeRootObject:*, serialized:Serializable):void {
 			LOGGER.debug("Deserializing  {0}...", serialized);
 
 			objectDefinedCheck(relativeRootObject, "Object passed for deserialization must be defined. Does the loaded property exist?")
@@ -149,7 +149,7 @@ package classes.internals
 		 * @param	relativeRootObject to write the classes data to
 		 * @param	toSerialize instance of class to serialize
 		 */
-		public static function serialize(relativeRootObject:*, toSerialize:ISerializable):void {
+		public static function serialize(relativeRootObject:*, toSerialize:Serializable):void {
 			LOGGER.debug("Serializing {0}...", toSerialize);
 			
 			objectDefinedCheck(relativeRootObject, "Object used for storage must be defined. Did you forget to initialize e.g. foo = []; ?");

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -67,43 +67,6 @@ package classes.internals
 			}
 		}
 		
-		
-		/**
-		 * Serializes a Vector into an array using AMF.
-		 * @param	vector to serialize
-		 * @return a array containing the serialized vector
-		 */
-		public static function serializeVectorWithAMF(vector:Vector.<ISerializableAMF>):Array {
-			var serialized:Array = [];
-			
-			for each(var element:ISerializableAMF in vector) {
-				serialized.push(element);
-			}
-			
-			return serialized;
-		}
-		
-		/**
-		 * Deserializes a Array into a Vector using AMF
-		 * @param	serializedVector an Array containing the serialized vector
-		 * @param	type of the serialized Vector
-		 * @return a deserialized Vector
-		 */
-		public static function deserializeVectorWithAMF(serializedVector:Array, type:Class):Vector.<ISerializableAMF> {
-			// 'is' will only work on an instance
-			if (!(new type() is ISerializableAMF)) {
-				throw new ArgumentError("Type must implement SerializableAMF");
-			}
-			
-			var deserialized:Vector.<ISerializableAMF> = new Vector.<ISerializableAMF>();
-			
-			for each(var element:Object in serializedVector) {
-				deserialized.push(element as type);
-			}
-			
-			return deserialized;
-		}
-		
 		/**
 		 * Casts a vector from one type to another. DOES NO VALIDATION.
 		 * @param	destinationVector vector where casted elements will be put

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -7,6 +7,7 @@ package classes.internals
 	import coc.script.Eval;
 	import classes.internals.LoggerFactory;
 	import mx.logging.ILogger;
+	import classes.internals.ActionScriptRNG;
 	
 	public class Utils extends Object
 	{
@@ -19,7 +20,7 @@ package classes.internals
 		/**
 		 * Default RNG instance. Uses Utils.rand internally.
 		 */
-		public static const DEFAULT_RNG:RandomNumberGenerator = new RandomNumber();
+		public static const DEFAULT_RNG:RandomNumberGenerator = new ActionScriptRNG();
 		
 		public function Utils()
 		{

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -5,8 +5,13 @@ package classes.internals
 {
 	import classes.*;
 	import coc.script.Eval;
+	import classes.internals.LoggerFactory;
+	import mx.logging.ILogger;
+	
 	public class Utils extends Object
 	{
+		private static const LOGGER:ILogger = LoggerFactory.getLogger(Utils);
+		
 		private static const NUMBER_WORDS_NORMAL:Array		= ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"];
 		private static const NUMBER_WORDS_CAPITAL:Array		= ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"];
 		private static const NUMBER_WORDS_POSITIONAL:Array	= ["zeroth", "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth"];
@@ -180,7 +185,7 @@ package classes.internals
 						skey = pd.skey;
 						dkey = pd.dkey;
 					} else {
-						//trace("WARNING: missing 'key' or 'skey'+'dkey' in property descriptor "+pd);
+						LOGGER.warn("Missing 'key' or 'skey'+'dkey' in property descriptor {0}", pd);
 						continue;
 					}
 					if (!forward) {

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -269,13 +269,7 @@ package classes.internals
 		public static function num2Text2(number:int):String {
 			if (number < 0) return number.toString(); //Can't really have the -10th of something
 			if (number <= 10) return NUMBER_WORDS_POSITIONAL[number];
-			// For (number > 10) the method would return 11st, 12nd, 13rd and so on with the switch-case below (Stadler76)
-			/*switch (number % 10) {
-				case 1: return number.toString() + "st";
-				case 2: return number.toString() + "nd";
-				case 3: return number.toString() + "rd";
-				default:
-			}*/
+			
 			return number.toString() + "th";
 		}
 		
@@ -416,38 +410,5 @@ package classes.internals
 			while (n-->0) rslt += s;
 			return rslt;
 		}
-
-		/* None of these functions are called anymore
-		// lazy(obj,arg1,...,argN)() = obj[arg1]...[argN]
-		public static function lazyIndex(obj:*,...args):Function{
-			return function():*{
-				while(args.length>0)
-					obj=obj[args.shift()];
-				return obj;
-			};
-		}
-		// lazy2(func,arg1,...,argN)() = func()[arg1]...[argN]
-		public static function lazyCallIndex(func:Function,...args):Function{
-			var _args:Array = args.slice();
-			return function():*{
-				var obj:*=func();
-				var __args:Array = _args.slice();
-				while(__args.length>0)
-					obj=obj[__args.shift()];
-				return obj
-			};
-		}
-		// lazy2(func,arg1,...,argN)(args2) = func()[arg1]...[argN](args2)
-		public static function lazyCallIndexCall(func:Function,...args):Function{
-			var _args:Array = args.slice();
-			return function (...fargs):*{
-				var obj:*=func();
-				var __args:Array = _args.slice();
-				while(__args.length>0)
-					obj=obj[__args.shift()];
-				return obj.apply(null,fargs);
-			};
-		}
-		*/
 	}
 }

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -14,7 +14,7 @@ package classes.internals
 		/**
 		 * Default RNG instance. Uses Utils.rand internally.
 		 */
-		public static const DEFAULT_RNG:IRandomNumber = new RandomNumber();
+		public static const DEFAULT_RNG:RandomNumberGenerator = new RandomNumber();
 		
 		public function Utils()
 		{

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -298,10 +298,14 @@ package classes.internals
 			return (string.substr(0, 1).toUpperCase() + string.substr(1));
 		}
 		
-		// Basically, you pass an arbitrary-length list of arguments, and it returns one of them at random.
-		// Accepts any type.
-		// Can also accept a *single* array of items, in which case it picks from the array instead.
-		// This lets you pre-construct the argument, to make things cleaner
+		/**
+		 * Basically, you pass an arbitrary-length list of arguments, and it returns one of them at random. Accepts any type.
+		 * Can also accept a *single* array of items, in which case it picks from the array instead.
+		 * This lets you pre-construct the argument, to make things cleaner
+		 * 
+		 * @param	...args arguments to pick from
+		 * @return a randomly selected argument
+		 */
 		public static function randomChoice(...args):*
 		{
 			var tar:Array;

--- a/test/classes/CreatureTest.as
+++ b/test/classes/CreatureTest.as
@@ -6,7 +6,7 @@ package classes{
 	import classes.PerkLib;
 	import classes.helper.StageLocator;
 	import classes.internals.RandomNumberGenerator;
-	import classes.internals.RandomNumber;
+	import classes.internals.ActionScriptRNG;
 	import classes.lists.Gender;
 	import org.flexunit.asserts.*;
 	import org.hamcrest.assertThat;
@@ -573,7 +573,7 @@ package classes{
 		
 		[Test]
 		public function setNewRng():void {
-			var rng:RandomNumberGenerator = new RandomNumber();
+			var rng:RandomNumberGenerator = new ActionScriptRNG();
 			
 			cut.rng = rng;
 			

--- a/test/classes/CreatureTest.as
+++ b/test/classes/CreatureTest.as
@@ -5,7 +5,7 @@ package classes{
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.PerkLib;
 	import classes.helper.StageLocator;
-	import classes.internals.IRandomNumber;
+	import classes.internals.RandomNumberGenerator;
 	import classes.internals.RandomNumber;
 	import classes.lists.Gender;
 	import org.flexunit.asserts.*;
@@ -34,7 +34,7 @@ package classes{
 		private var noVagina:Creature;
 		private var oneVagina:Creature;
 		private var maxVagina:Creature;
-		private var alwaysZero:IRandomNumber;
+		private var alwaysZero:RandomNumberGenerator;
 		
 		private function createVaginas(numberOfVaginas:Number, instance:Creature):void {
 			var i:Number;
@@ -573,7 +573,7 @@ package classes{
 		
 		[Test]
 		public function setNewRng():void {
-			var rng:IRandomNumber = new RandomNumber();
+			var rng:RandomNumberGenerator = new RandomNumber();
 			
 			cut.rng = rng;
 			
@@ -603,9 +603,9 @@ package classes{
     }
 }
 
-import classes.internals.IRandomNumber;
+import classes.internals.RandomNumberGenerator;
 
-class AlwaysZeroRNG implements IRandomNumber {
+class AlwaysZeroRNG implements RandomNumberGenerator {
 	public function random(max:int):int 
 	{
 		return 0;

--- a/test/classes/InternalsSuit.as
+++ b/test/classes/InternalsSuit.as
@@ -2,7 +2,7 @@ package classes {
 	import classes.helper.MemoryLogTarget;
 	import classes.helper.MemoryLogTargetTest;
 	import classes.internals.LoggerFactoryTest;
-	import classes.internals.RandomNumberTest;
+	import classes.internals.ActionScriptRNGTest;
 	import classes.internals.SerializationUtilTest;
 	import classes.internals.UtilsTest;
 	
@@ -13,6 +13,6 @@ package classes {
 		public var loggerFactoryTest:LoggerFactoryTest;
 		public var serializationUtilTest:SerializationUtilTest;
 		public var utilsTest:UtilsTest;
-		public var randomNumberTest:RandomNumberTest;
+		public var actionScriptRNGTest:ActionScriptRNGTest;
 	}
 }

--- a/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
+++ b/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
@@ -2,7 +2,7 @@ package classes.Scenes.Places.Bazaar{
 	import classes.Appearance;
 	import classes.BodyParts.Butt;
 	import classes.helper.FireButtonEvent;
-	import classes.internals.IRandomNumber;
+	import classes.internals.RandomNumberGenerator;
     import org.flexunit.asserts.*;
 	import org.hamcrest.assertThat;
 	import org.hamcrest.core.*;
@@ -32,7 +32,7 @@ package classes.Scenes.Places.Bazaar{
          
         [Before]
         public function setUp():void {
-			var rng:IRandomNumber = new RngMock();
+			var rng:RandomNumberGenerator = new RngMock();
 			
 			cut = new RoxanneForTest(rng);
 			
@@ -149,12 +149,12 @@ package classes.Scenes.Places.Bazaar{
 }
 
 import classes.Scenes.Places.Bazaar.Roxanne;
-import classes.internals.IRandomNumber;
+import classes.internals.RandomNumberGenerator;
 
 class RoxanneForTest extends Roxanne {
 	public var collectedOutput:Vector.<String> = new Vector.<String>();
 	
-	public function RoxanneForTest(rng:IRandomNumber) 
+	public function RoxanneForTest(rng:RandomNumberGenerator) 
 	{
 		super(rng);
 	}
@@ -168,7 +168,7 @@ class RoxanneForTest extends Roxanne {
 	}
 }
 
-class RngMock implements IRandomNumber {
+class RngMock implements RandomNumberGenerator {
 	public var randomValue:int = 0;
 	
 	public function random(max:int):int 

--- a/test/classes/internals/ActionScriptRNGTest.as
+++ b/test/classes/internals/ActionScriptRNGTest.as
@@ -7,8 +7,10 @@ package classes.internals
 	import org.hamcrest.object.*;
 	import org.hamcrest.text.*;
 	import org.hamcrest.collection.*;
+
+	import classes.internals.ActionScriptRNG
 	
-	public class RandomNumberTest
+	public class ActionScriptRNGTest
 	{
 		/**
 		 * If the max is 5, odds of not rolling a 5 (with 0 to 5): 5/6
@@ -19,12 +21,12 @@ package classes.internals
 		private static const RANDOM_NUMBER_ITERATIONS:int = 10000;
 		private static const RANDOM_NUMBER_MAX:int = 5;
 		
-		private var cut:RandomNumber;
+		private var cut:ActionScriptRNG;
 		
 		[Before]
 		public function setUp():void
 		{
-			cut = new RandomNumber;
+			cut = new ActionScriptRNG();
 		}
 		
 		[Test]

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -9,7 +9,6 @@ package classes.internals
 	import org.hamcrest.collection.*;
 	
 	import classes.internals.ISerializable;
-	import classes.internals.ISerializableAMF;
 	
 	public class SerializationUtilTest
 	{
@@ -18,7 +17,6 @@ package classes.internals
 		
 		private var testObject:Array;
 		private var testVector:Vector.<ISerializable>;
-		private var testAMFVector:Vector.<ISerializableAMF>;
 		private var deserializedVector:Vector.<*>;
 		private var serializedObject:*;
 		private var dummy:SerializationDummy;
@@ -31,14 +29,6 @@ package classes.internals
 			}
 		}
 		
-		private function buildAmfVector(instances:int):void
-		{
-			for (var i:int = 0; i < instances; i++)
-			{
-				testAMFVector.push(new AMFSerializationDummy(i, i + 1));
-			}
-		}
-		
 		private function getTestObject():* {
 			return SerializationUtils.serializeVector(testVector as Vector.<*>);
 		}
@@ -48,7 +38,6 @@ package classes.internals
 		{
 			testObject = null;
 			testVector = new Vector.<ISerializable>();
-			testAMFVector = new Vector.<ISerializableAMF>();
 			deserializedVector = new Vector.<*>();
 			
 			serializedObject = [];
@@ -57,7 +46,6 @@ package classes.internals
 			dummy = new SerializationDummy();
 			
 			buildVector(TEST_INSTANCES);
-			buildAmfVector(TEST_INSTANCES);
 		}
 		
 		[Test]
@@ -74,22 +62,6 @@ package classes.internals
 			testObject = getTestObject();
 			
 			assertThat(testObject[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1, bar: TEST_INSTANCES}));
-		}
-		
-		[Test]
-		public function serializeVectorWithAMFObjectSize():void
-		{
-			testObject = SerializationUtils.serializeVectorWithAMF(testAMFVector);
-			
-			assertThat(testObject, arrayWithSize(TEST_INSTANCES));
-		}
-		
-		[Test]
-		public function serializeVectorWithAMFLastObjectValue():void
-		{
-			testObject = SerializationUtils.serializeVectorWithAMF(testAMFVector);
-			
-			assertThat(testObject[TEST_INSTANCES - 1], instanceOf(AMFSerializationDummy));
 		}
 		
 		[Test]
@@ -152,37 +124,6 @@ package classes.internals
 			SerializationUtils.castVector(destinationVector, testVector, SerializationDummy);
 			
 			assertThat(destinationVector[TEST_INSTANCES - 1], instanceOf(SerializationDummy));
-		}
-		
-		[Test(expected="ArgumentError")]
-		public function deserializeWithNonSerializableAMFType():void {
-			SerializationUtils.deserializeVectorWithAMF(new Array(), String);
-		}
-		
-		private function deserializeAMF():Vector.<ISerializableAMF> {
-			testObject = SerializationUtils.serializeVectorWithAMF(testAMFVector);
-			return SerializationUtils.deserializeVectorWithAMF(testObject, AMFSerializationDummy);
-		}
-		
-		[Test]
-		public function deserializeVectorWithAMFSize():void {
-			var vector:Vector.<ISerializableAMF> = deserializeAMF();
-			
-			assertThat(vector, arrayWithSize(TEST_INSTANCES));
-		}
-		
-		[Test]
-		public function deserializeVectorWithAMFType():void {
-			var vector:Vector.<ISerializableAMF> = deserializeAMF();
-			
-			assertThat(vector[TEST_INSTANCES - 1], instanceOf(ISerializableAMF));
-		}
-		
-		[Test]
-		public function deserializeVectorWithAMFProperty():void {
-			var vector:Vector.<ISerializableAMF> = deserializeAMF();
-			
-			assertThat(vector[TEST_INSTANCES - 1], hasProperties({foo: TEST_INSTANCES - 1, bar: TEST_INSTANCES}));
 		}
 		
 		[Test]
@@ -276,7 +217,6 @@ package classes.internals
 }
 
 import classes.internals.ISerializable;
-import classes.internals.ISerializableAMF;
 import flash.errors.IllegalOperationError;
 
 class SerializationDummy implements ISerializable
@@ -317,17 +257,5 @@ class SerializationDummy implements ISerializable
 	public function currentSerializationVerison():int 
 	{
 		return 2;
-	}
-}
-
-class AMFSerializationDummy implements ISerializableAMF
-{
-	public var foo:int;
-	public var bar:int;
-	
-	public function AMFSerializationDummy(foo:int = -2, bar:int = -2)
-	{
-		this.foo = foo;
-		this.bar = bar;
 	}
 }

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -8,7 +8,7 @@ package classes.internals
 	import org.hamcrest.text.*;
 	import org.hamcrest.collection.*;
 	
-	import classes.internals.ISerializable;
+	import classes.internals.Serializable;
 	
 	public class SerializationUtilTest
 	{
@@ -16,7 +16,7 @@ package classes.internals
 		private static const SERIAL_VERSION:int = 2;
 		
 		private var testObject:Array;
-		private var testVector:Vector.<ISerializable>;
+		private var testVector:Vector.<Serializable>;
 		private var deserializedVector:Vector.<*>;
 		private var serializedObject:*;
 		private var dummy:SerializationDummy;
@@ -37,7 +37,7 @@ package classes.internals
 		public function setUp():void
 		{
 			testObject = null;
-			testVector = new Vector.<ISerializable>();
+			testVector = new Vector.<Serializable>();
 			deserializedVector = new Vector.<*>();
 			
 			serializedObject = [];
@@ -216,10 +216,10 @@ package classes.internals
 	}
 }
 
-import classes.internals.ISerializable;
+import classes.internals.Serializable;
 import flash.errors.IllegalOperationError;
 
-class SerializationDummy implements ISerializable
+class SerializationDummy implements Serializable
 {
 	public var foo:int;
 	private var bar:int;


### PR DESCRIPTION
Cleaning up interface related code.

- Remove AMF serialization (never worked correctly, to avoid confusion)
- Remove `I` prefix from Interfaces
- Renamed `IRandomNumber` to `RandomNumberGenerator`
- Renamed `RandomNumber` to `ActionScriptRNG`