### PR TITLE
Bugfix for impregnating Edryn

### DIFF
--- a/classes/classes/Scenes/Places/TelAdre/Edryn.as
+++ b/classes/classes/Scenes/Places/TelAdre/Edryn.as
@@ -1202,9 +1202,9 @@ private function postEdrynEatOutRut():void {
 	outputText("When Edryn and you wake, your genitals are so sore and sensitive that getting cleaned up is almost painful.  The centauress even goes so far as to comment that she'll have to pay someone to mop up the mess, but there's a proud twinkle in her eye.  Somehow, your [armor] got splattered with vaginal juices during the sexcapade, and as you put them back on, [eachCock] regains its familiar hardness.  You chew on your lower lip as you slip out after saying goodbye, rock-hard and smelling totally of Edryn's lust.  A limited applause goes up at your departure, mixed with hooting and catcalls.  What a fuck!");
 	hideUpDown();
 	dynStats("lus", 20+player.lib/5);
-	edrynPregChance();
-	edrynPregChance();
-	edrynPregChance();
+	if (player.statusEffectv1(StatusEffects.Edryn) >= 4) edrynPregChance();
+	if (player.statusEffectv1(StatusEffects.Edryn) >= 4) edrynPregChance();
+	if (player.statusEffectv1(StatusEffects.Edryn) >= 4) edrynPregChance();
 	flags[kFLAGS.TIMES_EATEN_EDRYN_PUSSY_RUT]++;
 	doNext(camp.returnToCampUseFourHours);
 }


### PR DESCRIPTION
One of Edryns sex options allowed the PC to impregnate her while she still charges money, skipping ahead in her sequence and leading to some problems with her later scenes.