### PR TITLE
Fixed Gargoyle nameBox above the text

### DIFF
--- a/classes/classes/Scenes/Explore/Gargoyle.as
+++ b/classes/classes/Scenes/Explore/Gargoyle.as
@@ -124,10 +124,10 @@ private function nameZeGargoyle():void {
 		// Solution? Fuck you for naming your Gargoyle "0".
 		clearOutput();
 		outputText("<b>You must name her.</b>");
+		menu();
 		mainView.promptCharacterName();
 		mainView.nameBox.x = mainView.mainText.x + 5;
 		mainView.nameBox.y = mainView.mainText.y + 3 + mainView.mainText.textHeight;
-		menu();
 		addButton(0,"Next",nameZeGargoyle);
 		return;
 	}


### PR DESCRIPTION
`mainView.mainText.textHeight` requires flushing the output (by calling `menu()` or by calling `output.flush()` to be up to date. Hence, why I've moved that one up. Just below the outputText-call