### PR TITLE
Stare ability revamped

### DIFF
--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -13,6 +13,7 @@
 	import classes.Scenes.Dungeons.Factory.SecretarialSuccubus;
 	import classes.Scenes.NPCs.Kiha;
 	import classes.Scenes.Quests.UrtaQuest.MilkySuccubus;
+	import classes.StatusEffects.Combat.BasiliskSlowDebuff;
 	import classes.internals.ChainedDrop;
 	import classes.internals.RandomDrop;
 	import classes.internals.Utils;
@@ -1186,6 +1187,25 @@
 					store = game.combat.doDamage(store);
 					if (plural) outputText(capitalA + short + " bleed profusely from the jagged wounds your weapon left behind. <b>(<font color=\"#800000\">" + store + "</font>)</b>\n\n");
 					else outputText(capitalA + short + " bleeds profusely from the jagged wounds your weapon left behind. <b>(<font color=\"#800000\">" + store + "</font>)</b>\n\n");
+				}
+			}
+			if (hasStatusEffect(StatusEffects.BasiliskCompulsion) && spe > 1) {
+				var oldSpeed:Number = spe;
+				var speedDiff:Number = 0;
+				var bse:BasiliskSlowDebuff = createOrFindStatusEffect(StatusEffects.BasiliskSlow) as BasiliskSlowDebuff;
+				bse.applyEffect(statusEffectv1(StatusEffects.BasiliskCompulsion));
+				speedDiff = Math.round(oldSpeed - spe);
+				if (plural) {
+					outputText(capitalA + short + "  still feel the spell of those grey eyes, making " + pronoun3 + " movements slow and difficult,"
+					          +" the remembered words tempting " + pronoun2 + " to look into your eyes again. "
+					          + Pronoun1 + " need to finish this fight as fast as " + pronoun3 + "  heavy limbs will allow."
+					          +" <b>(<font color=\"#800000\">" + Math.round(speedDiff) + "</font>)</b>\n\n");
+				} else {
+					outputText(capitalA + short + "  still feels the spell of those grey eyes, making " + pronoun3 + " movements slow and difficult,"
+					          +" the remembered words tempting " + pronoun2 + " to look into your eyes again. "
+					          + Pronoun1 + " needs to finish this fight as fast as " + pronoun3 + "  heavy limbs will allow."
+					          +" <b>(<font color=\"#800000\">" + Math.round(speedDiff) + "</font>)</b>\n\n");
+
 				}
 			}
 			if (hasStatusEffect(StatusEffects.OnFire)) {

--- a/classes/classes/Scenes/Areas/HighMountains/Basilisk.as
+++ b/classes/classes/Scenes/Areas/HighMountains/Basilisk.as
@@ -2,8 +2,8 @@ package classes.Scenes.Areas.HighMountains
 {
 	import classes.*;
 	import classes.BodyParts.*;
-import classes.StatusEffects.Combat.BasiliskSlowDebuff;
-import classes.internals.ChainedAction;
+	import classes.Scenes.Monsters.StareMonster;
+	import classes.internals.ChainedAction;
 	import classes.internals.ChainedDrop;
 	import classes.GlobalFlags.*
 	
@@ -11,14 +11,8 @@ import classes.internals.ChainedAction;
 	 * ...
 	 * @author ...
 	 */
-	public class Basilisk extends Monster 
+	public class Basilisk extends StareMonster 
 	{
-
-		public static function speedReduce(player:Player,amount:Number = 0):void {
-			var bse:BasiliskSlowDebuff = player.createOrFindStatusEffect(StatusEffects.BasiliskSlow) as BasiliskSlowDebuff;
-			bse.applyEffect(amount);
-		}
-
 		//special 1: basilisk mental compulsion attack
 		//(Check vs. Intelligence/Sensitivity, loss = recurrent speed loss each
 		//round, one time lust increase):
@@ -34,7 +28,7 @@ import classes.internals.ChainedAction;
 					outputText("You can't help yourself... you glimpse the reptile's grey, slit eyes. You look away quickly, but you can picture them in your mind's eye, staring in at your thoughts, making you feel sluggish and unable to coordinate. Something about the helplessness of it feels so good... you can't banish the feeling that really, you want to look in the basilisk's eyes forever, for it to have total control over you.");
 					game.dynStats("lus", 3);
 					//apply status here
-					speedReduce(player,20);
+					speedReduce(player, 20);
 					player.createStatusEffect(StatusEffects.BasiliskCompulsion,0,0,0,0);
 					flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] += 2;
 				}

--- a/classes/classes/Scenes/Areas/HighMountains/BasiliskScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/BasiliskScene.as
@@ -7,6 +7,7 @@ package classes.Scenes.Areas.HighMountains
 	import classes.BodyParts.*;
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Scenes.Monsters.StareMonster;
 	import classes.display.SpriteDb;
 	import classes.internals.*;
 
@@ -46,7 +47,7 @@ package classes.Scenes.Areas.HighMountains
 				}
 				var basilisk:Basilisk = new Basilisk();
 				//(spd loss)
-				Basilisk.speedReduce(player,5);
+				StareMonster.speedReduce(player, 5);
 				flags[kFLAGS.TIMES_ENCOUNTERED_BASILISK]++;
 				startCombat(basilisk);
 			}

--- a/classes/classes/Scenes/Areas/HighMountains/Cockatrice.as
+++ b/classes/classes/Scenes/Areas/HighMountains/Cockatrice.as
@@ -3,6 +3,7 @@ package classes.Scenes.Areas.HighMountains
 	import classes.*;
 	import classes.BodyParts.*;
 	import classes.BodyParts.Hips;
+	import classes.Scenes.Monsters.StareMonster;
 	import classes.internals.WeightedAction;
 	import classes.internals.WeightedDrop;
 	import classes.GlobalFlags.*
@@ -11,7 +12,7 @@ package classes.Scenes.Areas.HighMountains
 	 * ...
 	 * @author ...
 	 */
-	public class Cockatrice extends Monster 
+	public class Cockatrice extends StareMonster 
 	{
 		public var spellCostCompulsion:int = 20;
 		public var spellCostTailSwipe:int  = 25;
@@ -52,7 +53,7 @@ package classes.Scenes.Areas.HighMountains
 					          +" you want to look in the cockatrice’s eyes forever, for it to have total control over you.");
 					player.takeLustDamage(3, true);
 					//apply status here
-					Basilisk.speedReduce(player,20);
+					speedReduce(player, 20);
 					player.createStatusEffect(StatusEffects.BasiliskCompulsion,0,0,0,0);
 					flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] += 2;
 				}
@@ -140,7 +141,7 @@ package classes.Scenes.Areas.HighMountains
 				.add(eAttack,    20);
 
 			if (!player.hasStatusEffect(StatusEffects.BasiliskCompulsion) && !hasStatusEffect(StatusEffects.Blind))
-				actionChoices.add(compulsion, 40);
+				actionChoices.add(compulsion, 65);
 
 			actionChoices.exec();
 		}

--- a/classes/classes/Scenes/Areas/HighMountains/Cockatrice.as
+++ b/classes/classes/Scenes/Areas/HighMountains/Cockatrice.as
@@ -152,6 +152,12 @@ package classes.Scenes.Areas.HighMountains
 
 		override public function won(hpVictory:Boolean, pcCameWorms:Boolean):void
 		{
+			clearOutput();
+			if (hpVictory) {
+				player.HP = 1;
+				outputText("Your wounds are too great to bear, and you fall unconscious.");
+			}
+
 			if (pcCameWorms) {
 				outputText("\n\nThe cockatrice smirks, but waits for you to finish...");
 				doNext(game.combat.endLustLoss);

--- a/classes/classes/Scenes/Areas/HighMountains/CockatriceScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/CockatriceScene.as
@@ -593,7 +593,7 @@ package classes.Scenes.Areas.HighMountains {
 		public function cockatriceLossAnal():void {
 			clearOutput();
 			credits.authorText = "MissBlackthorne";
-			outputText("You fall to the ground [if (hp < 1)utterly exhausted|too aroused to continue]. "
+			outputText("You fall to the ground [if (hp <= 1)utterly exhausted|too aroused to continue]. "
 			          +"The Cockatrice, knowing that he’s won, approaches you slowly, eyes roving over your body hungrily. "
 			          +"[if (hasArmor) He makes short work of your [armor], tossing it aside with little care.] "
 			          +"With a sudden lunge he pins you to the ground, your wrists held under his scaled hands and your [if (isNaga)coils trapped beneath|[if (isGoo)mound trapped beneath|legs spread around]] his curved hips. "
@@ -625,7 +625,7 @@ package classes.Scenes.Areas.HighMountains {
 		public function cockatriceLossVaginal():void {
 			clearOutput();
 			credits.authorText = "MissBlackthorne";
-			outputText("You fall to the ground [if (hp < 1)utterly exhausted|too aroused to continue]. "
+			outputText("You fall to the ground [if (hp <= 1)utterly exhausted|too aroused to continue]. "
 			          +"The Cockatrice, knowing that he’s won, approaches you slowly, eyes roving over your body hungrily. "
 			          +"[if (hasArmor)He makes short work of your [armor], tossing it aside with little care.] "
 			          +"With a sudden lunge he pins you to the ground, your wrists held under his scaled hands and your [if (isNaga)coils trapped beneath|[if (isGoo)mound trapped beneath|legs spread around]] his curved hips. "
@@ -694,7 +694,7 @@ package classes.Scenes.Areas.HighMountains {
 		public function cockatriceLossOral():void {
 			clearOutput();
 			credits.authorText = "MissBlackthorne";
-			outputText("You fall to the ground [if (hp < 1)utterly exhausted|too aroused to continue]. "
+			outputText("You fall to the ground [if (hp <= 1)utterly exhausted|too aroused to continue]. "
 			          +"The cockatrice stalks over to you, eyeing you up as he strokes his rapidly emerging cock. "
 			          +"His casual approach has you mesmerised, such calm confidence something you didn't expect from the  hyperactive reptile. "
 			          +"He cups your chin, looking into your eyes, letting you get lost in that electric blue gaze as he gently hums. "

--- a/classes/classes/Scenes/Areas/HighMountains/CockatriceScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/CockatriceScene.as
@@ -5,6 +5,7 @@ package classes.Scenes.Areas.HighMountains {
 	import classes.*;
 	import classes.GlobalFlags.kFLAGS;
 	import classes.Items.ArmorLib;
+	import classes.Scenes.Monsters.StareMonster;
 	import classes.lists.BreastCup;
 
 	public class CockatriceScene extends BaseContent {
@@ -50,7 +51,7 @@ package classes.Scenes.Areas.HighMountains {
 				          +"It jumps from rock to rock with ease, quickly closing in on you with a squawking shout. "
 				          +"You ready your [weapon] as the creature shows no sign of slowing. Looks like you have a fight on your hands!");
 				//(spd loss)
-				Basilisk.speedReduce(player, 5);
+				StareMonster.speedReduce(player, 5);
 			}
 			else { //Standard encounter:
 				if (rand(100) < 40) //40% chance of wings

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1,25 +1,25 @@
 ﻿//Combat 2.0
 package classes.Scenes.Combat 
 {
-import classes.*;
-import classes.BodyParts.*;
-import classes.GlobalFlags.*;
-import classes.Items.*;
-import classes.Scenes.Areas.Desert.*;
-import classes.Scenes.Areas.Forest.*;
-import classes.Scenes.Areas.GlacialRift.*;
-import classes.Scenes.Areas.HighMountains.*;
-import classes.Scenes.Areas.Mountain.*;
-import classes.Scenes.Dungeons.HelDungeon.*;
-import classes.Scenes.Dungeons.LethicesKeep.*;
-import classes.Scenes.Monsters.*;
-import classes.Scenes.NPCs.*;
-import classes.Scenes.Places.TelAdre.UmasShop;
-import classes.display.SpriteDb;
+	import classes.*;
+	import classes.BodyParts.*;
+	import classes.GlobalFlags.*;
+	import classes.Items.*;
+	import classes.Scenes.Areas.Desert.*;
+	import classes.Scenes.Areas.Forest.*;
+	import classes.Scenes.Areas.GlacialRift.*;
+	import classes.Scenes.Areas.HighMountains.*;
+	import classes.Scenes.Areas.Mountain.*;
+	import classes.Scenes.Dungeons.HelDungeon.*;
+	import classes.Scenes.Dungeons.LethicesKeep.*;
+	import classes.Scenes.Monsters.*;
+	import classes.Scenes.NPCs.*;
+	import classes.Scenes.Places.TelAdre.UmasShop;
+	import classes.display.SpriteDb;
 
-import coc.view.MainView;
+	import coc.view.MainView;
 
-public class Combat extends BaseContent
+	public class Combat extends BaseContent
 	{
 		public function Combat() {}
 		
@@ -748,7 +748,7 @@ public class Combat extends BaseContent
 				//basilisk counter attack (block attack, significant speed loss): 
 				else if (player.inte / 5 + rand(20) < 25) {
 					outputText("Holding the basilisk in your peripheral vision, you charge forward to strike it.  Before the moment of impact, the reptile shifts its posture, dodging and flowing backward skillfully with your movements, trying to make eye contact with you. You find yourself staring directly into the basilisk's face!  Quickly you snap your eyes shut and recoil backwards, swinging madly at the lizard to force it back, but the damage has been done; you can see the terrible grey eyes behind your closed lids, and you feel a great weight settle on your bones as it becomes harder to move.");
-					Basilisk.speedReduce(player,20);
+					StareMonster.speedReduce(player,20);
 					player.removeStatusEffect(StatusEffects.FirstAttack);
 					combatRoundOver();
 					flags[kFLAGS.BASILISK_RESISTANCE_TRACKER] += 2;
@@ -1474,7 +1474,7 @@ public class Combat extends BaseContent
 			}
 			//Basilisk compulsion
 			if (player.hasStatusEffect(StatusEffects.BasiliskCompulsion)) {
-				Basilisk.speedReduce(player,15);
+				StareMonster.speedReduce(player,15);
 				//Continuing effect text: 
 				outputText("<b>You still feel the spell of those grey eyes, making your movements slow and difficult, the remembered words tempting you to look into its eyes again. You need to finish this fight as fast as your heavy limbs will allow.</b>\n\n");
 				flags[kFLAGS.BASILISK_RESISTANCE_TRACKER]++;
@@ -2040,7 +2040,7 @@ public class Combat extends BaseContent
 					return true;
 				}
 			}
-			if ((monster is Basilisk || monster is Cockatrice) && player.spe <= 1) {
+			if (monster is StareMonster && player.spe <= 1) {
 				doNext(endHpLoss);
 				return true;
 			}

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -2040,7 +2040,7 @@ public class Combat extends BaseContent
 					return true;
 				}
 			}
-			if (monster.short == "basilisk" && player.spe <= 1) {
+			if ((monster is Basilisk || monster is Cockatrice) && player.spe <= 1) {
 				doNext(endHpLoss);
 				return true;
 			}

--- a/classes/classes/Scenes/Monsters/StareMonster.as
+++ b/classes/classes/Scenes/Monsters/StareMonster.as
@@ -1,0 +1,19 @@
+package classes.Scenes.Monsters 
+{
+	import classes.*;
+	import classes.StatusEffects.Combat.BasiliskSlowDebuff;
+
+	/**
+	 * Class to categorize monsters with the stare ability
+	 * @since  27.02.2018
+	 * @author Stadler76
+	 */
+	public class StareMonster extends Monster
+	{
+		public static function speedReduce(player:Player, amount:Number = 0):void
+		{
+			var bse:BasiliskSlowDebuff = player.createOrFindStatusEffect(StatusEffects.BasiliskSlow) as BasiliskSlowDebuff;
+			bse.applyEffect(amount);
+		}
+	}
+}

--- a/classes/classes/StatusEffects/Combat/BasiliskSlowDebuff.as
+++ b/classes/classes/StatusEffects/Combat/BasiliskSlowDebuff.as
@@ -2,7 +2,6 @@ package classes.StatusEffects.Combat {
 import classes.StatusEffectType;
 
 public class BasiliskSlowDebuff extends CombatBuff {
-	public var count:int = 0;
 	public static const TYPE:StatusEffectType = register("BasiliskSlow",BasiliskSlowDebuff);
 	public function BasiliskSlowDebuff() {
 		super(TYPE,'spe');
@@ -10,7 +9,6 @@ public class BasiliskSlowDebuff extends CombatBuff {
 
 	public function applyEffect(amount:Number):void {
 		buffHost('spe', -amount, 'scale', false, 'max', false);
-		count++;
 	}
 }
 


### PR DESCRIPTION
### Gamplay changes
- Stare now works the same as the stare ability the basilisks and cockatrices in the mountains may put on you. Initially it applies -16 to -24 speed on success and then the compulsion reduces the monsters speed each round by another 75% of the initial amount.
- Added speed loss to cockatrices, meaning: If their compulsion  (stare afteraffect) reduces your speed down to 1 you'll suffer an auto HP-loss
- Fixed losing by HP to a cockatrice
- Made it more likely for cockatrices to use their paralyzing stare attack at the player (1/3 chance, like basilisks)

### Internal changes
Implemented `classes.Scenes.Monsters.StareMonster` (category-class for Bassys and Cockatrices)
Currently they share the 'compulsion' aftereffect and the auto-loss, if your speed is reduced to 1 during battle.