### PR TITLE
Engine core cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
  
 script:
     # this is where the build happens. A separate build is started for every entry in the matrix element
-  - ant test-$BUILD
+  - travis_wait ant test-$BUILD
   - devTools/ci/update-sonar-version.sh
 
 after_success:

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -321,7 +321,7 @@
 
 		protected function HPChange(changeNum:Number,display:Boolean):void
 		{
-			kGAMECLASS.HPChange(changeNum,display);
+			player.HPChange(changeNum,display);
 		}
 		
 		protected function playerMenu():void { 

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -318,11 +318,6 @@
 		{
 			return kGAMECLASS.silly();
 		}
-
-		protected function HPChange(changeNum:Number,display:Boolean):void
-		{
-			player.HPChange(changeNum,display);
-		}
 		
 		protected function playerMenu():void { 
 			kGAMECLASS.mainMenu.hideMainMenu();

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -134,7 +134,7 @@ package classes {
 				player.level = 1;
 				player.gems = flags[kFLAGS.NEW_GAME_PLUS_BONUS_STORED_ITEMS];
 			}
-			player.HP = player.maxHP();
+			player.restoreHP();
 			player.hair.length = 5;
 			player.skin.type = Skin.PLAIN;
 			player.underBody.restore();
@@ -899,7 +899,7 @@ package classes {
 			addButton(1, "No", chooseEndowment);
 		}
 
-		private function setEndowment(choice:PerkType):void {
+		protected function setEndowment(choice:PerkType):void {
 			switch(choice) {
 				//Attribute-specific
 				case PerkLib.Strong:
@@ -913,7 +913,7 @@ package classes {
 					player.tone += 5;
 					player.thickness += 5;
 					player.createPerk(PerkLib.Tough, 0.25, 0, 0, 0);
-					player.HP = kGAMECLASS.maxHP();
+					player.restoreHP();
 					break;
 				case PerkLib.Fast:
 					player.spe += 5;

--- a/classes/classes/CharSpecial.as
+++ b/classes/classes/CharSpecial.as
@@ -24,6 +24,11 @@ package classes
 		public static const NAVORN_NAME: String = "Navorn";
 		public static const LUKAZ_NAME: String = "Lukaz";
 		public static const MARA_NAME: String = "Mara";
+		public static const LEAH_NAME:String = "Leah"; 
+		public static const NIXI_NAME:String = "Nixi"; 
+		public static const VAHDUNBRII_NAME:String = "Vahdunbrii"; 
+		public static const ETIS_NAME:String = "Etis"; 
+		public static const CHIMERA_NAME:String = "Chimera"; 
 		
 		
 		public function CharSpecial() {}
@@ -49,23 +54,23 @@ package classes
 			[ "Annetta", customAnnetta, true, "You're a rather well-endowed hermaphrodite that sports a thick, dog-knotted cock, an unused pussy, and a nice, stretchy butt-hole.  You've also got horns and demonic high-heels on your feet.  It makes you wonder why you would ever get chosen to be champion!" ],
 			[ "Ceveo", customCeveo, true, "As a wandering mage you had found your way into no small amount of trouble in the search for knowledge." ],
 			[ "Charlie", customCharlie, true, "You're strong, smart, fast, and tough.  It also helps that you've got four dongs well beyond what others have lurking in their trousers.  With your wings, bow, weapon, and tough armor, you're a natural for protecting the town." ],
-			[ "Chimera", customChimera, true, "Your body is wrecked by your own experiments with otherworldly transformation items, and now you have no more money to buy any more from smugglers... But you would make your body as strong as your will. Or die trying." ],
-			[ "Etis", customEtis, true, "Kitsune-dragon hybrid with 3 tentacle cocks, tentacle hair, tentacle (well, draconic) tongue and very strong magic affinity." ],
+			[ CHIMERA_NAME, customChimera, true, "Your body is wrecked by your own experiments with otherworldly transformation items, and now you have no more money to buy any more from smugglers... But you would make your body as strong as your will. Or die trying." ],
+			[ ETIS_NAME, customEtis, true, "Kitsune-dragon hybrid with 3 tentacle cocks, tentacle hair, tentacle (well, draconic) tongue and very strong magic affinity." ],
 			[ "Isaac", customIsaac, true, "Born of a disgraced priestess, Isaac was raised alone until she was taken by illness.  He worked a number of odd jobs until he was eventually chosen as champion." ],
 			//[ "Kitteh6660", customKitteh6660, true, "" ],
-			[ "Leah", customLeah, true, "No Notes Available." ],
+			[ LEAH_NAME, customLeah, true, "No Notes Available." ],
 			[ LUKAZ_NAME, customLukaz, true, "No Notes Available." ],
 			[ MARA_NAME, customMara, true, "You're a bunny-girl with bimbo-tier curves, jiggly and soft, a curvy, wet girl with a bit of a flirty past." ],
 			[ "Mihari", customMihari, true, "The portal is not something you fear, not with your imposing armor and inscribed spellblade.  You're much faster and stronger than every champion that came before you, but will it be enough?" ],
 			[ MIRVANNA_NAME, customMirvanna, true, "You're an equine dragon-herm with a rather well-proportioned body.  Ingnam is certainly going to miss having you whoring yourself out around town.  You don't think they'll miss cleaning up all the messy sex, though." ],
 			[ "Nami", customNami, true, "Your exotic appearance caused you some trouble growing up, but you buried your nose in books until it came time to go through the portal." ],
-			[ "Nixi", customNixi, true, "As a German-Shepherd morph, the rest of the village never really knew what to do with you... until they sent you through the portal to face whatever's on the other side..." ],
+			[ NIXI_NAME, customNixi, true, "As a German-Shepherd morph, the rest of the village never really knew what to do with you... until they sent you through the portal to face whatever's on the other side..." ],
 			[ "Prismere", customPrismere, true, "You're more of a scout than a fighter, but you still feel confident you can handle your responsibilities as champion.  After all, what's to worry about when you can outrun everything you encounter?  You have olive skin, deep red hair, and a demonic tail and wings to blend in with the locals." ],
 			[ "Rann Rayla", customRannRayla, true, "You're a young, fiery redhead who\'s utterly feminine.  You've got C-cup breasts and long red hair.  Being a champion can\'t be that bad, right?" ],
 			[ "Sera", customSera, true, "You're something of a shemale - three rows of C-cup breasts matched with three, plump, juicy cocks.  Some decent sized balls, bat wings, and cat-like ears round out the package." ],
 			[ "Siveen", customSiveen, true, "You are a literal angel from beyond, and you take the place of a vilage's champion for your own reasons..." ],
 			[ "Tyriana", customTyriana, true, "Your many, posh tits, incredible fertility, and well-used cunt made you more popular than the village bicycle.  With your cat-like ears, paws, and tail, you certainly had a feline appeal.  It's time to see how you fare in the next chapter of your life." ],
-			[ "Vahdunbrii", customVahdunbrii, true, "You're something of a powerhouse, and you wager that between your odd mutations, power strong enough to threaten the village order, and talents, you're the natural choice to send through the portal." ],
+			[ VAHDUNBRII_NAME, customVahdunbrii, true, "You're something of a powerhouse, and you wager that between your odd mutations, power strong enough to threaten the village order, and talents, you're the natural choice to send through the portal." ],
 		]
 		
 		private function customAnnetta():void {
@@ -557,7 +562,7 @@ package classes
 			player.lib = 15;
 			player.cor = 0;
 			getGame().saves.notes = "No Notes Available.";
-			player.HP = kGAMECLASS.maxHP();
+			player.restoreHP();
 			player.hair.length=13;
 			player.skin.type = Skin.PLAIN;
 			player.face.type = Face.HUMAN;
@@ -637,7 +642,7 @@ package classes
 			player.lib = 15;
 			player.cor = 0;
 			getGame().saves.notes = "No Notes Available.";
-			player.HP = kGAMECLASS.maxHP();
+			player.restoreHP();
 			player.hair.length = 1;
 			player.skin.type = Skin.PLAIN;
 			player.skin.tone = "light";
@@ -1024,7 +1029,7 @@ package classes
 			player.lib = 15;
 			player.cor = 0;
 			getGame().saves.notes = "No Notes Available.";
-			player.HP = kGAMECLASS.maxHP();
+			player.restoreHP();
 			
 			player.skin.type = Skin.PLAIN;
 			player.face.type = Face.HUMAN;
@@ -1261,7 +1266,7 @@ package classes
 			player.lib = 30;
 			player.cor = 71;
 			getGame().saves.notes = "Cheater!";
-			player.HP = kGAMECLASS.maxHP();
+			player.restoreHP();
 			player.hair.length = 10;
 			player.skin.type = Skin.PLAIN;
 			player.face.type = Face.HUMAN;
@@ -1471,7 +1476,7 @@ package classes
 			player.lib = 15;
 			player.cor = 0;
 			getGame().saves.notes = "No Notes Available.";
-			player.HP = kGAMECLASS.maxHP();
+			player.restoreHP();
 			player.hair.length = 10;
 			player.skin.type = Skin.PLAIN;
 			player.face.type = Face.HUMAN;
@@ -1689,7 +1694,7 @@ package classes
 			
 			player.hoursSinceCum = 0;
 			player.fatigue = 0;
-			player.HP = kGAMECLASS.maxHP();
+			player.restoreHP();
 			
 			player.gems += 20;
 			
@@ -1933,7 +1938,7 @@ package classes
 
 			player.hoursSinceCum = 0;
 			player.fatigue = 0;
-			player.HP = kGAMECLASS.maxHP();
+			player.restoreHP();
 
 			player.gems += 15+ rand(55);
 			

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -3950,6 +3950,23 @@ package classes
 			if (max > 9999) max = 9999;
 			return max;
 		}
+		
+		/**
+		 * Restore the HP of the creature.
+		 * @param amount the amount to heal. If omitted, heal to max HP. Value must not be negative.
+		 */
+		public function restoreHP(amount:Number = Number.MAX_VALUE): void {
+			if (amount < 0) {
+				throw new RangeError("Value must not be negative");
+			}
+			
+			HP += amount;
+			
+			if (HP > maxHP()) {
+				HP = maxHP();
+			}
+		}
+
 		public function maxLust():Number
 		{
 			var max:Number = 100;

--- a/classes/classes/Items/Consumables/AkbalSaliva.as
+++ b/classes/classes/Items/Consumables/AkbalSaliva.as
@@ -13,7 +13,7 @@ package classes.Items.Consumables
 		override public function useItem():Boolean
 		{
 			outputText("You uncork the vial and chug down the saliva.  ");
-			game.HPChange((player.maxHP() / 4), true);
+			player.HPChange((player.maxHP() / 4), true);
 			player.refillHunger(5);
 			
 			return false;

--- a/classes/classes/Items/Consumables/BehemothCum.as
+++ b/classes/classes/Items/Consumables/BehemothCum.as
@@ -16,7 +16,7 @@ package classes.Items.Consumables
 			clearOutput();
 			outputText("You uncork the bottle and drink the behemoth cum; it tastes great and by the time you've finished drinking, you feel a bit stronger. ");
 			dynStats("str", 0.5, "tou", 0.5, "lus", 5 + (player.cor / 5));
-			game.HPChange(Math.round(player.maxHP() * .25), true);
+			player.HPChange(Math.round(player.maxHP() * .25), true);
 			player.slimeFeed();
 			player.refillHunger(25);
 			player.orgasm('Lips',false);

--- a/classes/classes/Items/Consumables/BodyLotion.as
+++ b/classes/classes/Items/Consumables/BodyLotion.as
@@ -55,7 +55,7 @@ package classes.Items.Consumables
 		public function lotionSkin():void {
 			if (game.player.skin.adj == _adj) {
 				outputText("You " + game.player.clothedOrNaked("take a second to disrobe before uncorking the flask of lotion and rubbing", "uncork the flask of lotion and rub") + " the " + liquidDesc() + " across your body. Once you’ve finished you feel reinvigorated. ");
-				game.HPChange(10, true);
+				player.HPChange(10, true);
 			}
 			else {
 				if ([Skin.GOO, Skin.DRAGON_SCALES].indexOf(game.player.skin.type) == -1) { //If skin is goo or dragon scales, don't change.
@@ -138,7 +138,7 @@ package classes.Items.Consumables
 		public function lotionUnderBodySkin():void {
 			if (game.player.underBody.skin.adj == _adj) {
 				outputText("You " + game.player.clothedOrNaked("take a second to disrobe before uncorking the flask of lotion and rubbing", "uncork the flask of lotion and rub") + " the " + liquidDesc() + " across your underbody. Once you’ve finished you feel reinvigorated. ");
-				game.HPChange(10, true);
+				player.HPChange(10, true);
 			}
 			else {
 				if (game.player.underBody.skin.type != Skin.GOO) { //If skin is goo, don't change.

--- a/classes/classes/Items/Consumables/BroBrew.as
+++ b/classes/classes/Items/Consumables/BroBrew.as
@@ -76,7 +76,7 @@ package classes.Items.Consumables
 			if (player.findPerk(PerkLib.BroBody) >= 0 || player.findPerk(PerkLib.FutaForm) >= 0) {
 				outputText("You crack open the can and guzzle it in a hurry.  Goddamn, this shit is the best.  As you crush the can against your forehead, you wonder if you can find a six-pack of it somewhere?\n\n");
 				player.changeFatigue(-33);
-				game.HPChange(100, true);
+				player.HPChange(100, true);
 				player.refillHunger(30);
 				return false;
 			}

--- a/classes/classes/Items/Consumables/CaninePepper.as
+++ b/classes/classes/Items/Consumables/CaninePepper.as
@@ -743,7 +743,7 @@ package classes.Items.Consumables
 			//If no changes yay
 			if (changes == 0) {
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n");
-				getGame().HPChange(20, true);
+				player.HPChange(20, true);
 				dynStats("lus", 3);
 			}
 			player.refillHunger(15);

--- a/classes/classes/Items/Consumables/Ectoplasm.as
+++ b/classes/classes/Items/Consumables/Ectoplasm.as
@@ -106,7 +106,7 @@ package classes.Items.Consumables
 			//Effect Script 8: 100% chance of healing
 			if (changes === 0) {
 				outputText("You feel strangely refreshed, as if you just gobbled down a bottle of sunshine.  A smile graces your lips as vitality fills you.  ");
-				game.HPChange(player.level * 5 + 10, true);
+				player.HPChange(player.level * 5 + 10, true);
 				//[removed:1.4.10]//changes++;
 			}
 			//Incorporeality Perk Text:  You seem to have inherited some of the spiritual powers of the residents of the afterlife!  While you wouldn't consider doing it for long due to its instability, you can temporarily become incorporeal for the sake of taking over enemies and giving them a taste of ghostly libido.

--- a/classes/classes/Items/Consumables/Equinum.as
+++ b/classes/classes/Items/Consumables/Equinum.as
@@ -517,7 +517,7 @@ package classes.Items.Consumables
 			//FAILSAFE CHANGE
 			if (changes === 0) {
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n");
-				game.HPChange(20, true);
+				player.HPChange(20, true);
 				dynStats("lus", 3);
 			}
 			player.refillHunger(15);

--- a/classes/classes/Items/Consumables/FishFillet.as
+++ b/classes/classes/Items/Consumables/FishFillet.as
@@ -24,7 +24,7 @@ package classes.Items.Consumables
 			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 2) dynStats("cor", 0.5);
 			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) dynStats("cor", -0.1);
 			dynStats("cor", 0.1);
-			game.HPChange(Math.round(player.maxHP() * .25), true);
+			player.HPChange(Math.round(player.maxHP() * .25), true);
 			player.refillHunger(30);
 			
 			return false;

--- a/classes/classes/Items/Consumables/GodMead.as
+++ b/classes/classes/Items/Consumables/GodMead.as
@@ -25,7 +25,7 @@ package classes.Items.Consumables
 			dynStats("lib", 1, "cor", -1);
 			//Health/HP(Large increase; always occurs):
 			outputText("\n\nYou feel suddenly invigorated by the potent beverage, like you could take on a whole horde of barbarians or giants and come out victorious! ");
-			game.HPChange(Math.round(player.maxHP() * .33), true);
+			player.HPChange(Math.round(player.maxHP() * .33), true);
 			if (rand(3) === 0) {
 				outputText("\n\nThe alcohol fills your limbs with vigor, making you feel like you could take on the world with just your fists!");
 				if (game.silly()) outputText("  Maybe you should run around shirtless, drink, and fight!  Saxton Hale would be proud.");

--- a/classes/classes/Items/Consumables/HealPill.as
+++ b/classes/classes/Items/Consumables/HealPill.as
@@ -20,7 +20,7 @@ package classes.Items.Consumables
 			var rand:int = Math.random() * 100;
 			outputText("You pop the small pill into your mouth and swallow. ");
 			
-			if (game.HPChange(50 + player.tou, true)) {
+			if (player.HPChange(50 + player.tou, true)) {
 				outputText("Some of your wounds are healed. ");
 			}
 			else

--- a/classes/classes/Items/Consumables/ImpFood.as
+++ b/classes/classes/Items/Consumables/ImpFood.as
@@ -41,7 +41,7 @@ package classes.Items.Consumables
 					changes++;
 				}
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n");
-				game.HPChange(30 + player.tou / 3, true);
+				player.HPChange(30 + player.tou / 3, true);
 				dynStats("lus", 3, "cor", 1);
 				//Red or orange skin!
 				if (rand(30) === 0 && ColorLists.IMP_SKIN.indexOf(player.skin.tone) === -1) {
@@ -56,7 +56,7 @@ package classes.Items.Consumables
 			else {
 				outputText("The food tastes... corrupt, for lack of a better word.\n");
 				player.refillHunger(20);
-				game.HPChange(20 + player.tou / 3, true);
+				player.HPChange(20 + player.tou / 3, true);
 				dynStats("lus", 3, "cor", 1);
 			}
 			//Red or orange skin!

--- a/classes/classes/Items/Consumables/MarbleMilk.as
+++ b/classes/classes/Items/Consumables/MarbleMilk.as
@@ -47,7 +47,7 @@ package classes.Items.Consumables
 				outputText("You no longer feel the symptoms of withdrawal.\n\n");
 			}
 			//Heals the player 70-100 health
-			game.HPChange(70 + rand(31), true);
+			player.HPChange(70 + rand(31), true);
 			//Restores a portion of fatigue (once implemented)
 			player.changeFatigue(-25);
 			//If the player is addicted, this item negates the withdrawal effects for a few hours (suggest 6), there will need to be a check here to make sure the withdrawal effect doesn't reactivate while the player is under the effect of 'Marble's Milk'.

--- a/classes/classes/Items/Consumables/MinotaurBlood.as
+++ b/classes/classes/Items/Consumables/MinotaurBlood.as
@@ -428,7 +428,7 @@ package classes.Items.Consumables
 					outputText("Your balls feel as if they've grown heavier with the weight of more sperm.\n");
 					player.hoursSinceCum += 200;
 				}
-				game.HPChange(50, true);
+				player.HPChange(50, true);
 				dynStats("lus", 50);
 			}
 			player.refillHunger(25);

--- a/classes/classes/Items/Consumables/ProMead.as
+++ b/classes/classes/Items/Consumables/ProMead.as
@@ -19,7 +19,7 @@ package classes.Items.Consumables
 			outputText("You take a hearty swig of mead, savoring the honeyed taste on your tongue.  Emboldened by the first drink, you chug the remainder of the horn\'s contents in no time flat.  You wipe your lips, satisfied, and let off a small belch as you toss the empty horn aside.");
 			dynStats("lib",1,"cor",-1);
 			outputText("\n\nYou feel suddenly invigorated by the potent beverage, like you could take on a whole horde of barbarians or giants and come out victorious!");
-			game.HPChange(Math.round(player.maxHP()), false);
+			player.HPChange(Math.round(player.maxHP()), false);
 			dynStats("lus=", 20 + rand(6));
 			if(rand(3) === 0) {
 				outputText("\n\nThe alcohol fills your limbs with vigor, making you feel like you could take on the world with just your fists!");

--- a/classes/classes/Items/Consumables/PurityPeach.as
+++ b/classes/classes/Items/Consumables/PurityPeach.as
@@ -16,7 +16,7 @@ package classes.Items.Consumables
 			clearOutput();
 			outputText("You bite into the sweet, juicy peach, feeling a sensation of energy sweeping through your limbs and your mind.  You feel revitalized, refreshed, and somehow cleansed.  ");
 			player.changeFatigue(-15);
-			game.HPChange(Math.round(player.maxHP() * 0.25), true);
+			player.HPChange(Math.round(player.maxHP() * 0.25), true);
 			player.refillHunger(25);	
 			
 			return false;

--- a/classes/classes/Items/Consumables/RedRiverRoot.as
+++ b/classes/classes/Items/Consumables/RedRiverRoot.as
@@ -557,7 +557,7 @@ package classes.Items.Consumables
 				} else {
 					outputText("\n\nDespite how spicy it was, the root was nevertheless nutritious, as you can confirm by feeling how your body feels"
 					          +" now much more invigorated.\n");
-					game.HPChange(250, true);
+					player.HPChange(250, true);
 					dynStats("lus", 3);
 				}
 			}

--- a/classes/classes/Items/Consumables/Reptilum.as
+++ b/classes/classes/Items/Consumables/Reptilum.as
@@ -397,7 +397,7 @@ package classes.Items.Consumables
 			//FAILSAFE CHANGE
 			if (changes === 0) {
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n");
-				game.HPChange(50, true);
+				player.HPChange(50, true);
 				dynStats("lus", 3);
 			}
 			player.refillHunger(20);

--- a/classes/classes/Items/Consumables/Salamanderfirewater.as
+++ b/classes/classes/Items/Consumables/Salamanderfirewater.as
@@ -287,7 +287,7 @@ package classes.Items.Consumables
 			//FAILSAFE CHANGE
 			if (changes === 0) {
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n");
-				game.HPChange(100, true);
+				player.HPChange(100, true);
 				dynStats("lus", 5);
 			}
 			player.refillHunger(20);

--- a/classes/classes/Items/Consumables/SpringWater.as
+++ b/classes/classes/Items/Consumables/SpringWater.as
@@ -18,7 +18,7 @@ package classes.Items.Consumables
 			//-30 fatigue, -2 libido, -10 lust]
 			player.changeFatigue(-10);
 			dynStats("lus", -25, "cor", (-3 - rand(2)), "scale", false);
-			game.HPChange(20 + (5 * player.level) + rand(5 * player.level), true);
+			player.HPChange(20 + (5 * player.level) + rand(5 * player.level), true);
 			player.refillHunger(10);
  			if (player.cor > 50) dynStats("cor", -1);
  			if (player.cor > 75) dynStats("cor", -1);

--- a/classes/classes/Items/Consumables/TonOTrice.as
+++ b/classes/classes/Items/Consumables/TonOTrice.as
@@ -588,7 +588,7 @@ package classes.Items.Consumables
 			//FAILSAFE CHANGE
 			if (changes == 0) {
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n");
-				game.HPChange(50, true);
+				player.HPChange(50, true);
 				dynStats("lus", 3);
 			}
 

--- a/classes/classes/Items/Consumables/TrailMix.as
+++ b/classes/classes/Items/Consumables/TrailMix.as
@@ -18,7 +18,7 @@ package classes.Items.Consumables
 			outputText("You eat the trail mix. You got energy boost from it!");
 			player.refillHunger(30);
 			player.changeFatigue(-20);
-			game.HPChange(Math.round(player.maxHP() * 0.1), true);
+			player.HPChange(Math.round(player.maxHP() * 0.1), true);
 			
 			return false;
 		}

--- a/classes/classes/Items/Consumables/UrtaCum.as
+++ b/classes/classes/Items/Consumables/UrtaCum.as
@@ -16,7 +16,7 @@ package classes.Items.Consumables
 			clearOutput();
 			outputText("You uncork the bottle and drink the vulpine cum; it tastes great. Urta definitely produces good-tasting cum!");
 			dynStats("sens", 1, "lus", 5 + (player.cor / 5));
-			game.HPChange(Math.round(player.maxHP() * .25), true);
+			player.HPChange(Math.round(player.maxHP() * .25), true);
 			player.slimeFeed();
 			player.refillHunger(25);
 			player.orgasm('Lips',false);

--- a/classes/classes/Items/Consumables/VitalityTincture.as
+++ b/classes/classes/Items/Consumables/VitalityTincture.as
@@ -38,7 +38,7 @@ package classes.Items.Consumables
 			//tou change
 			game.dynStats("tou", temp);
 			//Chance of fitness change
-			if (game.HPChange(50, false)) {
+			if (player.HPChange(50, false)) {
 				outputText("  Any aches, pains and bruises you have suffered no longer hurt and you feel much better.");
 			}
 			

--- a/classes/classes/Items/Consumables/WhiskerFruit.as
+++ b/classes/classes/Items/Consumables/WhiskerFruit.as
@@ -319,7 +319,7 @@ package classes.Items.Consumables
 			//FAILSAFE CHANGE
 			if (changes === 0) {
 				outputText("\n\nInhuman vitality spreads through your body, invigorating you!\n");
-				game.HPChange(50, true);
+				player.HPChange(50, true);
 				dynStats("lus", 3);
 			}
 			if (changes < changeLimit) {

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -262,7 +262,7 @@ package classes.Items
 			//(Healing – if hurt and uber-addicted (hasperk))
 			if (player.HP < player.maxHP() && player.hasPerk(PerkLib.MinotaurCumAddict)) {
 				outputText("\n\nThe fire of your arousal consumes your body, leaving vitality in its wake.  You feel much better!");
-				HPChange(int(player.maxHP() / 4), false);
+				player.HPChange(int(player.maxHP() / 4), false);
 			}
 			//Uber-addicted status!
 			if (player.hasPerk(PerkLib.MinotaurCumAddict) && flags[kFLAGS.MINOTAUR_CUM_REALLY_ADDICTED_STATE] <= 0 && !purified) {

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -595,7 +595,7 @@
 			// we return "1 damage received" if it is in (0..1) but deduce no HP
 			var returnDamage:int = (damage>0 && damage<1)?1:damage;
 			if (damage>0){
-				//game.HPChange(-damage, display);
+				//player.HPChange(-damage, display);
 				HP -= damage;
 				if (display) game.output.text(game.combat.getDamageText(damage));
 				game.mainView.statsView.showStatDown('hp');

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -42,7 +42,7 @@
 			itemSlots = [itemSlot1, itemSlot2, itemSlot3, itemSlot4, itemSlot5, itemSlot6, itemSlot7, itemSlot8, itemSlot9, itemSlot10];
 		}
 		
-		protected final function outputText(text:String):void
+		protected function outputText(text:String):void
 		{
 			game.outputText(text);
 		}
@@ -3369,6 +3369,101 @@
 		override public function set fatigue(value:Number):void {
 			super.fatigue = value;
 			game.mainView.statsView.refreshStats(game);
+		}
+		
+		/**
+		 * Alters player's HP.
+		 * @param	changeNum The amount to damage (negative) or heal (positive).
+		 * @param	display Show the damage or heal taken.
+		 * @return  effective delta
+		 */
+		public function HPChange(changeNum:Number, display:Boolean):Number
+		{
+			var before:Number = HP;
+			
+			if (changeNum === 0) {
+				return 0;
+			}
+			
+			if (changeNum > 0) {
+				if (findPerk(PerkLib.HistoryHealer) >= 0) {
+					changeNum *= 1.2; //Increase by 20%!
+				}
+				
+				if (armor.name === "skimpy nurse's outfit") {
+					changeNum *= 1.1; //Increase by 10%!
+				}
+				
+				if (HP + int(changeNum) > maxHP()) {
+					if (HP >= maxHP()) {
+						if (display) {
+							HPChangeNotify(changeNum);
+						}
+						
+						return HP - before;
+					}
+					
+					if (display) {
+						HPChangeNotify(changeNum);
+					}
+					
+					HP = maxHP();
+				}
+				else
+				{
+					if (display) {
+						HPChangeNotify(changeNum);
+					}
+					
+					HP += int(changeNum);
+					kGAMECLASS.mainView.statsView.showStatUp( 'hp' );
+					// hpUp.visible = true;
+				}
+			}
+			//Negative HP
+			else
+			{
+				if (HP + changeNum <= 0) {
+					if (display) {
+						HPChangeNotify(changeNum);
+					}
+					
+					HP = 0;
+					kGAMECLASS.mainView.statsView.showStatDown( 'hp' );
+				}
+				else {
+					if (display) {
+						HPChangeNotify(changeNum);
+					}
+					
+					HP += changeNum;
+					kGAMECLASS.mainView.statsView.showStatDown( 'hp' );
+				}
+			}
+			
+			dynStats("lust", 0, "scale", false); //Workaround to showing the arrow.
+			kGAMECLASS.statScreenRefresh();
+			return HP - before;
+		}
+
+		public function HPChangeNotify(changeNum:Number):void {
+			if (changeNum === 0) {
+				if (HP >= maxHP()) {
+					outputText("You're as healthy as you can be.\n");
+				}
+			} else if (changeNum > 0) {
+				if (HP >= maxHP()) {
+					outputText("Your HP maxes out at " + maxHP() + ".\n");
+				} else {
+					outputText("You gain <b><font color=\"#008000\">" + int(changeNum) + "</font></b> HP.\n");
+				}
+			} else {
+				if (HP <= 0) {
+					outputText("You take <b><font color=\"#800000\">" + int(changeNum*-1) + "</font></b> damage, dropping your HP to 0.\n");
+				} else {
+					outputText("You take <b><font color=\"#800000\">" + int(changeNum*-1) + "</font></b> damage.\n");
+				}
+			}
 		}
 	}
 }

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -3417,7 +3417,6 @@
 					
 					HP += int(changeNum);
 					kGAMECLASS.mainView.statsView.showStatUp( 'hp' );
-					// hpUp.visible = true;
 				}
 			}
 			//Negative HP

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -3407,7 +3407,7 @@
 						HPChangeNotify(changeNum);
 					}
 					
-					HP = maxHP();
+					restoreHP();
 				}
 				else
 				{

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -1004,7 +1004,7 @@ package classes
 			if (perk.ptype == PerkLib.StrongBack2) player.itemSlot5.unlocked = true;
 			if (perk.ptype == PerkLib.StrongBack) player.itemSlot4.unlocked = true;
 			if (perk.ptype == PerkLib.Tank2) {
-				HPChange(player.tou, false);
+				player.HPChange(player.tou, false);
 				statScreenRefresh();
 			}
 			doNext(playerMenu);

--- a/classes/classes/Scenes/Areas/Forest/PlantGirlScene.as
+++ b/classes/classes/Scenes/Areas/Forest/PlantGirlScene.as
@@ -1000,7 +1000,7 @@ package classes.Scenes.Areas.Forest
 			//(V & D 1.1inj. end, If wounded/Injured during the fight): 
 			if (player.HP < hpMax()) {
 				outputText("Upon returning to camp, you notice that some of the wounds the plant creature kissed have actually healed.  You're not sure how exactly this worked, but at least you don't have to put up with too many cut and bruises now.");
-				HPChange(50);
+				player.HPChange(50);
 			}
 			player.orgasm('Generic');
 			dynStats("sen", -1);

--- a/classes/classes/Scenes/Areas/HighMountains/MinervaPurification.as
+++ b/classes/classes/Scenes/Areas/HighMountains/MinervaPurification.as
@@ -1623,7 +1623,7 @@ package classes.Scenes.Areas.HighMountains
 			player.refillHunger(100);
 			player.changeFatigue(-100);
 			outputText(" ");
-			HPChange(player.maxHP(), true)
+			player.HPChange(player.maxHP(), true)
 			outputText("\nWith you fed and rested, the golden broodmother helps you to your feet, despite all the sleep you got; your legs are still a bit wobbly. Thankfully Minerva helps you steady yourself. \"< i > My goodness, are you alright? I guess you're not quite recovered are you, are you sure you don't want to rest more? < / i >\" the gentle maternal herm asks you, knowing that you must get back to your important work soon.");
 
 			outputText("\n\nDespite the feeling in your legs you nod your head in affirmation, while it would be nice to rest you have much to do, demons to slay, damsels to save from said demons. Smiling at the strong front you give, Minerva pulls you into a hug. \"<i>That's my strong hero, so brave, so strong. I just know you will save this world and soon there will be some more sirens in the world that will help make things a bit brighter.</i>\" she says with a bright proud grin on her face as she helps you walk, just to make sure you're alright.");

--- a/classes/classes/Scenes/Areas/VolcanicCrag/BehemothScene.as
+++ b/classes/classes/Scenes/Areas/VolcanicCrag/BehemothScene.as
@@ -214,7 +214,7 @@ package classes.Scenes.Areas.VolcanicCrag
 			kGAMECLASS.inCombat = false;
 			if (doSFWloss()) {
 				outputText("\n\n\"<i>Heh, guess I won,</i>\" he says. \"<i>I'll take care of you until you recover, but in exchange ....</i>\"\n\n He rifles through your pouch, taking " + gemsLost + " gems before picking you up.  You black out ....");
-				HPChange(player.maxHP() / 2, false);
+				player.HPChange(player.maxHP() / 2, false);
 				player.changeFatigue(-50);
 				return;
 			}
@@ -355,10 +355,10 @@ package classes.Scenes.Areas.VolcanicCrag
 			outputText("You wake up some time later and kiss his cheek before letting him know you'll be going.  \"<i>See you later,</i>\" he says as he lets you up, though he doesn't bother getting up. The main thing you remember as " + player.clothedOrNaked("he watches you redress and ") + "you walk back to your camp is his expression of utter contentment, and your mood carries on for the rest of the day.");
 			player.orgasm('Anal');
 			player.slimeFeed();
-			HPChange(player.maxHP() / 4, false);
+			player.HPChange(player.maxHP() / 4, false);
 			flags[kFLAGS.BEHEMOTH_ANAL_CATCH]++;
 			dynStats("str", 0.5, "tou", 0.5);
-			HPChange(50 + (player.maxHP() / 5), false);
+			player.HPChange(50 + (player.maxHP() / 5), false);
 			if (kGAMECLASS.inCombat) combat.cleanupAfterCombat();
 			else doNext(camp.returnToCampUseOneHour);
 		}
@@ -389,7 +389,7 @@ package classes.Scenes.Areas.VolcanicCrag
 			if (flags[kFLAGS.BEHEMOTH_CHILDREN] < 3 && player.isPureEnough(25)) player.knockUp(PregnancyStore.PREGNANCY_BEHEMOTH, PregnancyStore.INCUBATION_BEHEMOTH, 50 + (flags[kFLAGS.BEHEMOTH_CHILDREN] * 15) + player.cor);
 			flags[kFLAGS.BEHEMOTH_VAGINAL_CATCH]++;
 			dynStats("str", 0.5, "tou", 0.5);
-			HPChange(50 + (player.maxHP() / 5), false);
+			player.HPChange(50 + (player.maxHP() / 5), false);
 			if (kGAMECLASS.inCombat) combat.cleanupAfterCombat();
 			else doNext(camp.returnToCampUseOneHour);
 		}
@@ -447,7 +447,7 @@ package classes.Scenes.Areas.VolcanicCrag
 			outputText("\n\n<b>One hour later...</b>");
 			outputText("\n\nYou get out of the cum-filled basin and " + (player.isGoo() ? "absorb the cum into your gooey body": "shake the excessive cum off") + " before " + player.clothedOrNaked("getting yourself re-dressed into your [armor] and") + " rustling the behemoth's hair.  \"<i>See you later. Come back anytime for more fun,</i>\" the behemoth says. You give him a final kiss before you make your way back to camp, already feeling a lot better.");
 			flags[kFLAGS.BEHEMOTH_CUM_BATH]++;
-			HPChange(player.maxHP() / 2, false);
+			player.HPChange(player.maxHP() / 2, false);
 			player.changeFatigue(-50);
 			if (player.armor == armors.GOOARMR) kGAMECLASS.valeria.feedValeria(100);
 			dynStats("str", 0.5, "tou", 0.5, "lus", 30);

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -62,7 +62,7 @@ private function doCamp():void { //only called by playerMenu
 		return;
 	}
 	if (player.hasStatusEffect(StatusEffects.PostAnemoneBeatdown)) {
-		HPChange(Math.round(player.maxHP()/2),false);
+		player.HPChange(Math.round(player.maxHP()/2),false);
 		player.removeStatusEffect(StatusEffects.PostAnemoneBeatdown);
 	}
 	flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID] = ""; //clear out Izma's saved loot status
@@ -1311,7 +1311,7 @@ public function rest():void {
 		if (flags[kFLAGS.SHIFT_KEY_DOWN] > 0) { //rest until fully healed, midnight or hunger wake
 			while (player.HP < player.maxHP() || player.fatigue > 0) {
 				timeQ += 1;
-				HPChange(hpRecovery * multiplier, false); //no display since it is meant to be full rest anyway
+				player.HPChange(hpRecovery * multiplier, false); //no display since it is meant to be full rest anyway
 				player.changeFatigue( -fatRecovery * multiplier); 
 				if (timeQ + getGame().time.hours == 24 || flags[kFLAGS.HUNGER_ENABLED] > 0 && player.hunger < 5) break;
 			}
@@ -1320,7 +1320,7 @@ public function rest():void {
 		}
 		else {
 			timeQ = Math.min(4, 21 - getGame().time.hours);
-			HPChange(timeQ * hpRecovery * multiplier, false);
+			player.HPChange(timeQ * hpRecovery * multiplier, false);
 			player.changeFatigue(timeQ * -fatRecovery * multiplier); 
 		}
 		if (flags[kFLAGS.CAMP_BUILT_CABIN] > 0 && flags[kFLAGS.CAMP_CABIN_FURNITURE_BED] > 0 && !prison.inPrison && !ingnam.inIngnam) {
@@ -1575,7 +1575,7 @@ public function sleepRecovery(display:Boolean = false):void {
 		outputText("\nThe desire to find the bee girl that gave you this cursed " + player.cockDescript(0) + " and have her spread honey all over it grows with each passing minute\n");
 	if (player.armor == armors.GOOARMR && flags[kFLAGS.VALERIA_FLUIDS] <= 0) //Starved goo armor
 		outputText("\nYou feel the fluid-starved goo rubbing all over your groin as if Valeria wants you to feed her.\n");
-	HPChange(timeQ * hpRecovery * multiplier, display); //REGULAR HP/FATIGUE RECOVERY
+	player.HPChange(timeQ * hpRecovery * multiplier, display); //REGULAR HP/FATIGUE RECOVERY
 	player.changeFatigue(-(timeQ * fatRecovery * multiplier)); //Fatigue
 }
 //Bad End if your balls are too big. Only happens in Realistic Mode

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -1341,7 +1341,7 @@ public function rest():void {
 			outputText("\nYou feel the fluid-starved goo rubbing all over your groin as if Valeria wants you to feed her.\n");
 		if (flags[kFLAGS.HUNGER_ENABLED] > 0 && player.hunger < 25) //hungry
 			outputText("\nYou have difficulty resting as you toss and turn with your stomach growling.\n");
-		kGAMECLASS.HPChangeNotify(player.HP - hpBefore);
+		player.HPChangeNotify(player.HP - hpBefore);
 	}
 	else {
 		clearOutput();

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1726,7 +1726,7 @@ package classes.Scenes.Combat
 				if (player.armor == armors.GOOARMR) healingPercent += (getGame().valeria.valeriaFluidsEnabled() ? (flags[kFLAGS.VALERIA_FLUIDS] < 50 ? flags[kFLAGS.VALERIA_FLUIDS] / 25 : 2) : 2);
 				if (player.jewelry.effectId == JewelryLib.MODIFIER_REGENERATION) healingBonus += player.jewelry.effectMagnitude;
 				if (healingPercent > 5) healingPercent = 5;
-				HPChange(Math.round(player.maxHP() * healingPercent / 100) + healingBonus, false);
+				player.HPChange(Math.round(player.maxHP() * healingPercent / 100) + healingBonus, false);
 			}
 			else {
 				//Regeneration
@@ -1740,7 +1740,7 @@ package classes.Scenes.Combat
 				if (player.armorName == "goo armor") healingPercent += (getGame().valeria.valeriaFluidsEnabled() ? (flags[kFLAGS.VALERIA_FLUIDS] < 50 ? flags[kFLAGS.VALERIA_FLUIDS] / 16 : 3) : 3);
 				if (player.findPerk(PerkLib.LustyRegeneration) >= 0) healingPercent += 2;
 				if (healingPercent > 10) healingPercent = 10;
-				HPChange(Math.round(player.maxHP() * healingPercent / 100), false);
+				player.HPChange(Math.round(player.maxHP() * healingPercent / 100), false);
 			}
 		}
 		

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -430,7 +430,7 @@ package classes.Scenes.Combat
 			else {
 				temp = int((player.level + (player.inte / 1.5) + rand(player.inte)) * player.spellMod());
 				outputText("You flush with success as your wounds begin to knit. ");
-				HPChange(temp, true);
+				player.HPChange(temp, true);
 			}
 			
 			outputText("\n\n");
@@ -689,7 +689,7 @@ package classes.Scenes.Combat
 			clearOutput();
 			outputText("You gather energy in your Talisman and unleash the spell contained within.  A green aura washes over you and your wounds begin to close quickly. By the time the aura fully fades, you feel much better. ");
 			var temp:int = ((player.level * 5) + (player.inte / 1.5) + rand(player.inte)) * player.spellMod() * 1.5;
-			HPChange(temp, true);
+			player.HPChange(temp, true);
 			getGame().arianScene.clearTalisman();
 			monster.doAI();
 		}

--- a/classes/classes/Scenes/Dungeons/DesertCave.as
+++ b/classes/classes/Scenes/Dungeons/DesertCave.as
@@ -3934,7 +3934,7 @@ package classes.Scenes.Dungeons
 			clearOutput();
 			outputText("You allow the girl to continue for a long, long while until your entire body feels deeply refreshed, her milk having soaked into your body and making you feel fresh and revitalized. You start to thank the milk girl for the pleasurable company, but when you open your mouth, she slips into your arms and presses her lips to yours.  Chuckling to yourself, you hold the girl as tight against yourself as her udders will allow, turning her to the side to let her nuzzle her cheek into your [chest], kissing the top of her head before the two of you climb from the pool.  You have to help her out, her massive extra weight nearly dragging her back in except for your quick reflexes.  You gather your [armor] and ruffle the milk slave's hair before turning back to the task at hand.");
 			//[+Lust, +HP, -Fatigue]
-			HPChange(player.maxHP()*.33,false);
+			player.HPChange(player.maxHP()*.33,false);
 			player.changeFatigue(-20);
 			doNext(playerMenu);
 		}

--- a/classes/classes/Scenes/Dungeons/Factory.as
+++ b/classes/classes/Scenes/Dungeons/Factory.as
@@ -154,7 +154,7 @@ package classes.Scenes.Dungeons {
 			outputText(images.showImage("item-coffee"));
 			outputText("You take a sip of the rich creamy coffee and suddenly feel refreshed. As you replace the coffeepot, the busty coffee-maker comes to life, grabbing her thick dusky nipples and squeezing out a trickle of scaldingly hot liquid. You can see her eyes roll up into her head from what you assume to be pleasure as she automatically refills the missing coffee, mouth open with ecstasy.  Her movements gradually slow as she quivers almost imperceptibly. A contented smile graces her features as immobility overtakes her, freezing her back in place.  You wonder if 'Mrs. Coffee' was created, or a victim of this place's dark master.");
 			dynStats("lus", 1);
-			HPChange(35, false);
+			player.HPChange(35, false);
 			player.refillHunger(10);
 			doNext(roomBreakRoom);
 		}

--- a/classes/classes/Scenes/Dungeons/HelDungeon.as
+++ b/classes/classes/Scenes/Dungeons/HelDungeon.as
@@ -333,7 +333,7 @@ package classes.Scenes.Dungeons
 				outputText("\n\nSore, you pick yourself up off the floor and wipe a bit of gooey residue off your gear.  To your surprise, you feel rather invigorated after the battle, and rolling your shoulders, you turn your attention back to the dungeon ahead.");
 			}
 			//(PC regains HP)
-			HPChange(1000,false);
+			player.HPChange(1000,false);
 			player.orgasm('Generic');
 			dynStats("lib", 1, "sen", 3);
 			combat.cleanupAfterCombat();
@@ -374,7 +374,7 @@ package classes.Scenes.Dungeons
 			if (flags[kFLAGS.VALERIA_FOUND_IN_GLACIAL_RIFT] == 0) {
 				outputText("You tell her to fuck off -- you don't need armor that might try to kill or rape you at night.");
 				outputText("\n\nShe huffs indignantly and scrambles to her feet.  \"<i>Well fine, and fuck you anyway.  I hope you get raped by harpies, " + player.mf("sir","madam") + ".</i>\"  After a moment, she hesitantly adds, \"<i>But if you change your mind later... Well, we'll see if you live through this place without me!</i>\"  Before you can stop her, she ducks out the front door and off to... Wherever goo-armor-girl-things would go, you guess.  Still, to your surprise, you feel rather invigorated after the battle, and rolling your shoulders, you turn your attention back to the dungeon ahead.");
-				HPChange(1000,false);
+				player.HPChange(1000,false);
 				combat.cleanupAfterCombat();
 				doNext(playerMenu);
 			}
@@ -382,7 +382,7 @@ package classes.Scenes.Dungeons
 			else {
 				outputText("You tell her to fuck off -- you don't need armor that might try to kill or rape you at night.");
 				outputText("\n\nShe huffs indignantly and scrambles to her feet.  \"<i>Well fine, and fuck you anyway.  I hope you get raped by jotuns, " + player.mf("sir","madam") + ".</i>\"  After a moment, she hesitantly adds, \"<i>But if you change your mind later... Well, I guess I’ll be around here!</i>\"  Before you can stop her, she huffs off to... wherever goo-armor-girl-things would go, you guess.  You make your way back to your camp.");
-				HPChange(player.maxHP(),false);
+				player.HPChange(player.maxHP(),false);
 				combat.cleanupAfterCombat();
 				doNext(camp.returnToCampUseOneHour);
 			}
@@ -402,7 +402,7 @@ package classes.Scenes.Dungeons
 				outputText("You tell her that... no thanks, not now -- you don't need armor right now.");
 				outputText("\n\nShe huffs indignantly and scrambles to her feet.  \"<i>Well fine, maybe you can take me later, " + player.mf("sir", "madam") + "?</i>\"  After a moment, she hesitantly adds, \"<i>But if you change your mind later... You know where to find me, right?</i>\"  You give her a nod as you make your way back to your camp.");
 			}
-			HPChange(player.maxHP(),false);
+			player.HPChange(player.maxHP(),false);
 			combat.cleanupAfterCombat();
 			doNext(playerMenu);
 		}
@@ -419,7 +419,7 @@ package classes.Scenes.Dungeons
 			//Set flags
 			flags[kFLAGS.MET_VALERIA] = 1;
 			flags[kFLAGS.VALERIA_FLUIDS] = 80;
-			HPChange(player.maxHP(),false);
+			player.HPChange(player.maxHP(),false);
 			flags[kFLAGS.TOOK_GOO_ARMOR] = 1;
 			//(PC regains HP)
 			var item:Armor = player.setArmor(armors.GOOARMR); //Item is now the player's old armor

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
@@ -733,7 +733,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 			{
 				temp = temp * 1.2;
 			}
-			game.HPChange(temp,false);
+			player.HPChange(temp,false);
 			beginPhase3(true);
 		}
 		

--- a/classes/classes/Scenes/Masturbation.as
+++ b/classes/classes/Scenes/Masturbation.as
@@ -2473,7 +2473,9 @@ package classes.Scenes {
 			outputText("You find a flat, comfortable " + description + " to sit down on and meditate. As always, meditation brings a sense of peace and calm to you, but it eats up two hours of the day.");
 			
 			dynStats("lus", -50, "cor", -.3 - 0.3 * player.countCockSocks("alabaster"));
-			if (player.findPerk(PerkLib.Enlightened) >= 0 && player.isPureEnough(10)) HPChange(50, true);
+			if (player.findPerk(PerkLib.Enlightened) >= 0 && player.isPureEnough(10)) {
+				player.HPChange(50, true);
+			}
 			player.changeFatigue(-10);
 			
 			doNext(camp.returnToCampUseTwoHours);

--- a/classes/classes/Scenes/NPCs/AnemoneScene.as
+++ b/classes/classes/Scenes/NPCs/AnemoneScene.as
@@ -1346,8 +1346,10 @@ package classes.Scenes.NPCs
 					else outputText("stick");
 					if (flags[kFLAGS.ANEMONE_WEAPON_ID] != weapons.MACE__0.id) outputText(" is still enough to bruise you a bit.");
 					else outputText(" manages to bruise you a lot.");
-					HPChange(-5, false);
-					if (flags[kFLAGS.ANEMONE_WEAPON_ID] == weapons.MACE__0.id) HPChange(-15, false);
+					player.HPChange(-5, false);
+					if (flags[kFLAGS.ANEMONE_WEAPON_ID] == weapons.MACE__0.id) {
+						player.HPChange(-15, false);
+					}
 					kidAXP(6);
 					break;
 				case weapons.RIDING0.id: //[Riding Crop]
@@ -1358,7 +1360,7 @@ package classes.Scenes.NPCs
 					else outputText("isn't");
 					outputText(" enough to keep you from thinking dirty thoughts about grabbing her naughty, teasing face and mashing it into your crotch.");
 					//(HP - 5, lust +5 if lib>=50, KidXP + 2)
-					HPChange(-5, false);
+					player.HPChange(-5, false);
 					if (player.lib >= 50) dynStats("lus", 5, "scale", false);
 					kidAXP(6);
 					break;
@@ -1367,7 +1369,7 @@ package classes.Scenes.NPCs
 				case weapons.L_DAGR2.id:
 					outputText("\n\nThe enchanted dagger is light enough for the anemone to use one-handed, and she makes a good practice of turning aside your mock blows with it while reaching in to stimulate you with her other hand.  For good measure, she nicks you with the blade itself whenever her caress elicits a distracted flush.");
 					//(HP -5, lust +10, KidXP + 3)
-					HPChange(-5, false);
+					player.HPChange(-5, false);
 					dynStats("lus", 10, "scale", false);
 					kidAXP(5);
 					break;
@@ -1376,7 +1378,7 @@ package classes.Scenes.NPCs
 				case weapons.DAGGER2.id:
 					outputText("\n\nThe dagger is light enough for the anemone to use one-handed, and she makes a good practice of turning aside your mock blows with it while reaching in to stimulate you with her other hand.  For good measure, she nicks you with the blade itself whenever her caress elicits a distracted flush.");
 					//(HP -5, lust +5, KidXP + 3)
-					HPChange(-5, false);
+					player.HPChange(-5, false);
 					dynStats("lus", 5, "scale", false);
 					kidAXP(5);
 					break;
@@ -1385,7 +1387,7 @@ package classes.Scenes.NPCs
 					outputText("\n\nThe sword seems to dance in the air, as though it were the perfect weight and balance for your daughter.  She delivers several playful thrusts at you and though you deflect all but the last, that one slips by your guard.  The girl's eyes widen as the point lunges at your breast, but it delivers barely a scratch before twisting away.");
 					outputText("\n\nPerhaps anemones are a bit too corrupt to use the sword effectively?");
 					//(HP -1, KidXP - 2)
-					HPChange(-1, false);
+					player.HPChange(-1, false);
 					kidAXP(-2);
 					break;
 				case weapons.RRAPIER.id: //[Jeweled Rapier] or [Raphael's Rapier] or [Midnight Rapier]
@@ -1407,7 +1409,7 @@ package classes.Scenes.NPCs
 					outputText("\n\nShe can barely lift the weapon you've given her, although for a while she does manage to support one end with the ground and tilt it by the haft to ward off your blows with cleverness.  Distracting her by way of a feint, you part her from it and advance with a smile full of playful menace... whereupon she shrieks and pushes you backwards, causing you to trip over the weapon and fall with a crash.");
 					//(HP - 5, KidXP - 4)
 					kidAXP(-4);
-					HPChange(-5, false);
+					player.HPChange(-5, false);
 					break;
 				case weapons.KATANA0.id: //[Katana], [Scimitar], or [Spellsword]
 				case weapons.KATANA1.id:
@@ -1421,7 +1423,7 @@ package classes.Scenes.NPCs
 					outputText("\n\nThe light sword and the light anemone seem to be a good match, and she actually manages to make several deft moves with it after your instruction.  One is a bit too deft, as she fails to rein in her swing and delivers a long, drawing cut that connects with your [leg].");
 					//(HP - 20, KidXP + 2)
 					kidAXP(4);
-					HPChange(-20, false);
+					player.HPChange(-20, false);
 					break;
 				case weapons.SPEAR_0.id: //[Spear] or [Dragoon Spear]
 				case weapons.SPEAR_1.id:
@@ -1430,7 +1432,7 @@ package classes.Scenes.NPCs
 					outputText("\n\nThe natural length of the spear and the anemone racial mindset to get close and communicate by touch don't mesh well; she chokes up well past halfway on the haft despite your repeated instruction and pokes at you from close range with very little force, the idle end of the weapon waggling through the air behind her.");
 					//(HP -5, KidXP - 1)
 					kidAXP(-1);
-					HPChange(-5, false);
+					player.HPChange(-5, false);
 					break;
 				case weapons.WHIP__0.id: //[Whip] or [Succubi's Whip]
 				case weapons.WHIP__1.id:
@@ -1457,7 +1459,7 @@ package classes.Scenes.NPCs
 				case consumables.W_STICK.id: //[Wingstick]
 					outputText("\n\nThe girl stares at the stick, still uncomprehending how you intend her to use it.  One last time, you take the weapon from her and make a throwing motion, then return it.  She looks from it back to you once more, then tosses it at your head.  As it impacts with a clunk and your vision jars, she clutches her stomach in laughter.");
 					//(HP - 10, set Kidweapon to empty, KidXP + 1)
-					HPChange(-10, false);
+					player.HPChange(-10, false);
 					flags[kFLAGS.ANEMONE_WEAPON_ID] = 0;
 					kidAXP(5);
 					break;
@@ -1512,11 +1514,11 @@ package classes.Scenes.NPCs
 					}
 					else if (dodgeScore >= 40 && dodgeScore < 70) {
 						outputText("You try to dodge the bullets that are coming towards you.  You manage to dodge some but unfortunately, you've got hit.  You see yourself bleeding.  You tell her to stop and she obeys.");
-						HPChange(-10, false);
+						player.HPChange(-10, false);
 					}
 					else {
 						outputText("You try your best to avoid but you're unable to at all.  Anemone stops firing when she sees that you're bleeding and gives you a sheepish grin.");
-						HPChange(-40, false);
+						player.HPChange(-40, false);
 					}
 					kidAXP(5);
 					break;
@@ -1529,11 +1531,11 @@ package classes.Scenes.NPCs
 					}
 					else if (dodgeScore >= 30 && dodgeScore < 60) {
 						outputText("You try to dodge the bolts that are coming towards you.  You manage to dodge some but unfortunately, you've got hit.  You see yourself bleeding.  You tell her to stop and she obeys.");
-						HPChange(-10, false);
+						player.HPChange(-10, false);
 					}
 					else {
 						outputText("You try your best to avoid but you're unable to at all.  Anemone stops firing when she sees that you're bleeding and gives you a sheepish grin.");
-						HPChange(-40, false);
+						player.HPChange(-40, false);
 					}
 					kidAXP(5);
 					break;
@@ -1541,7 +1543,7 @@ package classes.Scenes.NPCs
 				case weapons.FLAIL_1.id:
 				case weapons.FLAIL_2.id:
 					outputText("\n\nThe girl holds up the flail with no problem and you teach her how to use the weapon.  However, after dozens of swings, she accidentally hits herself with the spiked ball and looks at you with a whimper.  You tell her to stop; maybe this isn't the right weapon for her?");
-					HPChange(-10, false);
+					player.HPChange(-10, false);
 					kidAXP(-2);
 					return;
 				default:

--- a/classes/classes/Scenes/NPCs/ArianScene.as
+++ b/classes/classes/Scenes/NPCs/ArianScene.as
@@ -3045,7 +3045,7 @@ private function giveArianLactaid():void {
 	}
 	else { //Lizard milk! Recover some HP and fatigue.
 		player.changeFatigue(-15);
-		HPChange(player.maxHP() * .2, false);
+		player.HPChange(player.maxHP() * .2, false);
 		outputText("\n\nAfter some time, Arian begins panting, sweating as [Arian eir] body temperature goes up.  \"<i>I feel... hot.</i>\"  In an attempt to lower [Arian eir] body temperature, Arian discards [Arian eir] robes and lays down on [Arian eir] bed, fanning herself with [Arian eir] clawed hands.");
 		
 		outputText("\n\nYou approach [Arian em] cautiously, asking if [Arian ey]'s okay.");

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -2059,7 +2059,7 @@ package classes.Scenes.NPCs
 			if (emberAffection() < 75) dynStats("lus", 20);
 			player.changeFatigue( -50);
 			player.slimeFeed();
-			HPChange(player.maxHP() * .33, false);
+			player.HPChange(player.maxHP() * .33, false);
 			doNext(camp.returnToCampUseOneHour);
 		}
 
@@ -2171,7 +2171,7 @@ package classes.Scenes.NPCs
 				emberAffection(-5);
 			}
 			combat.cleanupAfterCombat();
-			HPChange(player.maxHP() * .33, false);
+			player.HPChange(player.maxHP() * .33, false);
 		}
 
 //[Catch Anal] - a dragon coq up the date (Z)

--- a/classes/classes/Scenes/NPCs/JoyScene.as
+++ b/classes/classes/Scenes/NPCs/JoyScene.as
@@ -1352,7 +1352,7 @@ package classes.Scenes.NPCs
 			if (refillAmount > (120 - player.hunger)) refillAmount = (120 - player.hunger); //Constrain max weight gain to +2.
 			player.refillHunger(refillAmount);
 			player.changeFatigue(-40);
-			HPChange(50 + player.maxHP() / 5, false);
+			player.HPChange(50 + player.maxHP() / 5, false);
 			dynStats("lus", 20 + (player.lib / 5));
 			//Libido reduction
 			dynStats("lib", -1);

--- a/classes/classes/Scenes/NPCs/KihaFollower.as
+++ b/classes/classes/Scenes/NPCs/KihaFollower.as
@@ -235,7 +235,7 @@ private function warnKihaOfHerImpendingDemise():void {
 	//(Proceed to Spider Horde Combat)
 	//Set first round cover
 	monster.createStatusEffect(StatusEffects.MissFirstRound,0,0,0,0);
-	HPChange(100,false);
+	player.HPChange(100,false);
 	player.changeFatigue(-30);
 	dynStats("lus", -40);
 }
@@ -269,7 +269,7 @@ private function helpKihaAgainstSpoidahs():void {
 	//(Proceed to Spider Horde Combat)
 	startCombat(new SpiderMorphMob());
 	//st - say, 100 hp, -30 fatigue, and -40 lust - then have her cover for you for the first few rounds if you lost to her so you can blitz them or heal. -Z)
-	HPChange(100,false);
+	player.HPChange(100,false);
 	player.changeFatigue(-30);
 	dynStats("lus", -40);
 }

--- a/classes/classes/Scenes/NPCs/MarblePurification.as
+++ b/classes/classes/Scenes/NPCs/MarblePurification.as
@@ -1514,7 +1514,7 @@ package classes.Scenes.NPCs {
 			player.refillHunger(30);
 		 	outputText("\n\nFinally, your tender moment with your mate comes to an end, and the last of her milk flows down your throat.  You separate, and a small burp escapes your lips.  Marble giggles at this and tells you to come and see her again whenever you're feeling thirsty.  She should be ready to nurse you again in about four hours.");
 			//Restore 20% of PC's health
-			HPChange(Math.round(player.maxHP()*.2),false);
+			player.HPChange(Math.round(player.maxHP()*.2),false);
 			//Restore 30 fatigue
 			player.changeFatigue(-30);
 			//increase lust by 15

--- a/classes/classes/Scenes/NPCs/MarbleScene.as
+++ b/classes/classes/Scenes/NPCs/MarbleScene.as
@@ -555,7 +555,7 @@ private function apologizetoWalkingTitsIMEANMARBLE():void {
 	//(apply the stat effect 'Marble's Milk' to the player)
 	applyMarblesMilk();
 	dynStats("lib", .2, "lus", (5 + player.lib/10));
-	HPChange(100,false);
+	player.HPChange(100,false);
 	player.changeFatigue(-50);
 	//increase PC lust (5+ lib/10), health (100), and lib (0.2), reduce fatigue by (50)
 	//end event
@@ -856,7 +856,7 @@ private function drinkMarbleMilk():void {
 	marbleStatusChange(5,0);
 	//(apply Marble's Milk status effect)
 	applyMarblesMilk();
-	HPChange(10, false);
+	player.HPChange(10, false);
 	player.refillHunger(20);
 	player.changeFatigue(-20);
 	//(increase player lust by a 20 and libido, if player lust is over a threshold like 60, trigger milk sex scene)

--- a/classes/classes/Scenes/NPCs/MilkWaifu.as
+++ b/classes/classes/Scenes/NPCs/MilkWaifu.as
@@ -437,7 +437,7 @@ private function communalBath():void {
 	outputText("\n\nThe lot of you carry on like this for nearly an hour, enjoying what little relaxation you're able to get in these dark times.  Eventually, though, you know you must return to your duties.  You and your companions one by one pull yourselves out of the pool, stopping to help " + flags[kFLAGS.MILK_NAME] + " and her bloated breasts; towels are passed around between joking and flirting hands, a few are even cracked over bare skin, making girls scream and yelp.  The camp is soon a mess of laughing and playing, with you in the center of it, teasing your lovers between shameless gropes and playful caresses.");
 	player.refillHunger(50);
 	player.changeFatigue(-40);
-	HPChange(player.maxHP()*.33,false);
+	player.HPChange(player.maxHP()*.33,false);
 	doNext(camp.returnToCampUseOneHour);
 }
 
@@ -490,7 +490,7 @@ private function dontFuckTheMilkWaifu():void {
 	outputText("You allow the girl to continue for a long, long while until your entire body feels deeply refreshed, her milk having soaked thoroughly into your body and making you feel fresh and revitalized.  You start to thank the milk girl for the pleasurable company, but when you open your mouth, she slips into your arms and presses her lips to yours.  Chuckling to yourself, you hold the girl as tight against yourself as her udders will allow, turning her to the side to let her nuzzle her cheek into your [chest], kissing the top of her head before the two of you climb from the pool.  You have to help her out, her massive extra weight nearly dragging her back in except for your quick reflexes.  You gather your [armor] and ruffle the milk slave's hair before grabbing a towel and wandering back to the heart of camp.");
 	//[+Lust, +HP, -Fatigue]
 	dynStats("lus", 10+player.sens/10, "scale", false);
-	HPChange(player.maxHP()*.33,false);
+	player.HPChange(player.maxHP()*.33,false);
 	player.changeFatigue(-20);
 	doNext(camp.returnToCampUseOneHour);
 }
@@ -514,7 +514,7 @@ private function fuckTheMilkWaifu():void {
 	outputText("\n\nYour entire body feels deeply refreshed, her milk having soaked thoroughly into your body and making you feel fresh and revitalized, and every muscle seems to have relaxed thanks to your blissful coitus.  You start to thank " + flags[kFLAGS.MILK_NAME] + " for the pleasurable company, but when you open your mouth, she presses her lips to yours for a long, tongue-filled kiss.  Chuckling to yourself, you hold the girl as tight as her udders will allow, turning her to the side to let her nuzzle her cheek into your [chest], kissing the top of her head before the two of you climb from the pool.  You have to help her out, her massive extra weight nearly dragging her back in except for your quick reflexes.  You gather your [armor] and ruffle the milk slave's hair before grabbing a towel and wandering back to the heart of camp.");
 	//[+Lust, +HP, -Fatigue]
 	player.orgasm('Dick');
-	HPChange(player.maxHP()*.33,false);
+	player.HPChange(player.maxHP()*.33,false);
 	doNext(camp.returnToCampUseOneHour);
 }
 
@@ -536,7 +536,7 @@ private function beARugMunchingMilkDyke():void {
 	outputText("\n\nYour entire body feels deeply refreshed, her milk having soaked into your body and making you feel fresh and revitalized, and every muscle seems to have relaxed thanks to your blissful coitus.  You start to thank the milk girl for the pleasurable company, but when you open your mouth, she presses her lips to yours for a long, tongue-filled kiss.  Chuckling to yourself, you hold the girl as tight as her udders will allow, turning her to the side to let her nuzzle her cheek into your [chest], kissing the top of her head before the two of you climb from the pool.  You have to help her out, her massive extra weight nearly dragging her back in except for your quick reflexes.  You gather your [armor] and ruffle the milk slave's hair before grabbing a towel and wandering back to the heart of camp.");
 	//[+Lust, +HP, -Fatigue]
 	player.orgasm('Tits');
-	HPChange(player.maxHP()*.33,false);
+	player.HPChange(player.maxHP()*.33,false);
 	doNext(camp.returnToCampUseOneHour);
 }
 	

--- a/classes/classes/Scenes/NPCs/SheilaScene.as
+++ b/classes/classes/Scenes/NPCs/SheilaScene.as
@@ -637,7 +637,7 @@ private function sheilaReallyMadStandGround():void {
 	if (silly()) {
 		monster.HP *= 1.2;
 		player.changeFatigue(-10);
-		HPChange(20,false);
+		player.HPChange(20,false);
 	}
 }
 
@@ -1240,7 +1240,7 @@ private function shielaXPThreeSexyTimePostSexStayII():void {
 	outputText("\n\nYou nod sagely and get up to dress.  Sheila, or Harriet, does the same, shimmying into her panties and shorts quickly and pulling her top on.  Finished, she drags you off to the night's lodgings anxiously, hat in hand and body language more closely resembling a giddy girl's on her first date than a grizzled, solitary hunter's.");
 	//advance time to 6:00, gain 3 hours rest
 	player.changeFatigue(-20);
-	HPChange(player.maxHP()/2,false);
+	player.HPChange(player.maxHP()/2,false);
 	if (getGame().time.hours > 6) getGame().time.days++;
 	getGame().time.hours = 6;
 	statScreenRefresh();
@@ -5120,7 +5120,7 @@ public function rebellingScarredBlade(wieldAttempt:Boolean = false):void {
 		var dmg:int = 20
 		dmg -= player.armorDef;
 		if (dmg < 1) dmg = 1;
-		HPChange(-dmg, false);
+		player.HPChange(-dmg, false);
 		player.setWeapon(WeaponLib.FISTS);
 		flags[kFLAGS.SCARRED_BLADE_STATUS] = 1;
 	}

--- a/classes/classes/Scenes/NPCs/UrtaPregs.as
+++ b/classes/classes/Scenes/NPCs/UrtaPregs.as
@@ -433,7 +433,7 @@ private function wakeUpWithUrtaAfterStaying():void {
 	statScreenRefresh();
 	player.orgasm('Generic');
 	camp.sleepRecovery(false);
-	HPChange(player.maxHP(), true);
+	player.HPChange(player.maxHP(), true);
 	//PC Wakes with Urta
 	awardAchievement("Getaway", kACHIEVEMENTS.GENERAL_GETAWAY);
 	outputText("As the morning sun shines on the blinds, you open your eyes.  Then you remember the events of the last day.  You spent the whole day with Urta, not having sex, just walking together and buying stuff for your newborn ");

--- a/classes/classes/Scenes/NPCs/Valeria.as
+++ b/classes/classes/Scenes/NPCs/Valeria.as
@@ -277,7 +277,7 @@ public function valeriaGetFucked():void {
 
 	player.orgasm('VaginalAnal');
 	dynStats("sen", -1);
-	HPChange(25 + (player.newGamePlusMod() * 15),false);
+	player.HPChange(25 + (player.newGamePlusMod() * 15),false);
 	doNext(camp.returnToCampUseOneHour);
 }
 
@@ -308,7 +308,7 @@ public function gooFlation(clearText:Boolean = true):void {
 		outputText("and looms over you.  \"<i>That was fun, partner,</i>\" she says, leaning down to give you a wet peck on the cheek. \"<i>Let's do that again soon, alright?</i>\"");
 		player.orgasm('Generic');
 		dynStats("sen", 1);
-		HPChange(25 + (player.newGamePlusMod() * 15),false);
+		player.HPChange(25 + (player.newGamePlusMod() * 15),false);
 		doNext(camp.returnToCampUseOneHour);
 	}
 }
@@ -334,7 +334,7 @@ public function penetrateValeria():void {
 	outputText("\n\nYou run your hand along her curves as she digests her meal, but eventually you know you need to get on with your duties.  You roll Valeria off of you and start to redress.");
 	player.orgasm('Dick');
 	dynStats("sen", 1);
-	HPChange(25 + (player.newGamePlusMod() * 15), false);
+	player.HPChange(25 + (player.newGamePlusMod() * 15), false);
 	feedValeria(Math.sqrt(player.cumQ()) + 5);
 	doNext(camp.returnToCampUseOneHour);
 }
@@ -396,7 +396,7 @@ public function valeriaSexDominated(offCamp:Boolean = false):void {
 		outputText("\n\n\"<i>Oh, that's good... good, " + player.mf("boy","girl") + ", good.  Yes, let it all out, just like that... just like that,</i>\" she moans, soaking your juices up until your orgasm finally passes.  Sated, she withdraws around your foot, leaving you a quivering mess on the ground.");
 		outputText("\n\n\"<i>Mmm, not bad, partner</i>\" Valeria says, patting her full belly.  You can see a bit of your cum swirling around inside her.  \"<i>We'll do this again sometime,</i>\" she adds, walking off to another part of camp with a wink.");
 	}
-	HPChange(25 + (player.newGamePlusMod() * 15), false);
+	player.HPChange(25 + (player.newGamePlusMod() * 15), false);
 	feedValeria(Math.sqrt(player.cumQ()) + 5 + (player.averageVaginalWetness() * 5));
 	player.orgasm('Generic');
 	dynStats("sen", 1);

--- a/classes/classes/Scenes/Places/Ingnam.as
+++ b/classes/classes/Scenes/Places/Ingnam.as
@@ -502,7 +502,7 @@ package classes.Scenes.Places
 			outputText("\"<i>I'd like a glass of milk please,</i>\" you say. You hand over the two gems to the innkeeper and he pours you a glass of milk.");
 			outputText("\n\nYou drink the cup of milk. You feel calm and refreshed. ");
 			player.changeFatigue(-15);
-			HPChange(player.maxHP() / 4, false);
+			player.HPChange(player.maxHP() / 4, false);
 			player.refillHunger(10);
 			cheatTime(1/12);
 			doNext(menuTavern);
@@ -518,7 +518,7 @@ package classes.Scenes.Places
 			outputText("\"<i>I'd like a glass of root beer please,</i>\" you say. You hand over the three gems to the innkeeper and he pours you a glass of root beer.");
 			outputText("\n\nYou drink the cup of root beer. Refreshing! ");
 			player.changeFatigue(-15);
-			HPChange(player.maxHP() / 4, false);
+			player.HPChange(player.maxHP() / 4, false);
 			player.refillHunger(10);
 			cheatTime(1/12);
 			doNext(menuTavern);
@@ -550,7 +550,7 @@ package classes.Scenes.Places
 			player.gems -= 5;
 			outputText("You tell the innkeeper that you would like a sandwich and toss five gems at him. \"<i>Certainly, " + player.mf("sir", "madam") + ",</i>\" he says as he quickly grabs a plate and assembles a sandwich. Hey, it's your favorite type!");
 			outputText("\n\nYou eat the sandwich. Delicious!");
-			HPChange(player.maxHP() / 3, false);
+			player.HPChange(player.maxHP() / 3, false);
 			player.refillHunger(25);
 			cheatTime(1/12);
 			doNext(menuTavern);
@@ -566,7 +566,7 @@ package classes.Scenes.Places
 			player.gems -= 3;
 			outputText("You tell the innkeeper that you would like a bowl of soup and toss three gems at him. \"<i>Certainly, " + player.mf("sir", "madam") + ",</i>\" he says as he grabs a bowl and fills it with steaming soup. Hey, it's your favorite type!");
 			outputText("\n\nYou take one spoonful at a time, blowing to make sure the soup isn't too hot. You eventually finish the soup. Delicious!");
-			HPChange(player.maxHP() / 3, false);
+			player.HPChange(player.maxHP() / 3, false);
 			player.refillHunger(20);
 			cheatTime(1/12);
 			doNext(menuTavern);

--- a/classes/classes/Scenes/Places/Owca.as
+++ b/classes/classes/Scenes/Places/Owca.as
@@ -907,7 +907,7 @@ public function loseToOwca():void {
 	if (player.weaponName != "fists") outputText("your " + player.weaponName + " is taken away and ");
 	outputText("you are being uncomfortably transported to a destination you can guess easily.  Too dazed to resist or even worry about it; you are promptly brought to the dreaded pit, where the villagers tie you up and rudely shackle you.  Then, before you even realize how desperate your situation is, they're all gone.  Your numerous bruises and fatigue get the better of you and you quickly fall asleep.");
 	//redirect to dusk transition text, restore hp/fat consonant with sleeping until nightfall
-	HPChange(50,false);
+	player.HPChange(50,false);
 	player.changeFatigue(-30);
 	//after nightly scene, next encounter is Post-Mob Encounter
 	doNext(loseOrSubmitToVapula);

--- a/classes/classes/Scenes/Places/TelAdre/Niamh.as
+++ b/classes/classes/Scenes/Places/TelAdre/Niamh.as
@@ -277,7 +277,7 @@ public function blackCatBeerEffects(player:Player,clearScreen:Boolean = true,new
 	outputText("\n\nA wonderful warmth fills your body, making your pain fade away.  However, it also makes your crotch tingle - combined with the relaxation imparted already, you feel <b>very</b> turned-on.  A beautiful, warm, fuzzy sensation follows and fills your head, like your brain is being wrapped in cotton wool.  You don't feel quite as smart as before, but that's all right, it feels so nice...");
 	outputText("\n\nYour balance suddenly feels off-kilter and you stumble, narrowly avoiding falling.  You just can't move as fast as you could, not with your head feeling so full of fluff and fuzz; your body prickles and tingles with the warmth once your head feels full, the sensation concentrating around your erogenous zones.  You just feel so fluffy... you want to hold somebody and share your warmth with them, too; it's just so wonderful.");
 	//Regain 40 to 60 lost health, increase lust by 10 to 20 points, decrease Intelligence and Speed by 5, increase Libido by 5//
-	HPChange(40 + rand(21),false);
+	player.HPChange(40 + rand(21),false);
 	var lib:Number = 0;
 	if (player.hasStatusEffect(StatusEffects.BlackCatBeer)) {
 		if (player.getMaxStats('lib') - player.lib >= 10) lib = 10;

--- a/classes/classes/Scenes/Quests/UrtaQuest.as
+++ b/classes/classes/Scenes/Quests/UrtaQuest.as
@@ -1153,7 +1153,7 @@ private function urtaSecondWind():void {
 		return;
 	}
 	monster.createStatusEffect(StatusEffects.UrtaSecondWinded,0,0,0,0);
-	HPChange(Math.round(player.maxHP()/2),false);
+	player.HPChange(Math.round(player.maxHP()/2),false);
 	player.changeFatigue(-50);
 	dynStats("lus", -50);
 	outputText("Closing your eyes for a moment, you focus all of your willpower on pushing yourself to your absolute limits, forcing your lusts down and drawing on reserves of energy you didn't know you had!\n\n");
@@ -2100,7 +2100,7 @@ private function urtaSleepsArmored():void {
 	outputText("\n\nIt takes a while to get back to sleep, but when you do, you sleep comfortably, knowing your armor will protect you.");
 	outputText("\n\nA quick and messy fap in the morning takes care of the tension that built up overnight.  The ground happily drinks away the evidence of your lust.");
 	//{Recover less HP/fatigue or something}
-	HPChange(.5 * player.maxHP(),false);
+	player.HPChange(.5 * player.maxHP(),false);
 	player.changeFatigue(-50);
 	player.orgasm('Dick');
 	menu();
@@ -2111,7 +2111,7 @@ private function urtaSleepsNaked():void {
 	//NOT PLANNED AS A FIGHT
 	clearOutput();
 	outputText("You bed down for the night, languidly removing your armor and stretching in the pale moonlight.  The cool air feels wonderful on your skin, particularly after being bound up in that restricting armor all day.  You yawn and wrap yourself up in a blanket, swifly falling asleep in the soft grasses at the edges of the plains, comforted by the gentle hooting of the owls in the woods to the west.");
-	HPChange(player.maxHP(),false);
+	player.HPChange(player.maxHP(),false);
 	player.changeFatigue(-100);
 	dynStats("lus", 10);
 	menu();

--- a/classes/classes/Scenes/Seasonal/Thanksgiving.as
+++ b/classes/classes/Scenes/Seasonal/Thanksgiving.as
@@ -249,7 +249,7 @@ package classes.Scenes.Seasonal {
 				player.createPerk(PerkLib.Cornucopia,0,0,0,0);
 			}
 			player.changeFatigue(-100); // Fatigue to 0?
-			HPChange(3000,false); //HP set to full
+			player.HPChange(3000,false); //HP set to full
 			doNext(camp.returnToCampUseTwoHours);
 		}
 

--- a/classes/classes/Scenes/Seasonal/XmasJackFrost.as
+++ b/classes/classes/Scenes/Seasonal/XmasJackFrost.as
@@ -135,7 +135,7 @@ package classes.Scenes.Seasonal {
 				outputText("You sigh... this really reminds you of back home... you only wish you had someone to share this feeling with... Well, there is no reason you shouldn't enjoy yourself while it snows, so you set about rolling a big ball of snow to make a snowman out of...");
 				//Skip to next day...
 				flags[kFLAGS.JACK_FROST_PROGRESS] = 0;
-				HPChange(player.maxHP(), false);
+				player.HPChange(player.maxHP(), false);
 				player.changeFatigue(-100);
 				doNext(camp.returnToCampUseEightHours);
 			}
@@ -582,7 +582,7 @@ package classes.Scenes.Seasonal {
 					outputText("You take care of the preparations and cooking, whipping up a delightful meal for you and your companions.  For a moment you look around - this small band you've formed feels enough like a family that you wouldn't mind having more days like this in the future.  You vow to work extra hard to make this a reality.");
 					outputText("\n\nThe feast progresses without a hitch.  You cheer, eat and drink together (though you really don't have any appropriate alcohol for the evening).  As the feast progresses, you notice more than one pair of hungry eyes sizing you up... it seems your day is far from over...");
 				}
-				HPChange(player.maxHP(), false);
+				player.HPChange(player.maxHP(), false);
 				player.hunger = 100;
 				player.changeFatigue(-100);
 				flags[kFLAGS.JACK_FROST_PROGRESS] = 0;

--- a/classes/classes/Scenes/Seasonal/XmasMisc.as
+++ b/classes/classes/Scenes/Seasonal/XmasMisc.as
@@ -547,7 +547,7 @@ package classes.Scenes.Seasonal {
 			clearOutput();
 			outputText("You pull the cork off the gift from the mysterious stranger.  The scent of alluring mint fills your nose once again.  You bring the head of the bottle to your lips and tip it back, the creamy white fluid hits your tongue and slips down your throat.  The liquid is surprisingly refreshing, the creamy mint flavor clings to your tongue and mouth, and makes your breath feel cool as you exhale over your lips.  You can feel the liquid drip down to your stomach and fill you with a pleasant warmth and holiday cheer.\n\n");
 			//Recovers health and fatigue, adds five to max health, and one to libido.*/
-			HPChange(player.maxHP(), true);
+			player.HPChange(player.maxHP(), true);
 			player.changeFatigue(-100);
 		}
 

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -22,10 +22,6 @@ public function HPChange(changeNum:Number, display:Boolean):Number
 	return player.HPChange(changeNum, display);
 }
 
-public function HPChangeNotify(changeNum:Number):void {
-	player.HPChangeNotify(changeNum);
-}
-		
 public function clone(source:Object):* {
 	var copier:ByteArray = new ByteArray();
 	copier.writeObject(source);

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -15,98 +15,15 @@ public function silly():Boolean {
 }
 
 /**
- * Alters player's HP.
- * @param	changeNum The amount to damage (negative) or heal (positive).
- * @param	display Show the damage or heal taken.
- * @return  effective delta
+ * @see Player#HPChange()
  */
 public function HPChange(changeNum:Number, display:Boolean):Number
 {
-	var before:Number = player.HP;
-	
-	if (changeNum === 0) {
-		return 0;
-	}
-	
-	if (changeNum > 0) {
-		if (player.findPerk(PerkLib.HistoryHealer) >= 0) {
-			changeNum *= 1.2; //Increase by 20%!
-		}
-		
-		if (player.armor.name === "skimpy nurse's outfit") {
-			changeNum *= 1.1; //Increase by 10%!
-		}
-		
-		if (player.HP + int(changeNum) > player.maxHP()) {
-			if (player.HP >= player.maxHP()) {
-				if (display) {
-					HPChangeNotify(changeNum);
-				}
-				
-				return player.HP - before;
-			}
-			
-			if (display) {
-				HPChangeNotify(changeNum);
-			}
-			
-			player.HP = player.maxHP();
-		}
-		else
-		{
-			if (display) {
-				HPChangeNotify(changeNum);
-			}
-			
-			player.HP += int(changeNum);
-			mainView.statsView.showStatUp( 'hp' );
-			// hpUp.visible = true;
-		}
-	}
-	//Negative HP
-	else
-	{
-		if (player.HP + changeNum <= 0) {
-			if (display) {
-				HPChangeNotify(changeNum);
-			}
-			
-			player.HP = 0;
-			mainView.statsView.showStatDown( 'hp' );
-		}
-		else {
-			if (display) {
-				HPChangeNotify(changeNum);
-			}
-			
-			player.HP += changeNum;
-			mainView.statsView.showStatDown( 'hp' );
-		}
-	}
-	
-	player.dynStats("lust", 0, "scale", false); //Workaround to showing the arrow.
-	statScreenRefresh();
-	return player.HP - before;
+	return player.HPChange(changeNum, display);
 }
 
 public function HPChangeNotify(changeNum:Number):void {
-	if (changeNum === 0) {
-		if (player.HP >= player.maxHP()) {
-			outputText("You're as healthy as you can be.\n");
-		}
-	} else if (changeNum > 0) {
-		if (player.HP >= player.maxHP()) {
-			outputText("Your HP maxes out at " + player.maxHP() + ".\n");
-		} else {
-			outputText("You gain <b><font color=\"#008000\">" + int(changeNum) + "</font></b> HP.\n");
-		}
-	} else {
-		if (player.HP <= 0) {
-			outputText("You take <b><font color=\"#800000\">" + int(changeNum*-1) + "</font></b> damage, dropping your HP to 0.\n");
-		} else {
-			outputText("You take <b><font color=\"#800000\">" + int(changeNum*-1) + "</font></b> damage.\n");
-		}
-	}
+	player.HPChangeNotify(changeNum);
 }
 		
 public function clone(source:Object):* {

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -14,14 +14,6 @@ public function silly():Boolean {
 	return flags[kFLAGS.SILLY_MODE_ENABLE_FLAG] == 1;
 }
 
-/**
- * @see Player#HPChange()
- */
-public function HPChange(changeNum:Number, display:Boolean):Number
-{
-	return player.HPChange(changeNum, display);
-}
-
 public function clone(source:Object):* {
 	var copier:ByteArray = new ByteArray();
 	copier.writeObject(source);

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -24,7 +24,7 @@ public function HPChange(changeNum:Number, display:Boolean):Number
 {
 	var before:Number = player.HP;
 	
-	if (changeNum == 0) {
+	if (changeNum === 0) {
 		return 0;
 	}
 	
@@ -33,7 +33,7 @@ public function HPChange(changeNum:Number, display:Boolean):Number
 			changeNum *= 1.2; //Increase by 20%!
 		}
 		
-		if (player.armor.name == "skimpy nurse's outfit") {
+		if (player.armor.name === "skimpy nurse's outfit") {
 			changeNum *= 1.1; //Increase by 10%!
 		}
 		
@@ -90,7 +90,7 @@ public function HPChange(changeNum:Number, display:Boolean):Number
 }
 
 public function HPChangeNotify(changeNum:Number):void {
-	if (changeNum == 0) {
+	if (changeNum === 0) {
 		if (player.HP >= player.maxHP())
 			outputText("You're as healthy as you can be.\n");
 	}

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -10,10 +10,6 @@ import classes.internals.profiling.End;
 
 public static const MAX_BUTTON_INDEX:int = 14;
 
-public function maxHP():Number {
-	return player.maxHP();
-}
-
 public function silly():Boolean {
 	return flags[kFLAGS.SILLY_MODE_ENABLE_FLAG] == 1;
 }
@@ -27,21 +23,41 @@ public function silly():Boolean {
 public function HPChange(changeNum:Number, display:Boolean):Number
 {
 	var before:Number = player.HP;
-	if (changeNum == 0) return 0;
+	
+	if (changeNum == 0) {
+		return 0;
+	}
+	
 	if (changeNum > 0) {
-		if (player.findPerk(PerkLib.HistoryHealer) >= 0) changeNum *= 1.2; //Increase by 20%!
-		if (player.armor.name == "skimpy nurse's outfit") changeNum *= 1.1; //Increase by 10%!
-		if (player.HP + int(changeNum) > maxHP()) {
-			if (player.HP >= maxHP()) {
-			if (display) HPChangeNotify(changeNum);
+		if (player.findPerk(PerkLib.HistoryHealer) >= 0) {
+			changeNum *= 1.2; //Increase by 20%!
+		}
+		
+		if (player.armor.name == "skimpy nurse's outfit") {
+			changeNum *= 1.1; //Increase by 10%!
+		}
+		
+		if (player.HP + int(changeNum) > player.maxHP()) {
+			if (player.HP >= player.maxHP()) {
+				if (display) {
+					HPChangeNotify(changeNum);
+				}
+				
 				return player.HP - before;
 			}
-			if (display) HPChangeNotify(changeNum);
-			player.HP = maxHP();
+			
+			if (display) {
+				HPChangeNotify(changeNum);
+			}
+			
+			player.HP = player.maxHP();
 		}
 		else
 		{
-			if (display) HPChangeNotify(changeNum);
+			if (display) {
+				HPChangeNotify(changeNum);
+			}
+			
 			player.HP += int(changeNum);
 			mainView.statsView.showStatUp( 'hp' );
 			// hpUp.visible = true;
@@ -51,16 +67,23 @@ public function HPChange(changeNum:Number, display:Boolean):Number
 	else
 	{
 		if (player.HP + changeNum <= 0) {
-			if (display) HPChangeNotify(changeNum);
+			if (display) {
+				HPChangeNotify(changeNum);
+			}
+			
 			player.HP = 0;
 			mainView.statsView.showStatDown( 'hp' );
 		}
 		else {
-			if (display) HPChangeNotify(changeNum);
+			if (display) {
+				HPChangeNotify(changeNum);
+			}
+			
 			player.HP += changeNum;
 			mainView.statsView.showStatDown( 'hp' );
 		}
 	}
+	
 	player.dynStats("lust", 0, "scale", false); //Workaround to showing the arrow.
 	statScreenRefresh();
 	return player.HP - before;
@@ -68,12 +91,12 @@ public function HPChange(changeNum:Number, display:Boolean):Number
 
 public function HPChangeNotify(changeNum:Number):void {
 	if (changeNum == 0) {
-		if (player.HP >= maxHP())
+		if (player.HP >= player.maxHP())
 			outputText("You're as healthy as you can be.\n");
 	}
 	else if (changeNum > 0) {
-		if (player.HP >= maxHP())
-			outputText("Your HP maxes out at " + maxHP() + ".\n");
+		if (player.HP >= player.maxHP())
+			outputText("Your HP maxes out at " + player.maxHP() + ".\n");
 		else
 			outputText("You gain <b><font color=\"#008000\">" + int(changeNum) + "</font></b> HP.\n");
 	}

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -91,20 +91,21 @@ public function HPChange(changeNum:Number, display:Boolean):Number
 
 public function HPChangeNotify(changeNum:Number):void {
 	if (changeNum === 0) {
-		if (player.HP >= player.maxHP())
+		if (player.HP >= player.maxHP()) {
 			outputText("You're as healthy as you can be.\n");
-	}
-	else if (changeNum > 0) {
-		if (player.HP >= player.maxHP())
+		}
+	} else if (changeNum > 0) {
+		if (player.HP >= player.maxHP()) {
 			outputText("Your HP maxes out at " + player.maxHP() + ".\n");
-		else
+		} else {
 			outputText("You gain <b><font color=\"#008000\">" + int(changeNum) + "</font></b> HP.\n");
-	}
-	else {
-		if (player.HP <= 0)
+		}
+	} else {
+		if (player.HP <= 0) {
 			outputText("You take <b><font color=\"#800000\">" + int(changeNum*-1) + "</font></b> damage, dropping your HP to 0.\n");
-		else
+		} else {
 			outputText("You take <b><font color=\"#800000\">" + int(changeNum*-1) + "</font></b> damage.\n");
+		}
 	}
 }
 		

--- a/test/classes/CharCreationTest.as
+++ b/test/classes/CharCreationTest.as
@@ -86,15 +86,35 @@ package classes{
 			
 			assertThat(player.getClitLength(), equalTo(VaginaClass.DEFAULT_CLIT_LENGTH));
 		}
+		
+		[Test]
+		public function hpSetToMaxHpDuringNewGame(): void {
+			cut.newGameGo();
+			
+			assertThat(kGAMECLASS.player.HP, equalTo(95));
+		}
+		
+		[Test]
+		public function hpSetToMaxUsingToughPerk():void {
+			cut.testSetEndowment(PerkLib.Tough);
+			
+			assertThat(kGAMECLASS.player.HP, equalTo(60));
+		}
     }
 }
 
 import classes.CharCreation;
+import classes.PerkType;
+
 /**
  * This is to allow the testing of functions without making them public in the actual class.
  */
 class CharCreationForTest extends CharCreation {
 	public function testReincarnate():void {
 		reincarnate();
+	}
+	
+	public function testSetEndowment(choice:PerkType):void {
+		setEndowment(choice);
 	}
 }

--- a/test/classes/CharSpecialTest.as
+++ b/test/classes/CharSpecialTest.as
@@ -30,6 +30,12 @@ package classes{
 			return null;
 		}
 		
+		private function createCharByName(name:String):void {
+			var func:Function = findCharFunction(name);
+			
+			func();
+		}
+		
 		[BeforeClass]
 		public static function runOnceForTestClass():void { 
 			kGAMECLASS = new CoC(StageLocator.stage);
@@ -220,6 +226,13 @@ package classes{
 		}
 		
 		[Test]
+		public function leahHpRestored():void {
+			createCharByName(CharSpecial.LEAH_NAME);
+			
+			assertThat(player.HP, equalTo(80));
+		}
+		
+		[Test]
 		public function testKattiBreastFuckable() : void {
 			var func : Function = findCharFunction(CharSpecial.KATTI_NAME);
 			
@@ -291,6 +304,13 @@ package classes{
 			assertThat(player.breastRows[3].nipplesPerBreast, equalTo(4));
 		}
 		
+		[Test]
+		public function nixiHpRestored(): void {
+			createCharByName(CharSpecial.NIXI_NAME);
+			
+			assertThat(player.HP, equalTo(80));
+		}
+		
 				
 		[Test]
 		public function testLukazIsMale() : void {
@@ -302,6 +322,13 @@ package classes{
 		}
 		
 		[Test]
+		public function lukazHPRestored():void {
+			createCharByName(CharSpecial.LUKAZ_NAME);
+			
+			assertThat(player.HP, equalTo(84));
+		}
+		
+		[Test]
 		public function testMaraClitLength() : void {
 			var func : Function = findCharFunction(CharSpecial.MARA_NAME);
 			
@@ -309,5 +336,26 @@ package classes{
 			
 			assertThat(player.getClitLength(), equalTo(0.5));
 		}
-    }
+		
+		[Test]
+		public function vahdunbriiHpRestored(): void {
+			createCharByName(CharSpecial.VAHDUNBRII_NAME);
+			
+			assertThat(player.HP, equalTo(80));
+		}
+		
+		[Test]
+		public function etisHpRestored(): void {
+			createCharByName(CharSpecial.ETIS_NAME);
+			
+			assertThat(player.HP, equalTo(50));
+		}
+		
+		[Test]
+		public function chimeraHpRestored(): void {
+			createCharByName(CharSpecial.CHIMERA_NAME);
+			
+			assertThat(player.HP, equalTo(50));
+		}
+	}
 }

--- a/test/classes/CoCTest.as
+++ b/test/classes/CoCTest.as
@@ -13,32 +13,18 @@ package classes{
 	import classes.helper.StageLocator;
 	import classes.helper.FireButtonEvent;
 	import classes.GlobalFlags.kGAMECLASS;
-	import classes.Items.ArmorLib;
 	
 	public class CoCTest {
-		private static const HP_OVER_HEAL:Number = 1000;
-		private static const PLAYER_MAX_HP:Number = 250;
-		
 		private var cut:CoCForTest;
 		private var fireButton:FireButtonEvent;
-		private var player:DummyPlayer;
+		private var player:Player;
 		
 		[Before]
 		public function runBeforeEveryTest():void {
 			assertThat(StageLocator.stage, not(nullValue()));
 			
 			cut = new CoCForTest(StageLocator.stage);
-			player = new DummyPlayer();
-			cut.player = player;
-			
-			player.createVagina();
-			player.HP = 1;
-			player.tou = 100;
-			
-			// TODO clean up this fugly hack - exctract test into PlayerTest
-			// don't try this at home kids!
-			cut.calls = player.calls;
-			cut.collectedOutput = player.collectedOutput;
+			cut.player.createVagina();
 			
 			fireButton = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
 		}
@@ -66,168 +52,6 @@ package classes{
 			fireButton.fireButtonClick(0); //press 'proceed' button
 			fireButton.fireButtonClick(4); //press 'exit' button
 		}
-		
-		[Test]
-		public function hpChangeZeroNoDelta(): void {
-			assertThat(cut.HPChange(0, false), equalTo(0));
-		}
-		
-		[Test]
-		public function hpChangeHealerBoost(): void {
-			player.createPerk(PerkLib.HistoryHealer, 0, 0, 0, 0);
-			
-			assertThat(cut.HPChange(100, false), equalTo(120));
-		}
-		
-		[Test]
-		public function hpChangeNurseOutfitBoost(): void {
-			player.setArmor(new ArmorLib().NURSECL);
-			
-			assertThat(cut.HPChange(100, false), equalTo(110));
-		}
-		
-		[Test]
-		public function hpChangeOverHeal(): void {
-			assertThat(cut.HPChange(HP_OVER_HEAL, false), equalTo(249));
-		}
-		
-		[Test]
-		public function hpChangeOverHealPlayerHp(): void {
-			cut.HPChange(HP_OVER_HEAL, false);
-			
-			assertThat(player.HP, equalTo(PLAYER_MAX_HP));
-		}
-		
-		[Test]
-		public function hpChangeOverHealDisplayHpChange(): void {
-			cut.HPChange(HP_OVER_HEAL, true);
-			
-			assertThat(cut.calls, arrayWithSize(1));
-			assertThat(cut.calls, hasItem(equalTo(HP_OVER_HEAL)));
-		}
-		
-		[Test]
-		public function hpChangePlayerHpOverMaxDelta(): void {
-			player.HP = HP_OVER_HEAL;
-			
-			assertThat(cut.HPChange(HP_OVER_HEAL, false), equalTo(0));
-		}
-		
-		[Test]
-		public function hpChangePlayerHpOverMaxPlayerHp(): void {
-			player.HP = HP_OVER_HEAL;
-			
-			cut.HPChange(HP_OVER_HEAL, false);
-			
-			assertThat(player.HP, equalTo(1000));
-		}
-		
-		[Test]
-		public function hpChangePlayerHpOverMaxDisplayHpChange(): void {
-			player.HP = HP_OVER_HEAL;
-			
-			cut.HPChange(HP_OVER_HEAL, true);
-			
-			assertThat(cut.calls, arrayWithSize(1));
-			assertThat(cut.calls, hasItem(equalTo(HP_OVER_HEAL)));
-		}
-		
-		[Test]
-		public function hpChangeHealDisplayHpChange(): void {
-			cut.HPChange(1, true);
-			
-			assertThat(cut.calls, arrayWithSize(1));
-			assertThat(cut.calls, hasItem(equalTo(1)));
-		}
-		
-		[Test]
-		public function hpChangeHealPlayerHP(): void {
-			cut.HPChange(1, true);
-			
-			assertThat(player.HP, equalTo(2));
-		}
-		
-		[Test]
-		public function hpChangeDamageDisplayHpChange(): void {
-			player.HP = 50;
-			
-			cut.HPChange(-1, true);
-			
-			assertThat(cut.calls, arrayWithSize(1));
-			assertThat(cut.calls, hasItem(equalTo(-1)));
-		}
-		
-		[Test]
-		public function hpChangeDamagePlayerHp(): void {
-			player.HP = 50;
-			
-			cut.HPChange(-1, false);
-			
-			assertThat(player.HP, equalTo(49));
-		}
-		
-		[Test]
-		public function hpChangeDamageBelowZeroDisplayHpChange(): void {
-			cut.HPChange(-HP_OVER_HEAL, true);
-			
-			assertThat(cut.calls, arrayWithSize(1));
-			assertThat(cut.calls, hasItem(equalTo(-HP_OVER_HEAL)));
-		}
-		
-		[Test]
-		public function hpChangeDamageBelowZeroPlayerHp(): void {
-			cut.HPChange(-HP_OVER_HEAL, false);
-			
-			assertThat(player.HP, equalTo(0));
-		}
-		
-		[Test]
-		public function hpChangeNotifyNoChange(): void {
-			cut.HPChangeNotify(0);
-			
-			assertThat(cut.collectedOutput, emptyArray());
-		}
-		
-		[Test]
-		public function hpChangeNotifyNoChangeOverMaxHp(): void {
-			player.HP = HP_OVER_HEAL;
-			
-			cut.HPChangeNotify(0);
-			
-			assertThat(cut.collectedOutput, hasItem(startsWith("You're as healthy as you can be.")));
-		}
-		
-		[Test]
-		public function hpChangeNotifyHeal(): void {
-			cut.HPChangeNotify(1);
-			
-			assertThat(cut.collectedOutput, hasItem(startsWith("You gain")));
-		}
-		
-		[Test]
-		public function hpChangeNotifyHealOverMaxHp(): void {
-			player.HP = HP_OVER_HEAL;
-			
-			cut.HPChangeNotify(1);
-			
-			assertThat(cut.collectedOutput, hasItem(startsWith("Your HP maxes out at")));
-		}
-		
-		[Test]
-		public function hpChangeNotifyDamage(): void {
-			cut.HPChangeNotify(-1);
-			
-			assertThat(cut.collectedOutput, hasItem(containsString("damage.")));
-		}
-		
-		[Test]
-		public function hpChangeNotifyDamageHpBelowZero(): void {
-			player.HP = -1;
-			
-			cut.HPChangeNotify(-1);
-			
-			assertThat(cut.collectedOutput, hasItem(containsString("damage, dropping your HP to 0.")));
-		}
 	}
 }
 
@@ -241,51 +65,5 @@ class CoCForTest extends CoC {
 	public function CoCForTest(injectedStage:Stage) 
 	{
 		super(injectedStage);
-	}
-	
-	/**
-	 * Intercept calls to HPChangeNotify so we can sense them in tests.
-	 * 
-	 * @param	changeNum the value of the HP change?
-	 */
-	override public function HPChangeNotify(changeNum:Number):void {
-		calls.push(changeNum);
-		super.HPChangeNotify(changeNum);
-	}
-	
-	/**
-	 * Redirect output to a vector instead of displaying it on the GUI.
-	 * @param	text to store
-	 */
-	override public function outputText(text:String):void {
-		collectedOutput.push(text);
-	}
-}
-
-import classes.Player;
-
-/**
- * Yes, i'm a lazy git.
- */
-class DummyPlayer extends Player {
-	public var calls:Vector.<Number> = new Vector.<Number>();
-	public var collectedOutput:Vector.<String> = new Vector.<String>();
-
-	/**
-	 * Intercept calls to HPChangeNotify so we can sense them in tests.
-	 * 
-	 * @param	changeNum the value of the HP change?
-	 */
-	override public function HPChangeNotify(changeNum:Number):void {
-		calls.push(changeNum);
-		super.HPChangeNotify(changeNum);
-	}
-	
-	/**
-	 * Redirect output to a vector instead of displaying it on the GUI.
-	 * @param	text to store
-	 */
-	override protected function outputText(text:String):void {
-		collectedOutput.push(text);
 	}
 }

--- a/test/classes/CoCTest.as
+++ b/test/classes/CoCTest.as
@@ -2,6 +2,7 @@ package classes{
     import org.flexunit.asserts.*;
 	import org.hamcrest.assertThat;
 	import org.hamcrest.core.*;
+	import org.hamcrest.collection.*;
 	import org.hamcrest.number.*;
 	import org.hamcrest.object.*;
 	import org.hamcrest.text.*;
@@ -12,29 +13,38 @@ package classes{
 	import classes.helper.StageLocator;
 	import classes.helper.FireButtonEvent;
 	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Items.ArmorLib;
 	
 	public class CoCTest {
-		private var cut:CoC;
+		private static const HP_OVER_HEAL:Number = 1000;
+		private static const PLAYER_MAX_HP:Number = 250;
+		
+		private var cut:CoCForTest;
 		private var fireButton:FireButtonEvent;
+		private var player:Player;
 		
 		[Before]
 		public function runBeforeEveryTest():void {
 			assertThat(StageLocator.stage, not(nullValue()));
 			
-			cut = new CoC(StageLocator.stage);
-			cut.player.createVagina();
+			cut = new CoCForTest(StageLocator.stage);
+			
+			this.player = cut.player;
+			player.createVagina();
+			player.HP = 1;
+			player.tou = 100;
 			
 			fireButton = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
 		}
 
 		[Test] 
 		public function injectStageForTest():void {
-			cut = new CoC(StageLocator.stage);
+			var coc:CoC = new CoC(StageLocator.stage);
 		}
 		
 		[Test(expected="TypeError")] 
 		public function noInjectedStage():void {
-			cut = new CoC();
+			var coc:CoC = new CoC();
 		}
 		
 		[Test]
@@ -50,5 +60,198 @@ package classes{
 			fireButton.fireButtonClick(0); //press 'proceed' button
 			fireButton.fireButtonClick(4); //press 'exit' button
 		}
+		
+		[Test]
+		public function hpChangeZeroNoDelta(): void {
+			assertThat(cut.HPChange(0, false), equalTo(0));
+		}
+		
+		[Test]
+		public function hpChangeHealerBoost(): void {
+			player.createPerk(PerkLib.HistoryHealer, 0, 0, 0, 0);
+			
+			assertThat(cut.HPChange(100, false), equalTo(120));
+		}
+		
+		[Test]
+		public function hpChangeNurseOutfitBoost(): void {
+			player.setArmor(new ArmorLib().NURSECL);
+			
+			assertThat(cut.HPChange(100, false), equalTo(110));
+		}
+		
+		[Test]
+		public function hpChangeOverHeal(): void {
+			assertThat(cut.HPChange(HP_OVER_HEAL, false), equalTo(249));
+		}
+		
+		[Test]
+		public function hpChangeOverHealPlayerHp(): void {
+			cut.HPChange(HP_OVER_HEAL, false);
+			
+			assertThat(player.HP, equalTo(PLAYER_MAX_HP));
+		}
+		
+		[Test]
+		public function hpChangeOverHealDisplayHpChange(): void {
+			cut.HPChange(HP_OVER_HEAL, true);
+			
+			assertThat(cut.calls, arrayWithSize(1));
+			assertThat(cut.calls, hasItem(equalTo(HP_OVER_HEAL)));
+		}
+		
+		[Test]
+		public function hpChangePlayerHpOverMaxDelta(): void {
+			player.HP = HP_OVER_HEAL;
+			
+			assertThat(cut.HPChange(HP_OVER_HEAL, false), equalTo(0));
+		}
+		
+		[Test]
+		public function hpChangePlayerHpOverMaxPlayerHp(): void {
+			player.HP = HP_OVER_HEAL;
+			
+			cut.HPChange(HP_OVER_HEAL, false);
+			
+			assertThat(player.HP, equalTo(1000));
+		}
+		
+		[Test]
+		public function hpChangePlayerHpOverMaxDisplayHpChange(): void {
+			player.HP = HP_OVER_HEAL;
+			
+			cut.HPChange(HP_OVER_HEAL, true);
+			
+			assertThat(cut.calls, arrayWithSize(1));
+			assertThat(cut.calls, hasItem(equalTo(HP_OVER_HEAL)));
+		}
+		
+		[Test]
+		public function hpChangeHealDisplayHpChange(): void {
+			cut.HPChange(1, true);
+			
+			assertThat(cut.calls, arrayWithSize(1));
+			assertThat(cut.calls, hasItem(equalTo(1)));
+		}
+		
+		[Test]
+		public function hpChangeHealPlayerHP(): void {
+			cut.HPChange(1, true);
+			
+			assertThat(player.HP, equalTo(2));
+		}
+		
+		[Test]
+		public function hpChangeDamageDisplayHpChange(): void {
+			player.HP = 50;
+			
+			cut.HPChange(-1, true);
+			
+			assertThat(cut.calls, arrayWithSize(1));
+			assertThat(cut.calls, hasItem(equalTo(-1)));
+		}
+		
+		[Test]
+		public function hpChangeDamagePlayerHp(): void {
+			player.HP = 50;
+			
+			cut.HPChange(-1, false);
+			
+			assertThat(player.HP, equalTo(49));
+		}
+		
+		[Test]
+		public function hpChangeDamageBelowZeroDisplayHpChange(): void {
+			cut.HPChange(-HP_OVER_HEAL, true);
+			
+			assertThat(cut.calls, arrayWithSize(1));
+			assertThat(cut.calls, hasItem(equalTo(-HP_OVER_HEAL)));
+		}
+		
+		[Test]
+		public function hpChangeDamageBelowZeroPlayerHp(): void {
+			cut.HPChange(-HP_OVER_HEAL, false);
+			
+			assertThat(player.HP, equalTo(0));
+		}
+		
+		[Test]
+		public function hpChangeNotifyNoChange(): void {
+			cut.HPChangeNotify(0);
+			
+			assertThat(cut.collectedOutput, emptyArray());
+		}
+		
+		[Test]
+		public function hpChangeNotifyNoChangeOverMaxHp(): void {
+			player.HP = HP_OVER_HEAL;
+			
+			cut.HPChangeNotify(0);
+			
+			assertThat(cut.collectedOutput, hasItem(startsWith("You're as healthy as you can be.")));
+		}
+		
+		[Test]
+		public function hpChangeNotifyHeal(): void {
+			cut.HPChangeNotify(1);
+			
+			assertThat(cut.collectedOutput, hasItem(startsWith("You gain")));
+		}
+		
+		[Test]
+		public function hpChangeNotifyHealOverMaxHp(): void {
+			player.HP = HP_OVER_HEAL;
+			
+			cut.HPChangeNotify(1);
+			
+			assertThat(cut.collectedOutput, hasItem(startsWith("Your HP maxes out at")));
+		}
+		
+		[Test]
+		public function hpChangeNotifyDamage(): void {
+			cut.HPChangeNotify(-1);
+			
+			assertThat(cut.collectedOutput, hasItem(containsString("damage.")));
+		}
+		
+		[Test]
+		public function hpChangeNotifyDamageHpBelowZero(): void {
+			player.HP = -1;
+			
+			cut.HPChangeNotify(-1);
+			
+			assertThat(cut.collectedOutput, hasItem(containsString("damage, dropping your HP to 0.")));
+		}
+	}
+}
+
+import classes.CoC;
+import flash.display.Stage;
+
+class CoCForTest extends CoC {
+	public var calls:Vector.<Number> = new Vector.<Number>();
+	public var collectedOutput:Vector.<String> = new Vector.<String>();
+	
+	public function CoCForTest(injectedStage:Stage) 
+	{
+		super(injectedStage);
+	}
+	
+	/**
+	 * Intercept calls to HPChangeNotify so we can sense them in tests.
+	 * 
+	 * @param	changeNum the value of the HP change?
+	 */
+	override public function HPChangeNotify(changeNum:Number):void {
+		calls.push(changeNum);
+		super.HPChangeNotify(changeNum);
+	}
+	
+	/**
+	 * Redirect output to a vector instead of displaying it on the GUI.
+	 * @param	text to store
+	 */
+	override public function outputText(text:String):void {
+		collectedOutput.push(text);
 	}
 }

--- a/test/classes/CoCTest.as
+++ b/test/classes/CoCTest.as
@@ -21,18 +21,24 @@ package classes{
 		
 		private var cut:CoCForTest;
 		private var fireButton:FireButtonEvent;
-		private var player:Player;
+		private var player:DummyPlayer;
 		
 		[Before]
 		public function runBeforeEveryTest():void {
 			assertThat(StageLocator.stage, not(nullValue()));
 			
 			cut = new CoCForTest(StageLocator.stage);
+			player = new DummyPlayer();
+			cut.player = player;
 			
-			this.player = cut.player;
 			player.createVagina();
 			player.HP = 1;
 			player.tou = 100;
+			
+			// TODO clean up this fugly hack - exctract test into PlayerTest
+			// don't try this at home kids!
+			cut.calls = player.calls;
+			cut.collectedOutput = player.collectedOutput;
 			
 			fireButton = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
 		}
@@ -252,6 +258,34 @@ class CoCForTest extends CoC {
 	 * @param	text to store
 	 */
 	override public function outputText(text:String):void {
+		collectedOutput.push(text);
+	}
+}
+
+import classes.Player;
+
+/**
+ * Yes, i'm a lazy git.
+ */
+class DummyPlayer extends Player {
+	public var calls:Vector.<Number> = new Vector.<Number>();
+	public var collectedOutput:Vector.<String> = new Vector.<String>();
+
+	/**
+	 * Intercept calls to HPChangeNotify so we can sense them in tests.
+	 * 
+	 * @param	changeNum the value of the HP change?
+	 */
+	override public function HPChangeNotify(changeNum:Number):void {
+		calls.push(changeNum);
+		super.HPChangeNotify(changeNum);
+	}
+	
+	/**
+	 * Redirect output to a vector instead of displaying it on the GUI.
+	 * @param	text to store
+	 */
+	override protected function outputText(text:String):void {
 		collectedOutput.push(text);
 	}
 }

--- a/test/classes/CoCTest.as
+++ b/test/classes/CoCTest.as
@@ -17,7 +17,6 @@ package classes{
 	public class CoCTest {
 		private var cut:CoCForTest;
 		private var fireButton:FireButtonEvent;
-		private var player:Player;
 		
 		[Before]
 		public function runBeforeEveryTest():void {

--- a/test/classes/CreatureTest.as
+++ b/test/classes/CreatureTest.as
@@ -71,6 +71,8 @@ package classes{
 			cut = new Creature();
 			cut.rng = alwaysZero;
 			cut.ass.analLooseness = ANAL_LOOSENESS;
+						cut.tou = 100;
+			cut.HP = 1;
 			
 			noVagina = new Creature();
 			
@@ -647,6 +649,34 @@ package classes{
 			cut.clearGender();
 			
 			assertThat(cut.hasBreasts(), equalTo(false));
+		}
+		
+		[Test]
+		public function healToMaxHP():void {
+			cut.restoreHP();
+
+			assertThat(cut.HP, equalTo(250));
+		}
+
+		[Test]
+		public function healByAmount():void {
+			cut.restoreHP(1);
+
+			assertThat(cut.HP, equalTo(2));
+		}
+
+		[Test]
+		public function healOverflowCheck():void {
+			cut.HP = 1000;
+			
+			cut.restoreHP();
+
+			assertThat(cut.HP, equalTo(250));
+		}
+		
+		[Test(expected="RangeError")]
+		public function healByNegativeAmount():void {
+			cut.restoreHP(-1);
 		}
 	}
 }


### PR DESCRIPTION
This PR moves Player specific code out of `engineCore.as` into `Player.as`.

- Creature method to restore HP
- Replaced `HP = MaxHP()` calls with `.restoreHP()`
- Removed `MaxHP` function from `engineCore.as`
- Moved `HPChange` to `Player.as`
- Moved `HPChangeNotify` to `Player.as`
- Removed `HPChange` from `engineCore.as` and `BaseContent.as`