### PR TITLE
Engine core GUI cleanup

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -505,10 +505,6 @@
 			kGAMECLASS.mainView.statsView.showStatUp(arg);
 		}
 		
-		protected function getButtonText(index:int):String {
-			return kGAMECLASS.getButtonText(index);
-		}
-		
 				
 		/**
 		 * PRIMO BULLSHIT FUNCTION ACCESS

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -242,7 +242,7 @@
 
 		protected function doNext(eventNo:Function):void //Now typesafe
 		{
-			kGAMECLASS.doNext(eventNo);
+			kGAMECLASS.output.doNext(eventNo);
 		}
 		
 		/**

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -272,11 +272,11 @@
 		
 		protected function addButtonDisabled(pos:int, text:String = "", toolTipText:String = "", toolTipHeader:String = ""):CoCButton
 		{
-			return kGAMECLASS.addButtonDisabled(pos, text, toolTipText, toolTipHeader);
+			return kGAMECLASS.output.addButtonDisabled(pos, text, toolTipText, toolTipHeader);
 		}
 		protected function addDisabledButton(pos:int, text:String = "", toolTipText:String = "", toolTipHeader:String = ""):CoCButton
 		{
-			return kGAMECLASS.addButtonDisabled(pos, text, toolTipText, toolTipHeader);
+			return kGAMECLASS.output.addButtonDisabled(pos, text, toolTipText, toolTipHeader);
 		}
 		protected function button(pos:int):CoCButton
 		{

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -168,7 +168,7 @@
 		/** Refreshes the stats panel. */
 		protected function statScreenRefresh():void
 		{
-			kGAMECLASS.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 		}
 		
 		/** Displays the stats panel. */

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -174,7 +174,7 @@
 		/** Displays the stats panel. */
 		protected function showStats():void
 		{
-			kGAMECLASS.showStats();
+			kGAMECLASS.output.showStats();
 		}
 
 		/** Hide the stats panel. */

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -253,7 +253,7 @@
 		 */
 		protected function menu():void
 		{
-			kGAMECLASS.menu();
+			kGAMECLASS.output.menu();
 		}
 
 		protected function hideMenus():void

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -267,7 +267,7 @@
 
 		protected function addButton(pos:int, text:String = "", func1:Function = null, arg1:* = -9000, arg2:* = -9000, arg3:* = -9000, toolTipText:String = "", toolTipHeader:String = ""):CoCButton
 		{
-			return kGAMECLASS.addButton(pos, text, func1, arg1, arg2, arg3, toolTipText, toolTipHeader);
+			return kGAMECLASS.output.addButton(pos, text, func1, arg1, arg2, arg3, toolTipText, toolTipHeader);
 		}
 		
 		protected function addButtonDisabled(pos:int, text:String = "", toolTipText:String = "", toolTipHeader:String = ""):CoCButton

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -180,7 +180,7 @@
 		/** Hide the stats panel. */
 		protected function hideStats():void
 		{
-			kGAMECLASS.hideStats();
+			kGAMECLASS.output.hideStats();
 		}
 		
 		/** Hide the up/down arrows. */

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -280,7 +280,7 @@
 		}
 		protected function button(pos:int):CoCButton
 		{
-			return kGAMECLASS.button(pos);
+			return kGAMECLASS.output.button(pos);
 		}
 		
 		protected function removeButton(arg:*):void

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -505,10 +505,6 @@
 			kGAMECLASS.mainView.statsView.showStatUp(arg);
 		}
 		
-		protected function buttonTextIsOneOf(index:int, possibleLabels:Array):Boolean {
-			return kGAMECLASS.buttonTextIsOneOf(index, possibleLabels);
-		}		
-		
 		protected function getButtonText(index:int):String {
 			return kGAMECLASS.getButtonText(index);
 		}

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -513,9 +513,6 @@
 			return kGAMECLASS.getButtonText(index);
 		}
 		
-		protected function buttonIsVisible(index:int):Boolean {
-			return kGAMECLASS.buttonIsVisible(index);
-		}
 				
 		/**
 		 * PRIMO BULLSHIT FUNCTION ACCESS

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -258,7 +258,7 @@
 
 		protected function hideMenus():void
 		{
-			kGAMECLASS.hideMenus();
+			kGAMECLASS.output.hideMenus();
 		}
 		
 		protected function doYesNo(eventYes:Function, eventNo:Function):void { //Now typesafe

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -285,7 +285,7 @@
 		
 		protected function removeButton(arg:*):void
 		{
-			kGAMECLASS.removeButton(arg);
+			kGAMECLASS.output.removeButton(arg);
 		}
 		
 		protected function openURL(url:String):void{

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -186,7 +186,7 @@
 		/** Hide the up/down arrows. */
 		protected function hideUpDown():void
 		{
-			kGAMECLASS.hideUpDown();
+			kGAMECLASS.output.hideUpDown();
 		}
 
 		/** Create a function that will pass one argument. */

--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -262,7 +262,7 @@
 		}
 		
 		protected function doYesNo(eventYes:Function, eventNo:Function):void { //Now typesafe
-			kGAMECLASS.doYesNo(eventYes, eventNo);
+			kGAMECLASS.output.doYesNo(eventYes, eventNo);
 		}
 
 		protected function addButton(pos:int, text:String = "", func1:Function = null, arg1:* = -9000, arg2:* = -9000, arg3:* = -9000, toolTipText:String = "", toolTipHeader:String = ""):CoCButton

--- a/classes/classes/Bindings.as
+++ b/classes/classes/Bindings.as
@@ -47,7 +47,7 @@ package classes
 				var doQuickLoad:Function = function():void {
 					if (game.saves.loadGame("CoC_" + slot)) {
 						game.showStats();
-						game.statScreenRefresh();
+						kGAMECLASS.output.statScreenRefresh();
 						game.clearOutput();
 						game.outputText("Slot " + slot + " Loaded!");
 						kGAMECLASS.output.doNext(game.playerMenu);

--- a/classes/classes/Bindings.as
+++ b/classes/classes/Bindings.as
@@ -26,7 +26,7 @@ package classes
 					game.saves.saveGame(slotX);
 					game.clearOutput();
 					game.outputText("Game saved to " + slotX + "!");
-					game.doNext(game.playerMenu);
+					kGAMECLASS.output.doNext(game.playerMenu);
 				};
 				if (flags[kFLAGS.DISABLE_QUICKSAVE_CONFIRM] !== 0) {
 					doQuickSave();
@@ -50,7 +50,7 @@ package classes
 						game.statScreenRefresh();
 						game.clearOutput();
 						game.outputText("Slot " + slot + " Loaded!");
-						game.doNext(game.playerMenu);
+						kGAMECLASS.output.doNext(game.playerMenu);
 					}
 				};
 				if (saveFile.data.exists) {

--- a/classes/classes/Bindings.as
+++ b/classes/classes/Bindings.as
@@ -46,7 +46,7 @@ package classes
 				var saveFile:SharedObject = SharedObject.getLocal("CoC_" + slot, "/");
 				var doQuickLoad:Function = function():void {
 					if (game.saves.loadGame("CoC_" + slot)) {
-						game.showStats();
+						kGAMECLASS.output.showStats();
 						kGAMECLASS.output.statScreenRefresh();
 						game.clearOutput();
 						game.outputText("Slot " + slot + " Loaded!");

--- a/classes/classes/Bindings.as
+++ b/classes/classes/Bindings.as
@@ -35,8 +35,8 @@ package classes
 				game.clearOutput();
 				game.outputText("You are about to quicksave the current game to <b>" + slotX + "</b>\n\nAre you sure?");
 				game.menu();
-				game.addButton(0, "No", game.playerMenu);
-				game.addButton(1, "Yes", doQuickSave);
+				kGAMECLASS.output.addButton(0, "No", game.playerMenu);
+				kGAMECLASS.output.addButton(1, "Yes", doQuickSave);
 			}
 		}
 
@@ -61,8 +61,8 @@ package classes
 					game.clearOutput();
 					game.outputText("You are about to quickload the current game from slot <b>" + slot + "</b>\n\nAre you sure?");
 					game.menu();
-					game.addButton(0, "No", game.playerMenu);
-					game.addButton(1, "Yes", doQuickLoad);
+					kGAMECLASS.output.addButton(0, "No", game.playerMenu);
+					kGAMECLASS.output.addButton(1, "Yes", doQuickLoad);
 				}
 			}
 		}

--- a/classes/classes/Bindings.as
+++ b/classes/classes/Bindings.as
@@ -34,7 +34,7 @@ package classes
 				}
 				game.clearOutput();
 				game.outputText("You are about to quicksave the current game to <b>" + slotX + "</b>\n\nAre you sure?");
-				game.menu();
+				kGAMECLASS.output.menu();
 				kGAMECLASS.output.addButton(0, "No", game.playerMenu);
 				kGAMECLASS.output.addButton(1, "Yes", doQuickSave);
 			}
@@ -60,7 +60,7 @@ package classes
 					}
 					game.clearOutput();
 					game.outputText("You are about to quickload the current game from slot <b>" + slot + "</b>\n\nAre you sure?");
-					game.menu();
+					kGAMECLASS.output.menu();
 					kGAMECLASS.output.addButton(0, "No", game.playerMenu);
 					kGAMECLASS.output.addButton(1, "Yes", doQuickLoad);
 				}

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -494,7 +494,7 @@ package classes
 			this.mainView.onStatsClick = playerInfo.displayStats;
 			this.mainView.onBottomButtonClick = function(i:int):void
 			{
-				output.record("<br>[" + button(i).labelText + "]<br>");
+				output.record("<br>[" + output.button(i).labelText + "]<br>");
 			};
 			
 			// Set up all the messy global stuff:

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -703,5 +703,10 @@ package classes
 				}
 			}
 		}
+		
+		// TODO remove once that GuiInput interface has been sorted
+		public function addButton(pos:int, text:String = "", func1:Function = null, arg1:* = -9000, arg2:* = -9000, arg3:* = -9000, toolTipText:String = "", toolTipHeader:String = ""):CoCButton {
+			return output.addButton(pos, text, func1, arg1, arg2, arg3, toolTipText, toolTipHeader);
+		}
 	}
 }

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -708,5 +708,10 @@ package classes
 		public function addButton(pos:int, text:String = "", func1:Function = null, arg1:* = -9000, arg2:* = -9000, arg3:* = -9000, toolTipText:String = "", toolTipHeader:String = ""):CoCButton {
 			return output.addButton(pos, text, func1, arg1, arg2, arg3, toolTipText, toolTipHeader);
 		}
+		
+		// TODO remove once that GuiInput interface has been sorted
+		public function menu(): void {
+			output.menu();
+		}
 	}
 }

--- a/classes/classes/Items/Armors/LustyMaidensArmor.as
+++ b/classes/classes/Items/Armors/LustyMaidensArmor.as
@@ -11,6 +11,7 @@ package classes.Items.Armors
 	import classes.Scenes.Areas.HighMountains.MinotaurMob;
 	import classes.Scenes.Areas.Mountain.Minotaur;
 	import classes.lists.BreastCup;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public final class LustyMaidensArmor extends Armor {
 		
@@ -138,7 +139,7 @@ package classes.Items.Armors
 			//Usable on: Imps, Minotaurs, Satyrs, Incubus Mechanic, Anemones, Spider Guys, Akbal, Drider, Fetish Zealot, Sand Trap, Very Corrupt Jojo (Maybe slight decorruption to him), Ceraph, Red Kitsune if cock out.
 			if (game.inCombat)
 				game.combat.cleanupAfterCombat();
-			else game.doNext(game.camp.returnToCampUseOneHour);
+			else kGAMECLASS.output.doNext(game.camp.returnToCampUseOneHour);
 		}
 	}
 }

--- a/classes/classes/Items/Consumable.as
+++ b/classes/classes/Items/Consumable.as
@@ -30,8 +30,8 @@ package classes.Items
 		protected function get prison():Prison { return kGAMECLASS.prison; }
 		protected function get flags():DefaultDict { return kGAMECLASS.flags; }
 		protected function get camp():Camp { return kGAMECLASS.camp; }
-		protected function doNext(eventNo:Function):void { kGAMECLASS.doNext(eventNo); }
 		protected function tfChance(min:int, max:int):Boolean { return mutations.tfChance(min, max); }
+		protected function doNext(eventNo:Function):void { kGAMECLASS.output.doNext(eventNo); }
 
 		public function Consumable(id:String, shortName:String = null, longName:String = null, value:Number = 0, description:String = null) {
 			super(id, shortName, longName, value, description);

--- a/classes/classes/Items/Consumables/BodyLotion.as
+++ b/classes/classes/Items/Consumables/BodyLotion.as
@@ -46,9 +46,9 @@ package classes.Items.Consumables
 			outputText("The skin on your underBody is different from the rest. Where do you want to apply the " + _adj + " body lotion?");
 
 			game.menu();
-			game.addButton(0, "Body", lotionSkin);
-			game.addButton(1, "Underbody", lotionUnderBodySkin);
-			game.addButton(4, "Nevermind", lotionCancel);
+			kGAMECLASS.output.addButton(0, "Body", lotionSkin);
+			kGAMECLASS.output.addButton(1, "Underbody", lotionUnderBodySkin);
+			kGAMECLASS.output.addButton(4, "Nevermind", lotionCancel);
 			return true;
 		}
 

--- a/classes/classes/Items/Consumables/BodyLotion.as
+++ b/classes/classes/Items/Consumables/BodyLotion.as
@@ -45,7 +45,7 @@ package classes.Items.Consumables
 			clearOutput();
 			outputText("The skin on your underBody is different from the rest. Where do you want to apply the " + _adj + " body lotion?");
 
-			game.menu();
+			kGAMECLASS.output.menu();
 			kGAMECLASS.output.addButton(0, "Body", lotionSkin);
 			kGAMECLASS.output.addButton(1, "Underbody", lotionUnderBodySkin);
 			kGAMECLASS.output.addButton(4, "Nevermind", lotionCancel);

--- a/classes/classes/Items/Consumables/GroPlus.as
+++ b/classes/classes/Items/Consumables/GroPlus.as
@@ -30,7 +30,7 @@ package classes.Items.Consumables
 			var gpNipples:Function	= (game.player.totalNipples() > 0 ? growPlusNipples : null);
 			clearOutput();
 			outputText("You ponder the needle in your hand knowing it will enlarge the injection site.  What part of your body will you use it on?  ");
-			game.menu();
+			kGAMECLASS.output.menu();
 			kGAMECLASS.output.addButton(0, "Balls", gpBalls);
 			kGAMECLASS.output.addButton(1, "Breasts", gpBreasts);
 			kGAMECLASS.output.addButton(2, "Clit", gpClit);

--- a/classes/classes/Items/Consumables/GroPlus.as
+++ b/classes/classes/Items/Consumables/GroPlus.as
@@ -8,6 +8,7 @@ package classes.Items.Consumables
 	import classes.PerkLib;
 	import classes.Player;
 	import classes.internals.Utils;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public final class GroPlus extends Consumable {
 		
@@ -30,12 +31,12 @@ package classes.Items.Consumables
 			clearOutput();
 			outputText("You ponder the needle in your hand knowing it will enlarge the injection site.  What part of your body will you use it on?  ");
 			game.menu();
-			game.addButton(0, "Balls", gpBalls);
-			game.addButton(1, "Breasts", gpBreasts);
-			game.addButton(2, "Clit", gpClit);
-			game.addButton(3, "Cock", gpCock);
-			game.addButton(4, "Nipples", gpNipples);
-			game.addButton(14, "Nevermind", growPlusCancel);
+			kGAMECLASS.output.addButton(0, "Balls", gpBalls);
+			kGAMECLASS.output.addButton(1, "Breasts", gpBreasts);
+			kGAMECLASS.output.addButton(2, "Clit", gpClit);
+			kGAMECLASS.output.addButton(3, "Cock", gpCock);
+			kGAMECLASS.output.addButton(4, "Nipples", gpNipples);
+			kGAMECLASS.output.addButton(14, "Nevermind", growPlusCancel);
 			return(true);
 		}
 		

--- a/classes/classes/Items/Consumables/HairDye.as
+++ b/classes/classes/Items/Consumables/HairDye.as
@@ -31,63 +31,63 @@ package classes.Items.Consumables
 			if (game.player.hair.length > 0) {
 				outputText("You have " + game.player.hair.color + " hair.");
 				if (game.player.hair.color != _color) kGAMECLASS.output.addButton(0, "Hair", dyeHair);
-				else game.addButtonDisabled(0, "Hair", "Your already have " + game.player.hair.color + " hair!");
+				else kGAMECLASS.output.addButtonDisabled(0, "Hair", "Your already have " + game.player.hair.color + " hair!");
 			} else {
 				outputText("You have no hair.");
-				game.addButtonDisabled(0, "Hair", "You are bald!");
+				kGAMECLASS.output.addButtonDisabled(0, "Hair", "You are bald!");
 			}
 			
 			if (game.player.hasFur()) {
 				outputText("\n\nYou have " + game.player.skin.furColor + " fur.");
 				if (game.player.skin.furColor != _color) kGAMECLASS.output.addButton(1, "Fur", dyeFur);
-				else game.addButtonDisabled(1, "Fur", "Your already have " + _color + " fur!");
+				else kGAMECLASS.output.addButtonDisabled(1, "Fur", "Your already have " + _color + " fur!");
 			} else if (game.player.hasFeathers() || game.player.hasCockatriceSkin()) {
 				outputText("\n\nYou have " + game.player.skin.furColor + " feathers.");
 				if (game.player.skin.furColor != _color) kGAMECLASS.output.addButton(1, "Feathers", dyeFeathers);
-				else game.addButtonDisabled(1, "Feathers", "Your already have " + _color + " feathers!");
+				else kGAMECLASS.output.addButtonDisabled(1, "Feathers", "Your already have " + _color + " feathers!");
 			} else {
 				outputText("\n\nYou have no fur.");
-				game.addButtonDisabled(1, "Fur", "You have no fur!");
+				kGAMECLASS.output.addButtonDisabled(1, "Fur", "You have no fur!");
 			}
 
 			if (game.player.hasFurryUnderBody()) {
 				outputText("\n\nYou have " + game.player.underBody.skin.furColor + " fur on your underbody.");
 				if (game.player.underBody.skin.furColor != _color) kGAMECLASS.output.addButton(2, "Under Fur", dyeUnderBodyFur);
-				else game.addButtonDisabled(2, "Under Fur", "Your already have " + _color + " fur on your underbody!");
+				else kGAMECLASS.output.addButtonDisabled(2, "Under Fur", "Your already have " + _color + " fur on your underbody!");
 			} else if (game.player.hasFeatheredUnderBody()) {
 				outputText("\n\nYou have " + game.player.underBody.skin.furColor + " feathers on your underbody.");
 				if (game.player.underBody.skin.furColor != _color) kGAMECLASS.output.addButton(2, "Under Feathers", dyeUnderBodyFeathers);
-				else game.addButtonDisabled(2, "Under Feathers", "Your already have " + _color + " feathers on your underbody!");
+				else kGAMECLASS.output.addButtonDisabled(2, "Under Feathers", "Your already have " + _color + " feathers on your underbody!");
 			} else {
 				outputText("\n\nYou have no special or furry underbody.");
-				game.addButtonDisabled(2, "Under Fur", "You have no special or furry underbody!");
+				kGAMECLASS.output.addButtonDisabled(2, "Under Fur", "You have no special or furry underbody!");
 			}
 
 			if (game.player.wings.canDye()) {
 				outputText("\n\nYou have [wingColor] wings.");
 				if (!game.player.wings.hasDyeColor(_color)) kGAMECLASS.output.addButton(3, "Wings", dyeWings);
-				else game.addButtonDisabled(3, "Wings", "Your already have " + _color + " wings!");
+				else kGAMECLASS.output.addButtonDisabled(3, "Wings", "Your already have " + _color + " wings!");
 			} else {
 				outputText("\n\nYour wings can't be dyed.");
-				game.addButtonDisabled(3, "Wings", "Your wings can't be dyed!");
+				kGAMECLASS.output.addButtonDisabled(3, "Wings", "Your wings can't be dyed!");
 			}
 
 			if (game.player.neck.canDye()) {
 				outputText("\n\nYou have a [neckColor] neck.");
 				if (!game.player.neck.hasDyeColor(_color)) kGAMECLASS.output.addButton(5, "Neck", dyeNeck);
-				else game.addButtonDisabled(5, "Neck", "Your already have a " + _color + " neck!");
+				else kGAMECLASS.output.addButtonDisabled(5, "Neck", "Your already have a " + _color + " neck!");
 			} else {
 				outputText("\n\nYour neck can't be dyed.");
-				game.addButtonDisabled(5, "Neck", "Your neck can't be dyed!");
+				kGAMECLASS.output.addButtonDisabled(5, "Neck", "Your neck can't be dyed!");
 			}
 
 			if (game.player.rearBody.canDye()) {
 				outputText("\n\nYou have a [rearBodyColor] rear body.");
 				if (!game.player.rearBody.hasDyeColor(_color)) kGAMECLASS.output.addButton(6, "Rear Body", dyeRearBody);
-				else game.addButtonDisabled(6, "Rear Body", "Your already have a " + _color + " rear body!");
+				else kGAMECLASS.output.addButtonDisabled(6, "Rear Body", "Your already have a " + _color + " rear body!");
 			} else {
 				outputText("\n\nYour rear body can't be dyed.");
-				game.addButtonDisabled(6, "Rear Body", "Your rear body can't be dyed!");
+				kGAMECLASS.output.addButtonDisabled(6, "Rear Body", "Your rear body can't be dyed!");
 			}
 
 			kGAMECLASS.output.addButton(4, "Nevermind", dyeCancel);

--- a/classes/classes/Items/Consumables/HairDye.as
+++ b/classes/classes/Items/Consumables/HairDye.as
@@ -26,7 +26,7 @@ package classes.Items.Consumables
 		
 		override public function useItem():Boolean {
 			clearOutput();
-			game.menu();
+			kGAMECLASS.output.menu();
 			 
 			if (game.player.hair.length > 0) {
 				outputText("You have " + game.player.hair.color + " hair.");

--- a/classes/classes/Items/Consumables/HairDye.as
+++ b/classes/classes/Items/Consumables/HairDye.as
@@ -30,7 +30,7 @@ package classes.Items.Consumables
 			 
 			if (game.player.hair.length > 0) {
 				outputText("You have " + game.player.hair.color + " hair.");
-				if (game.player.hair.color != _color) game.addButton(0, "Hair", dyeHair);
+				if (game.player.hair.color != _color) kGAMECLASS.output.addButton(0, "Hair", dyeHair);
 				else game.addButtonDisabled(0, "Hair", "Your already have " + game.player.hair.color + " hair!");
 			} else {
 				outputText("You have no hair.");
@@ -39,11 +39,11 @@ package classes.Items.Consumables
 			
 			if (game.player.hasFur()) {
 				outputText("\n\nYou have " + game.player.skin.furColor + " fur.");
-				if (game.player.skin.furColor != _color) game.addButton(1, "Fur", dyeFur);
+				if (game.player.skin.furColor != _color) kGAMECLASS.output.addButton(1, "Fur", dyeFur);
 				else game.addButtonDisabled(1, "Fur", "Your already have " + _color + " fur!");
 			} else if (game.player.hasFeathers() || game.player.hasCockatriceSkin()) {
 				outputText("\n\nYou have " + game.player.skin.furColor + " feathers.");
-				if (game.player.skin.furColor != _color) game.addButton(1, "Feathers", dyeFeathers);
+				if (game.player.skin.furColor != _color) kGAMECLASS.output.addButton(1, "Feathers", dyeFeathers);
 				else game.addButtonDisabled(1, "Feathers", "Your already have " + _color + " feathers!");
 			} else {
 				outputText("\n\nYou have no fur.");
@@ -52,11 +52,11 @@ package classes.Items.Consumables
 
 			if (game.player.hasFurryUnderBody()) {
 				outputText("\n\nYou have " + game.player.underBody.skin.furColor + " fur on your underbody.");
-				if (game.player.underBody.skin.furColor != _color) game.addButton(2, "Under Fur", dyeUnderBodyFur);
+				if (game.player.underBody.skin.furColor != _color) kGAMECLASS.output.addButton(2, "Under Fur", dyeUnderBodyFur);
 				else game.addButtonDisabled(2, "Under Fur", "Your already have " + _color + " fur on your underbody!");
 			} else if (game.player.hasFeatheredUnderBody()) {
 				outputText("\n\nYou have " + game.player.underBody.skin.furColor + " feathers on your underbody.");
-				if (game.player.underBody.skin.furColor != _color) game.addButton(2, "Under Feathers", dyeUnderBodyFeathers);
+				if (game.player.underBody.skin.furColor != _color) kGAMECLASS.output.addButton(2, "Under Feathers", dyeUnderBodyFeathers);
 				else game.addButtonDisabled(2, "Under Feathers", "Your already have " + _color + " feathers on your underbody!");
 			} else {
 				outputText("\n\nYou have no special or furry underbody.");
@@ -65,7 +65,7 @@ package classes.Items.Consumables
 
 			if (game.player.wings.canDye()) {
 				outputText("\n\nYou have [wingColor] wings.");
-				if (!game.player.wings.hasDyeColor(_color)) game.addButton(3, "Wings", dyeWings);
+				if (!game.player.wings.hasDyeColor(_color)) kGAMECLASS.output.addButton(3, "Wings", dyeWings);
 				else game.addButtonDisabled(3, "Wings", "Your already have " + _color + " wings!");
 			} else {
 				outputText("\n\nYour wings can't be dyed.");
@@ -74,7 +74,7 @@ package classes.Items.Consumables
 
 			if (game.player.neck.canDye()) {
 				outputText("\n\nYou have a [neckColor] neck.");
-				if (!game.player.neck.hasDyeColor(_color)) game.addButton(5, "Neck", dyeNeck);
+				if (!game.player.neck.hasDyeColor(_color)) kGAMECLASS.output.addButton(5, "Neck", dyeNeck);
 				else game.addButtonDisabled(5, "Neck", "Your already have a " + _color + " neck!");
 			} else {
 				outputText("\n\nYour neck can't be dyed.");
@@ -83,14 +83,14 @@ package classes.Items.Consumables
 
 			if (game.player.rearBody.canDye()) {
 				outputText("\n\nYou have a [rearBodyColor] rear body.");
-				if (!game.player.rearBody.hasDyeColor(_color)) game.addButton(6, "Rear Body", dyeRearBody);
+				if (!game.player.rearBody.hasDyeColor(_color)) kGAMECLASS.output.addButton(6, "Rear Body", dyeRearBody);
 				else game.addButtonDisabled(6, "Rear Body", "Your already have a " + _color + " rear body!");
 			} else {
 				outputText("\n\nYour rear body can't be dyed.");
 				game.addButtonDisabled(6, "Rear Body", "Your rear body can't be dyed!");
 			}
 
-			game.addButton(4, "Nevermind", dyeCancel);
+			kGAMECLASS.output.addButton(4, "Nevermind", dyeCancel);
 			return true;
 		}
 		

--- a/classes/classes/Items/Consumables/KitsuneGift.as
+++ b/classes/classes/Items/Consumables/KitsuneGift.as
@@ -3,6 +3,7 @@ package classes.Items.Consumables
 	import classes.Items.Consumable;
 	import classes.Items.ConsumableLib;
 	import classes.internals.Utils;
+	import classes.GlobalFlags.kGAMECLASS;
 	
 	public final class KitsuneGift extends Consumable {
 		
@@ -37,7 +38,7 @@ package classes.Items.Consumables
 				outputText("\n\n<b>You've received " + Utils.num2Text(gems) + " shining gems from the kitsune's gift!  How generous!</b>");
 				game.player.gems += gems;
 				//add X gems to inventory
-				game.statScreenRefresh();
+				kGAMECLASS.output.statScreenRefresh();
 				break;
 
 			//[Kitsune Tea/Scholar's Tea] //Just use Scholar's Tea and drop the "trick" effect if you don't want to throw in another new item.
@@ -79,7 +80,7 @@ package classes.Items.Consumables
 				outputText("\n\n<b>The kitsune's familiar has stolen your gems!</b>");
 				// Lose X gems as though losing in battle to a kitsune
 				game.player.gems -= 2 + Utils.rand(15);
-				game.statScreenRefresh();
+				kGAMECLASS.output.statScreenRefresh();
 				break;
 
 			//[Prank]

--- a/classes/classes/Items/Consumables/PhoukaWhiskey.as
+++ b/classes/classes/Items/Consumables/PhoukaWhiskey.as
@@ -9,6 +9,7 @@ package classes.Items.Consumables
 	import classes.StatusEffects;
     import classes.internals.Utils;
 	import classes.Items.Consumable;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public class PhoukaWhiskey extends Consumable {
 		
@@ -115,7 +116,7 @@ package classes.Items.Consumables
 					//The four stats we’re affecting get paired together to save space. This way we don’t need a second StatusEffect to store more info.
 				game.dynStats("lib", libidoChange, "sens", -sensChange, "spe", -speedChange, "int", -intChange);
 			}
-			game.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
         }
 		
 		public function phoukaWhiskeyExpires(player:Player):void
@@ -136,7 +137,7 @@ package classes.Items.Consumables
 				outputText("\n<b>The fuzzy, happy feeling ebbs away.  With it goes the warmth and carefree feelings.  Your head aches and you wonder if you should have another whiskey, just to tide you over</b>\n");
 			else
 				outputText("\n<b>The fuzzy, happy feeling ebbs away.  The weight of the world’s problems seems to settle on you once more.  It was nice while it lasted and you wouldn’t mind having another whiskey.</b>\n");
-			game.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 		}
     }
 }

--- a/classes/classes/Items/Consumables/Reducto.as
+++ b/classes/classes/Items/Consumables/Reducto.as
@@ -34,7 +34,7 @@ package classes.Items.Consumables
 			var rdtHorns:Function	= (game.player.horns.value > 2 ? shrinkHorns : null);
 			clearOutput();
 			outputText("You ponder the paste in your hand and wonder what part of your body you would like to shrink.  What will you use it on?");
-			game.menu();
+			kGAMECLASS.output.menu();
 			kGAMECLASS.output.addButton(0, "Balls", rdtBalls);
 			kGAMECLASS.output.addButton(1, "Breasts", rdtBreasts);
 			kGAMECLASS.output.addButton(2, "Butt", rdtButt);

--- a/classes/classes/Items/Consumables/Reducto.as
+++ b/classes/classes/Items/Consumables/Reducto.as
@@ -9,6 +9,7 @@ package classes.Items.Consumables
 	import classes.PerkLib;
 	import classes.Player;
 	import classes.internals.Utils;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public final class Reducto extends Consumable {
 		
@@ -34,15 +35,15 @@ package classes.Items.Consumables
 			clearOutput();
 			outputText("You ponder the paste in your hand and wonder what part of your body you would like to shrink.  What will you use it on?");
 			game.menu();
-			game.addButton(0, "Balls", rdtBalls);
-			game.addButton(1, "Breasts", rdtBreasts);
-			game.addButton(2, "Butt", rdtButt);
-			game.addButton(3, "Clit", rdtClit);
-			game.addButton(4, "Cock", rdtCock);
-			game.addButton(5, "Hips", rdtHips);
-			game.addButton(6, "Nipples", rdtNipples);
-			game.addButton(7, "Horns", rdtHorns);
-			game.addButton(14, "Nevermind", reductoCancel);
+			kGAMECLASS.output.addButton(0, "Balls", rdtBalls);
+			kGAMECLASS.output.addButton(1, "Breasts", rdtBreasts);
+			kGAMECLASS.output.addButton(2, "Butt", rdtButt);
+			kGAMECLASS.output.addButton(3, "Clit", rdtClit);
+			kGAMECLASS.output.addButton(4, "Cock", rdtCock);
+			kGAMECLASS.output.addButton(5, "Hips", rdtHips);
+			kGAMECLASS.output.addButton(6, "Nipples", rdtNipples);
+			kGAMECLASS.output.addButton(7, "Horns", rdtHorns);
+			kGAMECLASS.output.addButton(14, "Nevermind", reductoCancel);
 			return(true);
 		}
 		

--- a/classes/classes/Items/Consumables/SkinOil.as
+++ b/classes/classes/Items/Consumables/SkinOil.as
@@ -33,7 +33,7 @@ package classes.Items.Consumables
 			clearOutput();
 			outputText("The skin on your underBody is different from the rest. Where do you want to apply the " + _color + " skin oil?");
 
-			game.menu();
+			kGAMECLASS.output.menu();
 			kGAMECLASS.output.addButton(0, "Body", oilSkin);
 			kGAMECLASS.output.addButton(1, "Underbody", oilUnderBodySkin);
 			kGAMECLASS.output.addButton(4, "Nevermind", oilCancel);

--- a/classes/classes/Items/Consumables/SkinOil.as
+++ b/classes/classes/Items/Consumables/SkinOil.as
@@ -34,9 +34,9 @@ package classes.Items.Consumables
 			outputText("The skin on your underBody is different from the rest. Where do you want to apply the " + _color + " skin oil?");
 
 			game.menu();
-			game.addButton(0, "Body", oilSkin);
-			game.addButton(1, "Underbody", oilUnderBodySkin);
-			game.addButton(4, "Nevermind", oilCancel);
+			kGAMECLASS.output.addButton(0, "Body", oilSkin);
+			kGAMECLASS.output.addButton(1, "Underbody", oilUnderBodySkin);
+			kGAMECLASS.output.addButton(4, "Nevermind", oilCancel);
 			return true;
 		}
 

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -49,7 +49,7 @@
 			game.statScreenRefresh();
 		}
 		protected final function doNext(eventNo:Function):void { //Now typesafe
-			game.doNext(eventNo);
+			kGAMECLASS.output.doNext(eventNo);
 		}
 		protected final function combatMiss():Boolean {
 			return game.combat.combatMiss();
@@ -896,7 +896,7 @@
 			if (temp > player.gems) temp = player.gems;
 			outputText("\n\nYou'll probably wake up in eight hours or so, missing " + temp + " gems.");
 			player.gems -= temp;
-			game.doNext(game.camp.returnToCampUseEightHours);
+			kGAMECLASS.output.doNext(game.camp.returnToCampUseEightHours);
 		}
 
 		/**

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -46,7 +46,7 @@
 			kGAMECLASS.mainView.statsView.showStatDown(a);
 		}
 		protected final function statScreenRefresh():void {
-			game.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 		}
 		protected final function doNext(eventNo:Function):void { //Now typesafe
 			kGAMECLASS.output.doNext(eventNo);
@@ -623,7 +623,7 @@
 				    var damage:int = eOneAttack();
 					outputAttack(damage);
 					postAttack(damage);
-					game.statScreenRefresh();
+					kGAMECLASS.output.statScreenRefresh();
 					outputText("\n");
 				}
 				if (statusEffectv1(StatusEffects.Attacks) >= 0) {

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -402,5 +402,12 @@ package classes
 			
 			kGAMECLASS.mainViewManager.tweenOutStats();
 		}
+		
+		/**
+		 * Hide the top buttons.
+		 */
+		public function hideMenus():void {
+			kGAMECLASS.mainView.hideAllMenuButtons();
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -409,5 +409,24 @@ package classes
 		public function hideMenus():void {
 			kGAMECLASS.mainView.hideAllMenuButtons();
 		}
+		
+		/**
+		 * Hides the up/down arrow on stats pane.
+		 */
+		public function hideUpDown():void {
+			kGAMECLASS.mainView.statsView.hideUpDown();
+			//Clear storage values so up/down arrows can be properly displayed
+			kGAMECLASS.oldStats.oldStr = 0;
+			kGAMECLASS.oldStats.oldTou = 0;
+			kGAMECLASS.oldStats.oldSpe = 0;
+			kGAMECLASS.oldStats.oldInte = 0;
+			kGAMECLASS.oldStats.oldLib = 0;
+			kGAMECLASS.oldStats.oldSens = 0;
+			kGAMECLASS.oldStats.oldCor = 0;  
+			kGAMECLASS.oldStats.oldHP = 0;
+			kGAMECLASS.oldStats.oldLust = 0;
+			kGAMECLASS.oldStats.oldFatigue = 0;
+			kGAMECLASS.oldStats.oldHunger = 0;
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -321,5 +321,21 @@ package classes
 		public function button(pos:int):CoCButton {
 			return kGAMECLASS.mainView.bottomButtons[pos];
 		}
+		
+		/**
+		 * Removes a button.
+		 * @param	arg The position to remove a button. (First row is 0-4, second row is 5-9, third row is 10-14.)
+		 */
+		public function removeButton(arg:*):void {
+			var buttonToRemove:int = 0;
+			if (arg is String) {
+				buttonToRemove = kGAMECLASS.mainView.indexOfButtonWithLabel( arg as String );
+			}
+			if (arg is Number) {
+				if (arg < 0 || arg > MAX_BUTTON_INDEX) return;
+				buttonToRemove = int(arg);
+			}
+			kGAMECLASS.mainView.hideBottomButton( buttonToRemove );
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -382,5 +382,14 @@ package classes
 			kGAMECLASS.mainView.statsView.show(); // show() method refreshes.
 			kGAMECLASS.mainViewManager.refreshStats();
 		}
+		
+		/**
+		 * Show the stats pane. (Name, stats and attributes)
+		 */
+		public function showStats():void {
+			kGAMECLASS.mainView.statsView.show();
+			kGAMECLASS.mainViewManager.refreshStats();
+			kGAMECLASS.mainViewManager.tweenInStats();
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -10,6 +10,8 @@ package classes
 	 */
 	public class Output extends BaseContent implements GuiOutput
 	{
+		public static const MAX_BUTTON_INDEX:int = 14;
+		
 		import flash.text.TextFormat;
 		import classes.GlobalFlags.kGAMECLASS;
 		import classes.GlobalFlags.kFLAGS;
@@ -238,6 +240,15 @@ package classes
 				if (player[statName] < oldStats[oldStatName]) {
 					mainView.statsView.showStatDown(statName);
 				}
+			}
+		}
+		
+		public function buttonIsVisible(index:int):Boolean {
+			if ( index < 0 || index > MAX_BUTTON_INDEX ) {
+				return undefined;
+			}
+			else {
+				return button(index).visible;
 			}
 		}
 	}

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -361,5 +361,18 @@ package classes
 			addButton(0, "Yes", eventYes);
 			addButton(1, "No", eventNo);
 		}
+		
+		/**
+		 * Clears all button and adds a 'Next' button.
+		 * @param	event The event function to call if the button is pressed.
+		 */
+		public function doNext(event:Function):void { //Now typesafe
+			//Prevent new events in combat from automatically overwriting a game over. 
+			if (kGAMECLASS.mainView.getButtonText(0).indexOf("Game Over") != -1) {
+				return;
+			}
+			menu();
+			addButton(0, "Next", event);
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -337,5 +337,18 @@ package classes
 			}
 			kGAMECLASS.mainView.hideBottomButton( buttonToRemove );
 		}
+		
+		/**
+		 * Hides all bottom buttons.
+		 * 
+		 * <b>Note:</b> Calling this with open formatting tags can result in strange behaviour, 
+		 * e.g. all text will be formatted instead of only a section.
+		 */
+		public function menu():void { //The newer, simpler menu - blanks all buttons so addButton can be used
+			for (var i:int = 0; i <= MAX_BUTTON_INDEX; i++) {
+				kGAMECLASS.mainView.hideBottomButton(i);
+			}
+			flush();
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -251,5 +251,14 @@ package classes
 				return button(index).visible;
 			}
 		}
+		
+		public function buttonTextIsOneOf(index:int, possibleLabels:Array):Boolean {
+			var label:String;
+			var buttonText:String;
+
+			buttonText = this.getButtonText(index);
+
+			return (possibleLabels.indexOf(buttonText) != -1);
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -207,5 +207,38 @@ package classes
 			},0);
 			return this;
 		}
+		
+		/**
+		 * Get the old stats variable from CoC. 
+		 * @return legacy oldstats variable
+		 */
+		private function getOldStats():Object {
+			return kGAMECLASS.oldStats;
+		}
+		
+		public function showUpDown():void {
+			var oldStats:Object = getOldStats();
+			
+			function _oldStatNameFor(statName:String):String {
+				return 'old' + statName.charAt(0).toUpperCase() + statName.substr(1);
+			}
+
+			var statName:String;
+			var	oldStatName:String;
+			var allStats:Array;
+
+			allStats = ["str", "tou", "spe", "inte", "lib", "sens", "cor", "HP", "lust", "fatigue", "hunger"];
+
+			for each(statName in allStats) {
+				oldStatName = _oldStatNameFor(statName);
+
+				if (player[statName] > oldStats[oldStatName]) {
+					mainView.statsView.showStatUp(statName);
+				}
+				if (player[statName] < oldStats[oldStatName]) {
+					mainView.statsView.showStatDown(statName);
+				}
+			}
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -260,5 +260,16 @@ package classes
 
 			return (possibleLabels.indexOf(buttonText) != -1);
 		}
+		
+		public function getButtonText(index:int):String {
+			var matches:*;
+
+			if (index < 0 || index > MAX_BUTTON_INDEX) {
+				return '';
+			}
+			else {
+				return button(index).labelText;
+			}
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -350,5 +350,16 @@ package classes
 			}
 			flush();
 		}
+		
+		/**
+		 * Clears all button and adds a 'Yes' and a 'No' button.
+		 * @param	eventYes The event parser or function to call if 'Yes' button is pressed.
+		 * @param	eventNo The event parser or function to call if 'No' button is pressed.
+		 */
+		public function doYesNo(eventYes:Function, eventNo:Function):void { //New typesafe version
+			menu();
+			addButton(0, "Yes", eventYes);
+			addButton(1, "No", eventNo);
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -303,5 +303,19 @@ package classes
 			flush();
 			return btn;
 		}
+		
+		public function addButtonDisabled(pos:int, text:String = "", toolTipText:String = "", toolTipHeader:String = ""):CoCButton {
+			var btn:CoCButton = kGAMECLASS.button(pos);
+			//Removes sex-related button in SFW mode.
+			if (kGAMECLASS.flags[kFLAGS.SFW_MODE] > 0) {
+				if (text.indexOf("Sex") != -1 || text.indexOf("Threesome") != -1 ||  text.indexOf("Foursome") != -1 || text == "Watersports" || text == "Make Love" || text == "Use Penis" || text == "Use Vagina" || text.indexOf("Fuck") != -1 || text.indexOf("Ride") != -1 || (text.indexOf("Mount") != -1 && text.indexOf("Mountain") == -1) || text.indexOf("Vagina") != -1) {
+					//trace("Button removed due to SFW mode.");
+					return btn.hide();
+				}
+			}
+
+			btn.showDisabled(text,toolTipText,toolTipHeader);
+			return btn;
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -374,5 +374,13 @@ package classes
 			menu();
 			addButton(0, "Next", event);
 		}
+		
+		/**
+		 * Used to update the display of statistics
+		 */
+		public function statScreenRefresh():void {
+			kGAMECLASS.mainView.statsView.show(); // show() method refreshes.
+			kGAMECLASS.mainViewManager.refreshStats();
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -2,7 +2,8 @@ package classes
 {
 	import classes.internals.GuiOutput;
 	import flash.utils.setTimeout;
-
+	import coc.view.CoCButton;
+	
 	/**
 	 * Class to replace the old and somewhat outdated output-system, which mostly uses the include-file includes/engineCore.as
 	 * @since  08.08.2016
@@ -270,6 +271,37 @@ package classes
 			else {
 				return kGAMECLASS.button(index).labelText;
 			}
+		}
+		
+		/**
+		 * Adds a button.
+		 * @param	pos Determines the position. Starts at 0. (First row is 0-4, second row is 5-9, third row is 10-14.)
+		 * @param	text Determines the text that will appear on button.
+		 * @param	func1 Determines what function to trigger.
+		 * @param	arg1 Pass argument #1 to func1 parameter.
+		 * @param	arg2 Pass argument #1 to func1 parameter.
+		 * @param	arg3 Pass argument #1 to func1 parameter.
+		 * @param	toolTipText The text that will appear on tooltip when the mouse goes over the button.
+		 * @param	toolTipHeader The text that will appear on the tooltip header. If not specified, it defaults to button text.
+		 */
+		public function addButton(pos:int, text:String = "", func1:Function = null, arg1:* = -9000, arg2:* = -9000, arg3:* = -9000, toolTipText:String = "", toolTipHeader:String = ""):CoCButton {
+			var btn:CoCButton = kGAMECLASS.button(pos);
+			if (func1==null) {
+				return btn.hide();
+			}
+			var callback:Function;
+
+			//Removes sex-related button in SFW mode.
+			if (kGAMECLASS.flags[kFLAGS.SFW_MODE] > 0) {
+				if (text.indexOf("Sex") != -1 || text.indexOf("Threesome") != -1 ||  text.indexOf("Foursome") != -1 || text == "Watersports" || text == "Make Love" || text == "Use Penis" || text == "Use Vagina" || text.indexOf("Fuck") != -1 || text.indexOf("Ride") != -1 || (text.indexOf("Mount") != -1 && text.indexOf("Mountain") == -1) || text.indexOf("Vagina") != -1) {
+					return btn.hide();
+				}
+			}
+			callback = kGAMECLASS.createCallBackFunction(func1, arg1, arg2, arg3);
+
+			btn.show(text,callback, toolTipText, toolTipHeader);
+			flush();
+			return btn;
 		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -8,7 +8,7 @@ package classes
 	 * @since  08.08.2016
 	 * @author Stadler76
 	 */
-	public class Output extends BaseContent implements GuiOutput
+	public class Output implements GuiOutput
 	{
 		public static const MAX_BUTTON_INDEX:int = 14;
 		
@@ -54,7 +54,7 @@ package classes
 		{
 			// This is cleaup in case someone hits the Data or new-game button when the event-test window is shown. 
 			// It's needed since those buttons are available even when in the event-tester
-			mainView.hideTestInputPanel();
+			kGAMECLASS.mainView.hideTestInputPanel();
 
 			text = kGAMECLASS.parser.recursiveParser(text);
 			record(text);
@@ -75,8 +75,8 @@ package classes
 		 */
 		public function flush():void
 		{
-			mainViewManager.setText(_currentText);
-			credits.show();
+			kGAMECLASS.mainViewManager.setText(_currentText);
+			kGAMECLASS.credits.show();
 		}
 
 		/**
@@ -111,16 +111,16 @@ package classes
 		{
 			if (hideMenuButtons) {
 				forceUpdate();
-				if (kGAMECLASS.gameState != 3) mainView.hideMenuButton(MainView.MENU_DATA);
-				mainView.hideMenuButton(MainView.MENU_APPEARANCE);
-				mainView.hideMenuButton(MainView.MENU_LEVEL);
-				mainView.hideMenuButton(MainView.MENU_PERKS);
-				mainView.hideMenuButton(MainView.MENU_STATS);
+				if (kGAMECLASS.gameState != 3) kGAMECLASS.mainView.hideMenuButton(MainView.MENU_DATA);
+				kGAMECLASS.mainView.hideMenuButton(MainView.MENU_APPEARANCE);
+				kGAMECLASS.mainView.hideMenuButton(MainView.MENU_LEVEL);
+				kGAMECLASS.mainView.hideMenuButton(MainView.MENU_PERKS);
+				kGAMECLASS.mainView.hideMenuButton(MainView.MENU_STATS);
 			}
 			nextEntry();
 			_currentText = "";
-			mainView.clearOutputText();
-			credits.clear();
+			kGAMECLASS.mainView.clearOutputText();
+			kGAMECLASS.credits.clear();
 			return this;
 		}
 
@@ -205,7 +205,7 @@ package classes
 			clearCurrentEntry();
 			// On the next animation frame
 			setTimeout(function():void {
-				mainView.scrollBar.value = mainView.scrollBar.maximum;
+				kGAMECLASS.mainView.scrollBar.value = kGAMECLASS.mainView.scrollBar.maximum;
 			},0);
 			return this;
 		}
@@ -234,11 +234,11 @@ package classes
 			for each(statName in allStats) {
 				oldStatName = _oldStatNameFor(statName);
 
-				if (player[statName] > oldStats[oldStatName]) {
-					mainView.statsView.showStatUp(statName);
+				if (kGAMECLASS.player[statName] > oldStats[oldStatName]) {
+					kGAMECLASS.mainView.statsView.showStatUp(statName);
 				}
-				if (player[statName] < oldStats[oldStatName]) {
-					mainView.statsView.showStatDown(statName);
+				if (kGAMECLASS.player[statName] < oldStats[oldStatName]) {
+					kGAMECLASS.mainView.statsView.showStatDown(statName);
 				}
 			}
 		}
@@ -248,7 +248,7 @@ package classes
 				return undefined;
 			}
 			else {
-				return button(index).visible;
+				return kGAMECLASS.button(index).visible;
 			}
 		}
 		
@@ -268,7 +268,7 @@ package classes
 				return '';
 			}
 			else {
-				return button(index).labelText;
+				return kGAMECLASS.button(index).labelText;
 			}
 		}
 	}

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -391,5 +391,16 @@ package classes
 			kGAMECLASS.mainViewManager.refreshStats();
 			kGAMECLASS.mainViewManager.tweenInStats();
 		}
+		
+		/**
+		 * Hide the stats pane. (Name, stats and attributes)
+		 */
+		public function hideStats():void {
+			if (!kGAMECLASS.mainViewManager.buttonsTweened) {
+				kGAMECLASS.mainView.statsView.hide();
+			}
+			
+			kGAMECLASS.mainViewManager.tweenOutStats();
+		}
 	}
 }

--- a/classes/classes/Output.as
+++ b/classes/classes/Output.as
@@ -249,7 +249,7 @@ package classes
 				return undefined;
 			}
 			else {
-				return kGAMECLASS.button(index).visible;
+				return kGAMECLASS.output.button(index).visible;
 			}
 		}
 		
@@ -269,7 +269,7 @@ package classes
 				return '';
 			}
 			else {
-				return kGAMECLASS.button(index).labelText;
+				return kGAMECLASS.output.button(index).labelText;
 			}
 		}
 		
@@ -285,7 +285,7 @@ package classes
 		 * @param	toolTipHeader The text that will appear on the tooltip header. If not specified, it defaults to button text.
 		 */
 		public function addButton(pos:int, text:String = "", func1:Function = null, arg1:* = -9000, arg2:* = -9000, arg3:* = -9000, toolTipText:String = "", toolTipHeader:String = ""):CoCButton {
-			var btn:CoCButton = kGAMECLASS.button(pos);
+			var btn:CoCButton = kGAMECLASS.output.button(pos);
 			if (func1==null) {
 				return btn.hide();
 			}
@@ -305,7 +305,7 @@ package classes
 		}
 		
 		public function addButtonDisabled(pos:int, text:String = "", toolTipText:String = "", toolTipHeader:String = ""):CoCButton {
-			var btn:CoCButton = kGAMECLASS.button(pos);
+			var btn:CoCButton = kGAMECLASS.output.button(pos);
 			//Removes sex-related button in SFW mode.
 			if (kGAMECLASS.flags[kFLAGS.SFW_MODE] > 0) {
 				if (text.indexOf("Sex") != -1 || text.indexOf("Threesome") != -1 ||  text.indexOf("Foursome") != -1 || text == "Watersports" || text == "Make Love" || text == "Use Penis" || text == "Use Vagina" || text.indexOf("Fuck") != -1 || text.indexOf("Ride") != -1 || (text.indexOf("Mount") != -1 && text.indexOf("Mountain") == -1) || text.indexOf("Vagina") != -1) {
@@ -316,6 +316,10 @@ package classes
 
 			btn.showDisabled(text,toolTipText,toolTipHeader);
 			return btn;
+		}
+		
+		public function button(pos:int):CoCButton {
+			return kGAMECLASS.mainView.bottomButtons[pos];
 		}
 	}
 }

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -606,7 +606,7 @@
 				//Prevent negatives
 				if (HP<=0){
 					HP = 0;
-					//This call did nothing. There is no event 5010: if (game.inCombat) game.doNext(5010);
+					//This call did nothing. There is no event 5010: if (game.inCombat) kGAMECLASS.output.doNext(5010);
 				}
 			}
 			return returnDamage;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -2793,7 +2793,7 @@
 				if (findPerk(PerkLib.Sensitive) >= 0 && dsens >= 0) dsens*= 1+ perk(findPerk(PerkLib.Sensitive)).value1;
 			}
 			super.modStats(dstr, dtou, dspe, dinte, dlib, dsens, dlust, dcor, false, max);
-			game.showUpDown();
+			game.output.showUpDown();
 			game.statScreenRefresh();
 		}
 

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -2184,7 +2184,7 @@
 				if (oldHunger >= 90) kGAMECLASS.awardAchievement("Glutton ", kACHIEVEMENTS.REALISTIC_GLUTTON);
 				if (hunger > oldHunger) kGAMECLASS.mainView.statsView.showStatUp("hunger");
 				game.dynStats("lus", 0, "scale", false);
-				kGAMECLASS.statScreenRefresh();
+				kGAMECLASS.output.statScreenRefresh();
 			}
 		}
 		
@@ -2352,7 +2352,7 @@
 			kGAMECLASS.dynStats("lus", 0, "scale", false); //Force display fatigue up/down by invoking zero lust change.
 			if (fatigue > maxFatigue()) fatigue = maxFatigue();
 			if (fatigue < 0) fatigue = 0;
-			kGAMECLASS.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 		}
 		
 		public function armorDescript(nakedText:String = "gear"):String
@@ -2794,7 +2794,7 @@
 			}
 			super.modStats(dstr, dtou, dspe, dinte, dlib, dsens, dlust, dcor, false, max);
 			game.output.showUpDown();
-			game.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 		}
 
 
@@ -2911,7 +2911,7 @@
 		{
 			if (kGAMECLASS.monster.hasStatusEffect(StatusEffects.TwuWuv)) {
 				inte += kGAMECLASS.monster.statusEffectv1(StatusEffects.TwuWuv);
-				kGAMECLASS.statScreenRefresh();
+				kGAMECLASS.output.statScreenRefresh();
 				kGAMECLASS.mainView.statsView.showStatUp( 'inte' );
 			}
 			if (hasStatusEffect(StatusEffects.Disarmed)) {
@@ -3441,7 +3441,7 @@
 			}
 			
 			dynStats("lust", 0, "scale", false); //Workaround to showing the arrow.
-			kGAMECLASS.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 			return HP - before;
 		}
 

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -448,7 +448,7 @@ package classes {
 					getGame().dynStats("lib", -player.statusEffectv2(StatusEffects.Heat), "scale");
 					player.removeStatusEffect(StatusEffects.Heat); //remove heat
 					if (player.lib < 1) player.lib = 1;
-					getGame().statScreenRefresh();
+					output.statScreenRefresh();
 					outputText("\n<b>Your body calms down, at last getting over your heat.</b>\n");
 					needNext = true;
 				}
@@ -461,7 +461,7 @@ package classes {
 					getGame().dynStats("lib", -player.statusEffectv2(StatusEffects.Rut), "scale", false);
 					player.removeStatusEffect(StatusEffects.Rut); //remove heat
 					if (player.lib < 10) player.lib = 10;
-					getGame().statScreenRefresh();
+					output.statScreenRefresh();
 					outputText("\n<b>Your body calms down, at last getting over your rut.</b>\n");
 					needNext = true;
 				}

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -1010,7 +1010,7 @@ package classes {
 					player.fertilizeEggs(); //convert eggs to fertilized based on player cum output, reduce lust by 100 and then add 20 lust
 					player.orgasm('Dick'); //reduce lust by 100 and add 20, convert eggs to fertilized depending on cum output
 					getGame().dynStats("lus", 20);
-					getGame().doNext(playerMenu);
+					kGAMECLASS.output.doNext(playerMenu);
 					//Hey Fenoxo - maybe the unsexed characters get a few \"cock up the ovipositor\" scenes for fertilization with some characters (probably only willing ones)?
 					//Hey whoever, maybe you write them? -Z
 					return true;
@@ -1030,7 +1030,7 @@ package classes {
 					player.fertilizeEggs(); //reduce lust by 100 and add 20, convert eggs to fertilized depending on cum output
 					player.orgasm('Dick');
 					getGame().dynStats("lus", 20);
-					getGame().doNext(playerMenu);
+					kGAMECLASS.output.doNext(playerMenu);
 					//Hey Fenoxo - maybe the unsexed characters get a few \"cock up the ovipositor\" scenes for fertilization with some characters (probably only willing ones)?
 					//Hey whoever, maybe you write them? -Z
 					return true;

--- a/classes/classes/Scenes/Areas/Desert/DemonPack.as
+++ b/classes/classes/Scenes/Areas/Desert/DemonPack.as
@@ -5,6 +5,7 @@ package classes.Scenes.Areas.Desert
 	import classes.BodyParts.Hips;
 	import classes.internals.WeightedDrop;
 	import classes.GlobalFlags.kFLAGS;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public class DemonPack extends Monster
 	{
@@ -33,7 +34,7 @@ package classes.Scenes.Areas.Desert
 				game.combat.cleanupAfterCombat();
 			} else {
 				outputText("  Do you rape them?");
-				game.doYesNo(rapeDemons, game.combat.cleanupAfterCombat);
+				kGAMECLASS.output.doYesNo(rapeDemons, game.combat.cleanupAfterCombat);
 			}
 		}
 

--- a/classes/classes/Scenes/Areas/Forest/AkbalScene.as
+++ b/classes/classes/Scenes/Areas/Forest/AkbalScene.as
@@ -467,7 +467,7 @@ public class AkbalScene extends BaseContent implements Encounter
 		private function girlsRapeAkbalPart2():void
 		{
 			clearOutput();
-			kGAMECLASS.hideUpDown();
+			kGAMECLASS.output.hideUpDown();
 			//Centaur
 			outputText(images.showImage("akbal-deepwoods-female-taur-bindakbal"));
 			if (player.isTaur())

--- a/classes/classes/Scenes/Areas/Forest/TentacleBeast.as
+++ b/classes/classes/Scenes/Areas/Forest/TentacleBeast.as
@@ -5,6 +5,7 @@ package classes.Scenes.Areas.Forest
 	import classes.internals.*;
 	import classes.GlobalFlags.kACHIEVEMENTS;
 	import classes.GlobalFlags.kFLAGS;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public class TentacleBeast extends Monster
 	{
@@ -64,7 +65,7 @@ package classes.Scenes.Areas.Forest
 			else {
 				if (!hpVictory && player.gender > 0 && flags[kFLAGS.SFW_MODE] <= 0) {
 					outputText("  Perhaps you could use it to sate yourself?");
-					game.doYesNo(game.forest.tentacleBeastScene.tentacleVictoryRape,game.combat.cleanupAfterCombat);
+					kGAMECLASS.output.doYesNo(game.forest.tentacleBeastScene.tentacleVictoryRape,game.combat.cleanupAfterCombat);
 				} else {
 					game.combat.cleanupAfterCombat();
 				}

--- a/classes/classes/Scenes/Areas/Lake/FetishCultist.as
+++ b/classes/classes/Scenes/Areas/Lake/FetishCultist.as
@@ -130,7 +130,7 @@ package classes.Scenes.Areas.Lake
 				return;
 			}
 			
-			game.menu();
+			kGAMECLASS.output.menu();
 			
 			kGAMECLASS.output.addButtonDisabled(0, "Sex", "This scene requires you to have genitals and sufficient arousal.");
 			kGAMECLASS.output.addButtonDisabled(1, "B. Feed", "This scene requires you to have enough milk.");

--- a/classes/classes/Scenes/Areas/Lake/FetishCultist.as
+++ b/classes/classes/Scenes/Areas/Lake/FetishCultist.as
@@ -132,8 +132,8 @@ package classes.Scenes.Areas.Lake
 			
 			game.menu();
 			
-			game.addButtonDisabled(0, "Sex", "This scene requires you to have genitals and sufficient arousal.");
-			game.addButtonDisabled(1, "B. Feed", "This scene requires you to have enough milk.");
+			kGAMECLASS.output.addButtonDisabled(0, "Sex", "This scene requires you to have genitals and sufficient arousal.");
+			kGAMECLASS.output.addButtonDisabled(1, "B. Feed", "This scene requires you to have enough milk.");
 			
 			if (player.lust >= 33 && !player.isGenderless()) {
 				outputText("  You realize she'd make a perfect receptacle for your lusts.  Do you have your way with her?");

--- a/classes/classes/Scenes/Areas/Lake/FetishCultist.as
+++ b/classes/classes/Scenes/Areas/Lake/FetishCultist.as
@@ -137,14 +137,14 @@ package classes.Scenes.Areas.Lake
 			
 			if (player.lust >= 33 && !player.isGenderless()) {
 				outputText("  You realize she'd make a perfect receptacle for your lusts.  Do you have your way with her?");
-				game.addButton(0, "Sex", game.lake.fetishCultistScene.playerRapesCultist);
+				kGAMECLASS.output.addButton(0, "Sex", game.lake.fetishCultistScene.playerRapesCultist);
 			}
 			
 			if (player.hasStatusEffect(StatusEffects.Feeder) || player.lactationQ() >= 500) {
-				game.addButton(1, "B. Feed", game.lake.fetishCultistScene.fetishCultistHasAMilkFetish);
+				kGAMECLASS.output.addButton(1, "B. Feed", game.lake.fetishCultistScene.fetishCultistHasAMilkFetish);
 			}
 		
-			game.addButton(14, "Leave", game.combat.cleanupAfterCombat);
+			kGAMECLASS.output.addButton(14, "Leave", game.combat.cleanupAfterCombat);
 		}
 
 		override public function won(hpVictory:Boolean, pcCameWorms:Boolean):void

--- a/classes/classes/Scenes/Areas/Mountain/HellHound.as
+++ b/classes/classes/Scenes/Areas/Mountain/HellHound.as
@@ -78,8 +78,8 @@ package classes.Scenes.Areas.Mountain
 			}
 			game.menu();
 			
-			game.addButtonDisabled(0, "Fuck it", "Ride his twin cocks. This scene requires you to have vagina and sufficient arousal. This scene can not accommodate naga body.");
-			game.addButtonDisabled(1, "Lick", "Make him use his tongues. This scene requires you to have genitals and sufficient arousal. This scene requires lust victory.");
+			kGAMECLASS.output.addButtonDisabled(0, "Fuck it", "Ride his twin cocks. This scene requires you to have vagina and sufficient arousal. This scene can not accommodate naga body.");
+			kGAMECLASS.output.addButtonDisabled(1, "Lick", "Make him use his tongues. This scene requires you to have genitals and sufficient arousal. This scene requires lust victory.");
 			
 			if (player.lust >= 33 && !player.isGenderless()) {
 				if (player.hasVagina() && !player.isNaga()) {

--- a/classes/classes/Scenes/Areas/Mountain/HellHound.as
+++ b/classes/classes/Scenes/Areas/Mountain/HellHound.as
@@ -3,6 +3,7 @@ package classes.Scenes.Areas.Mountain
 	import classes.*;
 	import classes.BodyParts.*;
 	import classes.internals.*;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public class HellHound extends Monster
 	{
@@ -82,14 +83,14 @@ package classes.Scenes.Areas.Mountain
 			
 			if (player.lust >= 33 && !player.isGenderless()) {
 				if (player.hasVagina() && !player.isNaga()) {
-					game.addButton(0, "Fuck it", game.mountain.hellHoundScene.hellHoundPropahRape, undefined, undefined, undefined, "Ride his twin cocks.");
+					kGAMECLASS.output.addButton(0, "Fuck it", game.mountain.hellHoundScene.hellHoundPropahRape, undefined, undefined, undefined, "Ride his twin cocks.");
 				}
 				if (!hpVictory) {
-					game.addButton(1, "Lick", game.mountain.hellHoundScene.hellHoundGetsRaped, undefined, undefined, undefined, "Make him use his tongues.");
+					kGAMECLASS.output.addButton(1, "Lick", game.mountain.hellHoundScene.hellHoundGetsRaped, undefined, undefined, undefined, "Make him use his tongues.");
 				}
 			}
 			
-			game.addButton(14, "Leave", game.combat.cleanupAfterCombat);
+			kGAMECLASS.output.addButton(14, "Leave", game.combat.cleanupAfterCombat);
 		}
 
 		override public function won(hpVictory:Boolean, pcCameWorms:Boolean):void

--- a/classes/classes/Scenes/Areas/Mountain/HellHound.as
+++ b/classes/classes/Scenes/Areas/Mountain/HellHound.as
@@ -76,7 +76,7 @@ package classes.Scenes.Areas.Mountain
 			} else {
 				outputText("Unable to bear hurting you anymore, the hellhound's flames dim as he stops his attack. The two heads look at you, whining plaintively.  The hellhound slowly pads over to you and nudges its noses at your crotch.  It seems he wishes to pleasure you.\n\n");
 			}
-			game.menu();
+			kGAMECLASS.output.menu();
 			
 			kGAMECLASS.output.addButtonDisabled(0, "Fuck it", "Ride his twin cocks. This scene requires you to have vagina and sufficient arousal. This scene can not accommodate naga body.");
 			kGAMECLASS.output.addButtonDisabled(1, "Lick", "Make him use his tongues. This scene requires you to have genitals and sufficient arousal. This scene requires lust victory.");

--- a/classes/classes/Scenes/Areas/Mountain/InfestedHellhound.as
+++ b/classes/classes/Scenes/Areas/Mountain/InfestedHellhound.as
@@ -75,7 +75,7 @@ package classes.Scenes.Areas.Mountain
 			
 			game.menu();
 			
-			game.addButtonDisabled(0, "Lick", "Make him use his tongues. This scene requires you to have genitals and sufficient arousal. This scene requires lust victory.");
+			kGAMECLASS.output.addButtonDisabled(0, "Lick", "Make him use his tongues. This scene requires you to have genitals and sufficient arousal. This scene requires lust victory.");
 			
 			if (player.lust >= 33 && !player.isGenderless()) {
 				if (!hpVictory) {

--- a/classes/classes/Scenes/Areas/Mountain/InfestedHellhound.as
+++ b/classes/classes/Scenes/Areas/Mountain/InfestedHellhound.as
@@ -3,6 +3,7 @@ package classes.Scenes.Areas.Mountain
 	import classes.*;
 	import classes.BodyParts.*;
 	import classes.internals.*;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	/**
 	 * ...
@@ -78,11 +79,11 @@ package classes.Scenes.Areas.Mountain
 			
 			if (player.lust >= 33 && !player.isGenderless()) {
 				if (!hpVictory) {
-					game.addButton(0, "Lick", game.mountain.hellHoundScene.hellHoundGetsRaped, undefined, undefined, undefined, "Make him use his tongues.");
+					kGAMECLASS.output.addButton(0, "Lick", game.mountain.hellHoundScene.hellHoundGetsRaped, undefined, undefined, undefined, "Make him use his tongues.");
 				}
 			}
 			
-			game.addButton(14, "Leave", game.combat.cleanupAfterCombat);
+			kGAMECLASS.output.addButton(14, "Leave", game.combat.cleanupAfterCombat);
 		}
 
 		override public function won(hpVictory:Boolean, pcCameWorms:Boolean):void

--- a/classes/classes/Scenes/Areas/Mountain/InfestedHellhound.as
+++ b/classes/classes/Scenes/Areas/Mountain/InfestedHellhound.as
@@ -73,7 +73,7 @@ package classes.Scenes.Areas.Mountain
 				outputText("Unable to bear its unnatural arousal, the infested hellhound's flames dim as he stops his attack. The two heads look at you, whining plaintively.  The hellhound slowly pads over to you and nudges its noses at your crotch.  It seems he wishes to pleasure you.\n\n");
 			}
 			
-			game.menu();
+			kGAMECLASS.output.menu();
 			
 			kGAMECLASS.output.addButtonDisabled(0, "Lick", "Make him use his tongues. This scene requires you to have genitals and sufficient arousal. This scene requires lust victory.");
 			

--- a/classes/classes/Scenes/Areas/Plains/Gnoll.as
+++ b/classes/classes/Scenes/Areas/Plains/Gnoll.as
@@ -3,6 +3,7 @@ package classes.Scenes.Areas.Plains
 	import classes.*;
 	import classes.BodyParts.*;
 	import classes.internals.*;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	/**
 	 * ...
@@ -86,7 +87,7 @@ package classes.Scenes.Areas.Plains
 					outputText(" ");
 					player.takeDamage(damage, true);
 				}
-				game.statScreenRefresh();
+				kGAMECLASS.output.statScreenRefresh();
 			}
 		}
 		
@@ -199,7 +200,7 @@ package classes.Scenes.Areas.Plains
 					outputText(" ");
 					player.takeDamage(damage, true);
 				}
-				game.statScreenRefresh();
+				kGAMECLASS.output.statScreenRefresh();
 			}
 		}
 
@@ -338,7 +339,7 @@ package classes.Scenes.Areas.Plains
 						outputText(" ");
 						player.takeDamage(damage);
 					}
-					game.statScreenRefresh();
+					kGAMECLASS.output.statScreenRefresh();
 				}
 				gnollAttackText();
 			}

--- a/classes/classes/Scenes/Areas/Plains/GnollSpearThrower.as
+++ b/classes/classes/Scenes/Areas/Plains/GnollSpearThrower.as
@@ -4,6 +4,7 @@ package classes.Scenes.Areas.Plains
 	import classes.BodyParts.*;
 import classes.StatusEffects.Combat.GnollSpearDebuff;
 import classes.internals.*;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	/**
 	 * ...
@@ -307,9 +308,9 @@ import classes.internals.*;
 				game.clearOutput();
 				outputText("The gnoll alpha is defeated!  You could use her for a quick, willing fuck to sate your lusts before continuing on.  Hell, you could even dose her up with that succubi milk you took from the goblin first - it might make her even hotter.  Do you?");
 				game.menu();
-				game.addButton(0,"Fuck",	game.urtaQuest.winRapeHyenaPrincess);
-				game.addButton(1,"Succ Milk", game.urtaQuest.useSuccubiMilkOnGnollPrincesses);
-				game.addButton(4,"Leave",game.urtaQuest.urtaNightSleep);
+				kGAMECLASS.output.addButton(0,"Fuck",	game.urtaQuest.winRapeHyenaPrincess);
+				kGAMECLASS.output.addButton(1,"Succ Milk", game.urtaQuest.useSuccubiMilkOnGnollPrincesses);
+				kGAMECLASS.output.addButton(4,"Leave",game.urtaQuest.urtaNightSleep);
 			} else {
 				game.plains.gnollSpearThrowerScene.hyenaVictory();
 			}

--- a/classes/classes/Scenes/Areas/Plains/GnollSpearThrower.as
+++ b/classes/classes/Scenes/Areas/Plains/GnollSpearThrower.as
@@ -307,7 +307,7 @@ import classes.internals.*;
 			if (short == "alpha gnoll") {
 				game.clearOutput();
 				outputText("The gnoll alpha is defeated!  You could use her for a quick, willing fuck to sate your lusts before continuing on.  Hell, you could even dose her up with that succubi milk you took from the goblin first - it might make her even hotter.  Do you?");
-				game.menu();
+				kGAMECLASS.output.menu();
 				kGAMECLASS.output.addButton(0,"Fuck",	game.urtaQuest.winRapeHyenaPrincess);
 				kGAMECLASS.output.addButton(1,"Succ Milk", game.urtaQuest.useSuccubiMilkOnGnollPrincesses);
 				kGAMECLASS.output.addButton(4,"Leave",game.urtaQuest.urtaNightSleep);

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -630,13 +630,13 @@ private function doCamp():void { //only called by playerMenu
 		addButton(12, "Cash Shop", getGame().aprilFools.pay2WinSelection).hint("Need more gems? Want to buy special items to give you the edge? Purchase with real money!");
 	//Remove buttons according to conditions
 	if (getGame().time.hours >= 21 || getGame().time.hours < 6) {
-		addDisabledButton(0, getButtonText(0), "It's too dark outside. It wouldn't be a good idea to explore when danger lurks in every corner of darkness."); //Explore
-		addDisabledButton(1, getButtonText(1), "It's too dark outside. It wouldn't be a good idea to explore when danger lurks in every corner of darkness."); //Explore
+		addDisabledButton(0, kGAMECLASS.output.getButtonText(0), "It's too dark outside. It wouldn't be a good idea to explore when danger lurks in every corner of darkness."); //Explore
+		addDisabledButton(1, kGAMECLASS.output.getButtonText(1), "It's too dark outside. It wouldn't be a good idea to explore when danger lurks in every corner of darkness."); //Explore
 		if (getGame().time.hours >= 23 || getGame().time.hours < 5) {
-			addDisabledButton(4, getButtonText(4), "You are too tired to perform any camp actions. All you can do right now is to sleep until morning."); //Camp Actions
-			if (followersCount() > 0) addDisabledButton(5, getButtonText(5), "Your followers are sleeping at the moment."); //Followers
-			if (loversCount() > 0) addDisabledButton(6, getButtonText(6), "Your lovers are sleeping at the moment."); //Followers
-			if (slavesCount() > 0) addDisabledButton(6, getButtonText(7), "Your slaves are sleeping at the moment. Even slaves need their sleepy times to recuperate."); //Followers
+			addDisabledButton(4, kGAMECLASS.output.getButtonText(4), "You are too tired to perform any camp actions. All you can do right now is to sleep until morning."); //Camp Actions
+			if (followersCount() > 0) addDisabledButton(5, kGAMECLASS.output.getButtonText(5), "Your followers are sleeping at the moment."); //Followers
+			if (loversCount() > 0) addDisabledButton(6, kGAMECLASS.output.getButtonText(6), "Your lovers are sleeping at the moment."); //Followers
+			if (slavesCount() > 0) addDisabledButton(6, kGAMECLASS.output.getButtonText(7), "Your slaves are sleeping at the moment. Even slaves need their sleepy times to recuperate."); //Followers
 		}
 	}
 	if (player.lust >= player.maxLust() && canFap) {

--- a/classes/classes/Scenes/Camp/CabinProgress.as
+++ b/classes/classes/Scenes/Camp/CabinProgress.as
@@ -88,7 +88,7 @@ package classes.Scenes.Camp
 				outputText("You suddenly have the strange urge to punch trees. Do you punch the tree? \n") 
 				addButton(2, "Punch Tree", punchTreeMinecraftStyle);
 			}
-			if (!(buttonIsVisible(0) || buttonIsVisible(1) || buttonIsVisible(2))) {
+			if (!(output.buttonIsVisible(0) || output.buttonIsVisible(1) || output.buttonIsVisible(2))) {
 				outputText("<b>Unfortunately, there is nothing you can do right now.</b>");
 			}
 			addButton(14, "Leave", noThanks);

--- a/classes/classes/Scenes/Codex.as
+++ b/classes/classes/Scenes/Codex.as
@@ -183,7 +183,7 @@ package classes.Scenes
 		private function addCodexButton(codexEntryName:String, codexEntryId:String, codexEntry:Function, flag:int):void {
 			var button:int = 0;
 			for (var i:int = 0; i < 14; i++) {
-				if (buttonIsVisible(i)) button++;
+				if (output.buttonIsVisible(i)) button++;
 				if (button == 4 || button == 9) button++; //Last slot of the row is reserved for next and previous.
 			}
 			if (flags[flag] > 0) {

--- a/classes/classes/Scenes/Crafting.as
+++ b/classes/classes/Scenes/Crafting.as
@@ -49,7 +49,7 @@ package classes.Scenes
 			var goal:int = 14;
 			while (temp < goal)
 			{
-				if (buttonIsVisible(temp)) {
+				if (output.buttonIsVisible(temp)) {
 					button++;
 				}
 				if (button == 4 || button == 9) button++;

--- a/classes/classes/Scenes/Dungeons/Factory/IncubusMechanic.as
+++ b/classes/classes/Scenes/Dungeons/Factory/IncubusMechanic.as
@@ -27,7 +27,7 @@ package classes.Scenes.Dungeons.Factory
 		
 		private function defeatedInDungeon1(hpVictory:Boolean):void {
 			clearOutput();
-			game.menu();
+			kGAMECLASS.output.menu();
 			if (hpVictory)
 				outputText("You smile in satisfaction as the " + short + " collapses, unable to continue fighting.");
 			else outputText("You smile in satisfaction as the " + short + " collapses, masturbating happily.");

--- a/classes/classes/Scenes/Dungeons/Factory/IncubusMechanic.as
+++ b/classes/classes/Scenes/Dungeons/Factory/IncubusMechanic.as
@@ -37,7 +37,7 @@ package classes.Scenes.Dungeons.Factory
 			if (!player.isGenderless()) {
 				kGAMECLASS.output.addButton(0, "Rape", game.lethicesKeep.incubusMechanic.doRapeIncubus).hint(player.hasCock() ? "Fuck his butt." : "Ride him vaginally.");
 			} else {
-				game.addButtonDisabled(0, "Rape", "This scene requires you to have genitals.");
+				kGAMECLASS.output.addButtonDisabled(0, "Rape", "This scene requires you to have genitals.");
 			}
 			kGAMECLASS.output.addButton(1, "Service Him", game.lethicesKeep.incubusMechanic.doOralIncubus).hint("Service the incubus orally.");
 			kGAMECLASS.output.addButton(2, "AnalRide", game.lethicesKeep.incubusMechanic.doRideIncubusAnally).hint("Ride him anally.");

--- a/classes/classes/Scenes/Dungeons/Factory/IncubusMechanic.as
+++ b/classes/classes/Scenes/Dungeons/Factory/IncubusMechanic.as
@@ -9,6 +9,7 @@ package classes.Scenes.Dungeons.Factory
 	import classes.internals.*;
 	import flash.display.InteractiveObject;
 	import classes.GlobalFlags.kFLAGS;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public class IncubusMechanic extends Monster {
 		
@@ -34,15 +35,15 @@ package classes.Scenes.Dungeons.Factory
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] >= 2 && flags[kFLAGS.FACTORY_INCUBUS_BRIBED] == 0) outputText("\n\n<b>You swear you can hear a clicking sound coming from the west.</b>");
 			
 			if (!player.isGenderless()) {
-				game.addButton(0, "Rape", game.lethicesKeep.incubusMechanic.doRapeIncubus).hint(player.hasCock() ? "Fuck his butt." : "Ride him vaginally.");
+				kGAMECLASS.output.addButton(0, "Rape", game.lethicesKeep.incubusMechanic.doRapeIncubus).hint(player.hasCock() ? "Fuck his butt." : "Ride him vaginally.");
 			} else {
 				game.addButtonDisabled(0, "Rape", "This scene requires you to have genitals.");
 			}
-			game.addButton(1, "Service Him", game.lethicesKeep.incubusMechanic.doOralIncubus).hint("Service the incubus orally.");
-			game.addButton(2, "AnalRide", game.lethicesKeep.incubusMechanic.doRideIncubusAnally).hint("Ride him anally.");
-			if (player.hasVagina() && player.biggestTitSize() >= 4 && player.armor == armors.LMARMOR) game.addButton(3, "B.Titfuck", (player.armor as LustyMaidensArmor).lustyMaidenPaizuri, player, this);
+			kGAMECLASS.output.addButton(1, "Service Him", game.lethicesKeep.incubusMechanic.doOralIncubus).hint("Service the incubus orally.");
+			kGAMECLASS.output.addButton(2, "AnalRide", game.lethicesKeep.incubusMechanic.doRideIncubusAnally).hint("Ride him anally.");
+			if (player.hasVagina() && player.biggestTitSize() >= 4 && player.armor == armors.LMARMOR) kGAMECLASS.output.addButton(3, "B.Titfuck", (player.armor as LustyMaidensArmor).lustyMaidenPaizuri, player, this);
 			// no disabled button for this option
-			game.addButton(14, "Leave", game.combat.cleanupAfterCombat);
+			kGAMECLASS.output.addButton(14, "Leave", game.combat.cleanupAfterCombat);
 		}
 		
 		private function defeatedInDungeon3(hpVictory:Boolean):void

--- a/classes/classes/Scenes/Dungeons/Factory/SecretarialSuccubus.as
+++ b/classes/classes/Scenes/Dungeons/Factory/SecretarialSuccubus.as
@@ -5,6 +5,7 @@ package classes.Scenes.Dungeons.Factory
 	import classes.Scenes.Monsters.AbstractSuccubus;
 	import classes.Scenes.Dungeons.Factory;
 	import classes.internals.*;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public class SecretarialSuccubus extends AbstractSuccubus 
 	{
@@ -18,12 +19,12 @@ package classes.Scenes.Dungeons.Factory
 					outputText("You smile in satisfaction as the " + short + " collapses, unable to continue fighting.  Now would be the perfect opportunity to taste the fruits of her sex-ready form...\n\nDo you rape her?");
 					player.takeLustDamage(1, true);
 					game.doYesNo(factory.secretarialSuccubus.doRapeSuccubus, factory.secretarialSuccubus.doLeaveSuccubus)
-					if (player.hasKeyItem("Deluxe Dildo") >= 0) game.addButton(2, "Dildo Rape", factory.secretarialSuccubus.dildoSuccubus);
+					if (player.hasKeyItem("Deluxe Dildo") >= 0) kGAMECLASS.output.addButton(2, "Dildo Rape", factory.secretarialSuccubus.dildoSuccubus);
 				} else if (player.lust >= 33) {	
 					outputText("You smile in satisfaction as the " + short + " gives up on fighting you and starts masturbating, begging for you to fuck her.  Now would be the perfect opportunity to taste the fruits of her sex-ready form...\n\nDo you fuck her?");
 					player.takeLustDamage(1, true);
 					game.doYesNo(factory.secretarialSuccubus.doRapeSuccubus, factory.secretarialSuccubus.doLeaveSuccubus)
-					if (player.hasKeyItem("Deluxe Dildo") >= 0) game.addButton(2, "Dildo Rape", factory.secretarialSuccubus.dildoSuccubus);
+					if (player.hasKeyItem("Deluxe Dildo") >= 0) kGAMECLASS.output.addButton(2, "Dildo Rape", factory.secretarialSuccubus.dildoSuccubus);
 				} else {
 					doNext(factory.secretarialSuccubus.doLeaveSuccubus);
 				}

--- a/classes/classes/Scenes/Dungeons/Factory/SecretarialSuccubus.as
+++ b/classes/classes/Scenes/Dungeons/Factory/SecretarialSuccubus.as
@@ -18,12 +18,12 @@ package classes.Scenes.Dungeons.Factory
 				if (hpVictory) {
 					outputText("You smile in satisfaction as the " + short + " collapses, unable to continue fighting.  Now would be the perfect opportunity to taste the fruits of her sex-ready form...\n\nDo you rape her?");
 					player.takeLustDamage(1, true);
-					game.doYesNo(factory.secretarialSuccubus.doRapeSuccubus, factory.secretarialSuccubus.doLeaveSuccubus)
+					kGAMECLASS.output.doYesNo(factory.secretarialSuccubus.doRapeSuccubus, factory.secretarialSuccubus.doLeaveSuccubus)
 					if (player.hasKeyItem("Deluxe Dildo") >= 0) kGAMECLASS.output.addButton(2, "Dildo Rape", factory.secretarialSuccubus.dildoSuccubus);
 				} else if (player.lust >= 33) {	
 					outputText("You smile in satisfaction as the " + short + " gives up on fighting you and starts masturbating, begging for you to fuck her.  Now would be the perfect opportunity to taste the fruits of her sex-ready form...\n\nDo you fuck her?");
 					player.takeLustDamage(1, true);
-					game.doYesNo(factory.secretarialSuccubus.doRapeSuccubus, factory.secretarialSuccubus.doLeaveSuccubus)
+					kGAMECLASS.output.doYesNo(factory.secretarialSuccubus.doRapeSuccubus, factory.secretarialSuccubus.doLeaveSuccubus)
 					if (player.hasKeyItem("Deluxe Dildo") >= 0) kGAMECLASS.output.addButton(2, "Dildo Rape", factory.secretarialSuccubus.dildoSuccubus);
 				} else {
 					doNext(factory.secretarialSuccubus.doLeaveSuccubus);

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
@@ -567,7 +567,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 				outputText("Lethice’s minions have all but turned into an orgy, completely forgetting their original intent, no matter how much their draconic queen screeches for them to attack.");
 			}
 			outputText("\n\nWhile the demons are down, and Lethice is still recovering from your first skirmish, you have a much-needed moment to relieve the tensions starting to grow within you. Or you could press the attack, and take the fight to the queen.");
-			game.menu();
+			kGAMECLASS.output.menu();
 			if (Boolean(player.hasCock()) || Boolean(player.hasVagina()))
 			{
 				kGAMECLASS.output.addButton(0,"DemonFuck",p2DemonFuck,hpVictory);
@@ -621,7 +621,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 				outputText(" sucking cock.");
 			}
 			outputText("\n\nAround you, spurred on by your face-fucking the omnibus, the defeated demon court undulates in waves of orgiastic pleasure, gleefully sucking each other’s cocks, penetrating any hole they can find, or simply rolling on the floor locked in each other’s sensual embraces. Those that didn’t join the fight hoot and holler from the stands, encouraging you to fuck the omnibus like the eager slut she is. For her part, the horny demon just smirks up at you between long, loving licks across your sex.");
-			game.menu();
+			kGAMECLASS.output.menu();
 			kGAMECLASS.output.addButton(0,"OralFinish",oralFinish);
 			if (player.hasCock())
 			{
@@ -767,7 +767,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 				this.armorName = "lethicite armor";
 				this.armorDef += 30;
 			}
-			game.menu();
+			kGAMECLASS.output.menu();
 			if (doLethNext)
 			{
 				kGAMECLASS.output.addButton(0,"Next",p2Next);

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
@@ -276,7 +276,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 			outputText("\n\n");
 			flags[kFLAGS.SPELLS_CAST]++;
 			game.combat.combatAbilities.spellPerkUnlock();
-			game.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 			doAI();
 		}
 		
@@ -944,7 +944,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 					damage = eOneAttack();
 					outputAttack(damage);
 					postAttack(damage);
-					game.statScreenRefresh();
+					kGAMECLASS.output.statScreenRefresh();
 					outputText("\n");
 				}
 				else

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
@@ -7,6 +7,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 	import classes.PerkLib;
 	import classes.BodyParts.Butt;
 	import classes.BodyParts.Hips;
+	import classes.GlobalFlags.kGAMECLASS;
 	
 	public class Lethice extends Monster
 	{
@@ -569,13 +570,13 @@ package classes.Scenes.Dungeons.LethicesKeep
 			game.menu();
 			if (Boolean(player.hasCock()) || Boolean(player.hasVagina()))
 			{
-				game.addButton(0,"DemonFuck",p2DemonFuck,hpVictory);
+				kGAMECLASS.output.addButton(0,"DemonFuck",p2DemonFuck,hpVictory);
 			}
 			if (player.hasStatusEffect(StatusEffects.KnowsHeal))
 			{
-				game.addButton(1,"Heal",p2Heal);
+				kGAMECLASS.output.addButton(1,"Heal",p2Heal);
 			}
-			game.addButton(2,"Next",p2Next);
+			kGAMECLASS.output.addButton(2,"Next",p2Next);
 		}
 		
 		private function p2DemonFuck(hpVictory:Boolean):void
@@ -621,12 +622,12 @@ package classes.Scenes.Dungeons.LethicesKeep
 			}
 			outputText("\n\nAround you, spurred on by your face-fucking the omnibus, the defeated demon court undulates in waves of orgiastic pleasure, gleefully sucking each other’s cocks, penetrating any hole they can find, or simply rolling on the floor locked in each other’s sensual embraces. Those that didn’t join the fight hoot and holler from the stands, encouraging you to fuck the omnibus like the eager slut she is. For her part, the horny demon just smirks up at you between long, loving licks across your sex.");
 			game.menu();
-			game.addButton(0,"OralFinish",oralFinish);
+			kGAMECLASS.output.addButton(0,"OralFinish",oralFinish);
 			if (player.hasCock())
 			{
-				game.addButton(1,"FuckDemon",fuckDemon);
+				kGAMECLASS.output.addButton(1,"FuckDemon",fuckDemon);
 			}
-			game.addButton(2,"RideCock",rideCock);
+			kGAMECLASS.output.addButton(2,"RideCock",rideCock);
 		}
 		
 		private function oralFinish():void
@@ -769,7 +770,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 			game.menu();
 			if (doLethNext)
 			{
-				game.addButton(0,"Next",p2Next);
+				kGAMECLASS.output.addButton(0,"Next",p2Next);
 			}
 			else
 			{

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
@@ -271,7 +271,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 				outputText("You struggle and manage to raise your arm against the tight grasp of the tentacles, managing to");
 			}
 			outputText(" spray forth a torrent of white flame, burning the shadowy constructs away in the light of your pure, focused fire. In the span of seconds, Lethice’s spell is gone.");
-			game.doNext(game.combat.combatMenu);
+			kGAMECLASS.output.doNext(game.combat.combatMenu);
 			player.changeFatigue(30,1);
 			outputText("\n\n");
 			flags[kFLAGS.SPELLS_CAST]++;

--- a/classes/classes/Scenes/NPCs/Amily.as
+++ b/classes/classes/Scenes/NPCs/Amily.as
@@ -5,6 +5,7 @@ package classes.Scenes.NPCs
 import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
 import classes.StatusEffects.Combat.AmilyVenomDebuff;
+	import classes.GlobalFlags.kGAMECLASS;
 
 /**
 	 * ...
@@ -82,7 +83,7 @@ import classes.StatusEffects.Combat.AmilyVenomDebuff;
 					lust += 10 * lustVuln;
 				}
 			}
-			game.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 			outputText("\n");
 			game.combat.combatRoundOver();
 		}

--- a/classes/classes/Scenes/NPCs/AnemoneScene.as
+++ b/classes/classes/Scenes/NPCs/AnemoneScene.as
@@ -1251,7 +1251,7 @@ package classes.Scenes.NPCs
 				return item == consumables.W__BOOK || item == consumables.B__BOOK || item == consumables.W_STICK || item is Weapon;
 			}
 			menu();
-			kGAMECLASS.hideUpDown();
+			kGAMECLASS.output.hideUpDown();
 			var foundItem:Boolean = false;
 			for (var x:int = 0; x < inventory.getMaxSlots(); x++) {
 				if (player.itemSlots[x].quantity > 0 && giveableToAnemone(player.itemSlots[x].itype)) {

--- a/classes/classes/Scenes/NPCs/Ceraph.as
+++ b/classes/classes/Scenes/NPCs/Ceraph.as
@@ -6,6 +6,7 @@ package classes.Scenes.NPCs
 	import classes.GlobalFlags.kFLAGS;
 	import classes.display.SpriteDb;
 	import classes.internals.*;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public class Ceraph extends Monster
 	{
@@ -195,7 +196,7 @@ package classes.Scenes.NPCs
 				if (damage > 0) outputText("<b>(<font color=\"#800000\">" + damage + "</font>)</b>")
 				else outputText("<b>(<font color=\"#000080\">" + damage + "</font>)</b>")
 			}
-			game.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 			outputText("\n");
 			//SECOND ATTACK HERE------
 			//Blind dodge change
@@ -242,7 +243,7 @@ package classes.Scenes.NPCs
 				if (damage > 0) outputText("<b>(<font color=\"#800000\">" + damage + "</font>)</b>")
 				else outputText("<b>(<font color=\"#000080\">" + damage + "</font>)</b>")
 			}
-			game.statScreenRefresh();
+			kGAMECLASS.output.statScreenRefresh();
 			outputText("\n");
 			combatRoundOver();
 		}

--- a/classes/classes/Scenes/Places/Bazaar/BlackCock.as
+++ b/classes/classes/Scenes/Places/Bazaar/BlackCock.as
@@ -121,7 +121,7 @@ package classes.Scenes.Places.Bazaar
 		private function addFoodToGo(item:ItemType, price:int):void {
 			var button:int = 0;
 			for (var i:int = 0; i < 14; i++) {
-				if (buttonIsVisible(i)) button++;
+				if (output.buttonIsVisible(i)) button++;
 			}
 			outputText("\n" + capitalizeFirstLetter(item.longName) + " - " + price + " gems");
 			addButton(button, item.shortName, orderFoodToGo, item, price);
@@ -142,7 +142,7 @@ package classes.Scenes.Places.Bazaar
 		private function addFoodPlate(foodName:String, gems:int, tooltip:String, foodEatDesc:String):void {
 			var button:int = 0;
 			for (var i:int = 0; i < 14; i++) {
-				if (buttonIsVisible(i)) button++;
+				if (output.buttonIsVisible(i)) button++;
 			}
 			var header:String = "";
 			switch(foodName) {

--- a/classes/classes/Scenes/Places/Farm/FarmCorruption.as
+++ b/classes/classes/Scenes/Places/Farm/FarmCorruption.as
@@ -344,7 +344,7 @@ package classes.Scenes.Places.Farm
 				player.gems += flags[kFLAGS.FARM_CORRUPTION_GEMS_WAITING];
 				flags[kFLAGS.FARM_CORRUPTION_GEMS_WAITING] = 0;
 				flags[kFLAGS.FARM_CORRUPTION_DAYS_SINCE_LAST_PAYOUT] = 0;
-				kGAMECLASS.showStats();
+				kGAMECLASS.output.showStats();
 			}
 			
 			if (flags[kFLAGS.FARM_SUCCUMILK_STORED] > 0 || flags[kFLAGS.FARM_INCUDRAFT_STORED] > 0 || flags[kFLAGS.FARM_EGG_STORED] > 0 || flags[kFLAGS.FARM_CONTRACEPTIVE_STORED] > 0)

--- a/classes/classes/Scenes/Places/Ingnam.as
+++ b/classes/classes/Scenes/Places/Ingnam.as
@@ -345,7 +345,7 @@ package classes.Scenes.Places
 			outputText("\n" + capitalizeFirstLetter(item.longName) + " - " + price + " gems");
 			var button:int = 0;
 			for (var i:int = 0; i < 14; i++) {
-				if (buttonIsVisible(i)) button++;
+				if (output.buttonIsVisible(i)) button++;
 			}
 			addButton(button, item.shortName, transactionItemConfirmation, item, price, shop);
 		}

--- a/classes/classes/Scenes/Quests/UrtaQuest/GoblinBroodmother.as
+++ b/classes/classes/Scenes/Quests/UrtaQuest/GoblinBroodmother.as
@@ -8,6 +8,7 @@ package classes.Scenes.Quests.UrtaQuest
 	import classes.BodyParts.Hips;
 	import classes.Scenes.Monsters.Goblin;
 	import classes.internals.*;
+	import classes.GlobalFlags.kGAMECLASS;
 
 	public class GoblinBroodmother extends Goblin
 	{
@@ -17,8 +18,8 @@ package classes.Scenes.Quests.UrtaQuest
 			outputText("The goblin broodmother is defeated!  You find a bottle of succubi milk on her.  That stuff is banned in Tel'Adre - and for good reason, but it might come in handy.  You pocket the foul fluid for now.");
 			outputText("  You could use her for a quick, willing fuck to sate your lusts before continuing on.  Do you?");
 			game.menu();
-			game.addButton(0,"Fuck",game.urtaQuest.winFuckAGoblinBroodmotherAsUrta);
-			game.addButton(4,"Leave",game.urtaQuest.nagaPleaseNagaStoleMyDick);
+			kGAMECLASS.output.addButton(0,"Fuck",game.urtaQuest.winFuckAGoblinBroodmotherAsUrta);
+			kGAMECLASS.output.addButton(4,"Leave",game.urtaQuest.nagaPleaseNagaStoleMyDick);
 		}
 
 		override public function won(hpVictory:Boolean, pcCameWorms:Boolean):void

--- a/classes/classes/Scenes/Quests/UrtaQuest/GoblinBroodmother.as
+++ b/classes/classes/Scenes/Quests/UrtaQuest/GoblinBroodmother.as
@@ -17,7 +17,7 @@ package classes.Scenes.Quests.UrtaQuest
 			game.clearOutput();
 			outputText("The goblin broodmother is defeated!  You find a bottle of succubi milk on her.  That stuff is banned in Tel'Adre - and for good reason, but it might come in handy.  You pocket the foul fluid for now.");
 			outputText("  You could use her for a quick, willing fuck to sate your lusts before continuing on.  Do you?");
-			game.menu();
+			kGAMECLASS.output.menu();
 			kGAMECLASS.output.addButton(0,"Fuck",game.urtaQuest.winFuckAGoblinBroodmotherAsUrta);
 			kGAMECLASS.output.addButton(4,"Leave",game.urtaQuest.nagaPleaseNagaStoleMyDick);
 		}

--- a/classes/classes/Scenes/Quests/UrtaQuest/MinotaurLord.as
+++ b/classes/classes/Scenes/Quests/UrtaQuest/MinotaurLord.as
@@ -139,8 +139,8 @@ package classes.Scenes.Quests.UrtaQuest
 			if (flags[kFLAGS.URTA_QUEST_STATUS] == 0.75) {
 				outputText("  You could use him for a quick fuck to sate your lusts before continuing on.  Do you?");
 				game.menu();
-				game.addButton(0,"Fuck",game.urtaQuest.winRapeAMinoLordAsUrta);
-				game.addButton(4, "Leave", game.urtaQuest.beatMinoLordOnToSuccubi);
+				kGAMECLASS.output.addButton(0,"Fuck",game.urtaQuest.winRapeAMinoLordAsUrta);
+				kGAMECLASS.output.addButton(4, "Leave", game.urtaQuest.beatMinoLordOnToSuccubi);
 			}
 			else game.mountain.minotaurScene.minoVictoryRapeChoices();
 		}

--- a/classes/classes/Scenes/Quests/UrtaQuest/MinotaurLord.as
+++ b/classes/classes/Scenes/Quests/UrtaQuest/MinotaurLord.as
@@ -138,7 +138,7 @@ package classes.Scenes.Quests.UrtaQuest
 			outputText("The minotaur lord is defeated!  ");
 			if (flags[kFLAGS.URTA_QUEST_STATUS] == 0.75) {
 				outputText("  You could use him for a quick fuck to sate your lusts before continuing on.  Do you?");
-				game.menu();
+				kGAMECLASS.output.menu();
 				kGAMECLASS.output.addButton(0,"Fuck",game.urtaQuest.winRapeAMinoLordAsUrta);
 				kGAMECLASS.output.addButton(4, "Leave", game.urtaQuest.beatMinoLordOnToSuccubi);
 			}

--- a/includes/ControlBindings.as
+++ b/includes/ControlBindings.as
@@ -115,7 +115,7 @@ inputManager.AddBindableControl(
 			return;
 		}
 		// Button 14
-		if (kGAMECLASS.buttonIsVisible(14) && kGAMECLASS.buttonTextIsOneOf(14, [ "Nevermind", "Abandon", "Next", "Return", "Back", "Leave", "Resume" ]))
+		if (kGAMECLASS.output.buttonIsVisible(14) && kGAMECLASS.buttonTextIsOneOf(14, [ "Nevermind", "Abandon", "Next", "Return", "Back", "Leave", "Resume" ]))
 		{
 			//trace( "keyboard(): processing space bar for button 9",
 			//	mainView.buttonIsVisible( 9 ) ? "(visible)" : "(hidden)",
@@ -293,7 +293,7 @@ inputManager.AddBindableControl(
 	"Button 11",
 	"Activate button 11",
 	function():void {
-		if (kGAMECLASS.buttonIsVisible(10))
+		if (kGAMECLASS.output.buttonIsVisible(10))
 		{
 			mainView.toolTipView.hide();
 			mainView.clickButton(10);
@@ -303,7 +303,7 @@ inputManager.AddBindableControl(
 	"Button 12",
 	"Activate button 12",
 	function():void {
-		if (kGAMECLASS.buttonIsVisible(11))
+		if (kGAMECLASS.output.buttonIsVisible(11))
 		{
 			mainView.toolTipView.hide();
 			mainView.clickButton(11);
@@ -313,7 +313,7 @@ inputManager.AddBindableControl(
 	"Button 13",
 	"Activate button 13",
 	function():void {
-		if (kGAMECLASS.buttonIsVisible(12))
+		if (kGAMECLASS.output.buttonIsVisible(12))
 		{
 			mainView.toolTipView.hide();
 			mainView.clickButton(12);
@@ -323,7 +323,7 @@ inputManager.AddBindableControl(
 	"Button 14",
 	"Activate button 14",
 	function():void {
-		if (kGAMECLASS.buttonIsVisible(13))
+		if (kGAMECLASS.output.buttonIsVisible(13))
 		{
 			mainView.toolTipView.hide();
 			mainView.clickButton(13);
@@ -333,7 +333,7 @@ inputManager.AddBindableControl(
 	"Button 15",
 	"Activate button 15",
 	function():void {
-		if (kGAMECLASS.buttonIsVisible(14))
+		if (kGAMECLASS.output.buttonIsVisible(14))
 		{
 			mainView.toolTipView.hide();
 			mainView.clickButton(14);

--- a/includes/ControlBindings.as
+++ b/includes/ControlBindings.as
@@ -115,7 +115,7 @@ inputManager.AddBindableControl(
 			return;
 		}
 		// Button 14
-		if (kGAMECLASS.output.buttonIsVisible(14) && kGAMECLASS.buttonTextIsOneOf(14, [ "Nevermind", "Abandon", "Next", "Return", "Back", "Leave", "Resume" ]))
+		if (kGAMECLASS.output.buttonIsVisible(14) && kGAMECLASS.output.buttonTextIsOneOf(14, [ "Nevermind", "Abandon", "Next", "Return", "Back", "Leave", "Resume" ]))
 		{
 			//trace( "keyboard(): processing space bar for button 9",
 			//	mainView.buttonIsVisible( 9 ) ? "(visible)" : "(hidden)",

--- a/includes/debug.as
+++ b/includes/debug.as
@@ -34,9 +34,9 @@ public function debugPane():void {
 	outputText(images.showImage("monster-ceraph"));
 
 	menu();
-	addButton(0, "Test Input", eventTester);
-	addButton(1, "Parser Tests", doThatTestingThang);
-	addButton(4, "Back", gameSettings.exitSettings);
+	output.addButton(0, "Test Input", eventTester);
+	output.addButton(1, "Parser Tests", doThatTestingThang);
+	output.addButton(4, "Back", gameSettings.exitSettings);
 }
 
 public function doThatTestingThang():void
@@ -304,7 +304,7 @@ convert "
 
 
 	menu();
-	addButton(4, "Back", debugPane)
+	output.addButton(4, "Back", debugPane)
 
 }
 
@@ -327,8 +327,8 @@ public function eventTester():void {
 
 	;
 	menu();
-	addButton(0, "Proceed", eventTesterGo);
-	addButton(4, "Back", eventTesterExit);
+	output.addButton(0, "Proceed", eventTesterGo);
+	output.addButton(4, "Back", eventTesterExit);
 }
 
 public function eventTesterGo():void {
@@ -342,7 +342,7 @@ public function eventTesterGo():void {
 	clearOutput();
 	outputText(temp);
 
-	addButton(14, "Back", eventTester);
+	output.addButton(14, "Back", eventTester);
 	output.flush();
 }
 

--- a/includes/debug.as
+++ b/includes/debug.as
@@ -33,7 +33,7 @@ public function debugPane():void {
 
 	outputText(images.showImage("monster-ceraph"));
 
-	menu();
+	output.menu();
 	output.addButton(0, "Test Input", eventTester);
 	output.addButton(1, "Parser Tests", doThatTestingThang);
 	output.addButton(4, "Back", gameSettings.exitSettings);
@@ -303,7 +303,7 @@ convert "
 	]]>);
 
 
-	menu();
+	output.menu();
 	output.addButton(4, "Back", debugPane)
 
 }
@@ -326,7 +326,7 @@ public function eventTester():void {
 ]]>;
 
 	;
-	menu();
+	output.menu();
 	output.addButton(0, "Proceed", eventTesterGo);
 	output.addButton(4, "Back", eventTesterExit);
 }
@@ -338,7 +338,7 @@ public function eventTesterGo():void {
 
 	trace("Temp = ", temp);
 
-	menu();
+	output.menu();
 	clearOutput();
 	outputText(temp);
 

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -12,15 +12,6 @@ import classes.internals.profiling.End;
 ////////////	GUI CODE	////////////
 public static const MAX_BUTTON_INDEX:int = 14;
 
-public function buttonTextIsOneOf(index:int, possibleLabels:Array):Boolean {
-	var label:String;
-	var buttonText:String;
-
-	buttonText = this.getButtonText(index);
-
-	return (possibleLabels.indexOf(buttonText) != -1);
-}
-
 public function getButtonText(index:int):String {
 	var matches:*;
 

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -13,13 +13,6 @@ import classes.internals.profiling.End;
 public static const MAX_BUTTON_INDEX:int = 14;
 
 /**
- * Hide the top buttons.
- */
-public function hideMenus():void {
-	mainView.hideAllMenuButtons();
-}
-
-/**
  * Hides the up/down arrow on stats pane.
  */
 public function hideUpDown():void {

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -12,15 +12,6 @@ import classes.internals.profiling.End;
 ////////////	GUI CODE	////////////
 public static const MAX_BUTTON_INDEX:int = 14;
 
-public function buttonIsVisible(index:int):Boolean {
-	if ( index < 0 || index > MAX_BUTTON_INDEX ) {
-		return undefined;
-	}
-	else {
-		return button(index).visible;
-	}
-}
-
 public function buttonTextIsOneOf(index:int, possibleLabels:Array):Boolean {
 	var label:String;
 	var buttonText:String;

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -13,13 +13,6 @@ import classes.internals.profiling.End;
 public static const MAX_BUTTON_INDEX:int = 14;
 
 /**
- * Used to update the display of statistics
- */
-public function statScreenRefresh():void {
-	mainView.statsView.show(); // show() method refreshes.
-	mainViewManager.refreshStats();
-}
-/**
  * Show the stats pane. (Name, stats and attributes)
  */
 public function showStats():void {

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -233,8 +233,6 @@ public function showUpDown():void { //Moved from StatsView.
 		oldStatName:String,
 		allStats:Array;
 
-//	mainView.statsView.upDownsContainer.visible = true;
-
 	allStats = ["str", "tou", "spe", "inte", "lib", "sens", "cor", "HP", "lust", "fatigue", "hunger"];
 
 	for each(statName in allStats) {

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -13,25 +13,12 @@ import classes.internals.profiling.End;
 public static const MAX_BUTTON_INDEX:int = 14;
 
 /**
- * Hides all bottom buttons.
- * 
- * <b>Note:</b> Calling this with open formatting tags can result in strange behaviour, 
- * e.g. all text will be formatted instead of only a section.
- */
-public function menu():void { //The newer, simpler menu - blanks all buttons so addButton can be used
-	for (var i:int = 0; i <= MAX_BUTTON_INDEX; i++) {
-		mainView.hideBottomButton(i);
-	}
-	output.flush();
-}
-
-/**
  * Clears all button and adds a 'Yes' and a 'No' button.
  * @param	eventYes The event parser or function to call if 'Yes' button is pressed.
  * @param	eventNo The event parser or function to call if 'No' button is pressed.
  */
 public function doYesNo(eventYes:Function, eventNo:Function):void { //New typesafe version
-	menu();
+	output.menu();
 	output.addButton(0, "Yes", eventYes);
 	output.addButton(1, "No", eventNo);
 }
@@ -46,7 +33,7 @@ public function doNext(event:Function):void { //Now typesafe
 		//trace("Do next setup cancelled by game over");
 		return;
 	}
-	menu();
+	output.menu();
 	output.addButton(0, "Next", event);
 }
 

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -12,20 +12,6 @@ import classes.internals.profiling.End;
 ////////////	GUI CODE	////////////
 public static const MAX_BUTTON_INDEX:int = 14;
 
-public function addButtonDisabled(pos:int, text:String = "", toolTipText:String = "", toolTipHeader:String = ""):CoCButton {
-	var btn:CoCButton = button(pos);
-	//Removes sex-related button in SFW mode.
-	if (flags[kFLAGS.SFW_MODE] > 0) {
-		if (text.indexOf("Sex") != -1 || text.indexOf("Threesome") != -1 ||  text.indexOf("Foursome") != -1 || text == "Watersports" || text == "Make Love" || text == "Use Penis" || text == "Use Vagina" || text.indexOf("Fuck") != -1 || text.indexOf("Ride") != -1 || (text.indexOf("Mount") != -1 && text.indexOf("Mountain") == -1) || text.indexOf("Vagina") != -1) {
-			//trace("Button removed due to SFW mode.");
-			return btn.hide();
-		}
-	}
-
-	btn.showDisabled(text,toolTipText,toolTipHeader);
-	return btn;
-}
-
 public function button(pos:int):CoCButton {
 	return mainView.bottomButtons[pos];
 }

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -13,22 +13,6 @@ import classes.internals.profiling.End;
 public static const MAX_BUTTON_INDEX:int = 14;
 
 /**
- * Removes a button.
- * @param	arg The position to remove a button. (First row is 0-4, second row is 5-9, third row is 10-14.)
- */
-public function removeButton(arg:*):void {
-	var buttonToRemove:int = 0;
-	if (arg is String) {
-		buttonToRemove = mainView.indexOfButtonWithLabel( arg as String );
-	}
-	if (arg is Number) {
-		if (arg < 0 || arg > MAX_BUTTON_INDEX) return;
-		buttonToRemove = int(arg);
-	}
-	mainView.hideBottomButton( buttonToRemove );
-}
-
-/**
  * Hides all bottom buttons.
  * 
  * <b>Note:</b> Calling this with open formatting tags can result in strange behaviour, 

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -224,28 +224,6 @@ public function hideUpDown():void {
 	oldStats.oldHunger = 0;
 }
 
-public function showUpDown():void { //Moved from StatsView.
-	function _oldStatNameFor(statName:String):String {
-		return 'old' + statName.charAt(0).toUpperCase() + statName.substr(1);
-	}
-
-	var statName:String;
-	var	oldStatName:String;
-	var allStats:Array;
-
-	allStats = ["str", "tou", "spe", "inte", "lib", "sens", "cor", "HP", "lust", "fatigue", "hunger"];
-
-	for each(statName in allStats) {
-		oldStatName = _oldStatNameFor(statName);
-
-		if (player[statName] > oldStats[oldStatName]) {
-			mainView.statsView.showStatUp(statName);
-		}
-		if (player[statName] < oldStats[oldStatName]) {
-			mainView.statsView.showStatDown(statName);
-		}
-	}
-}
 ////////////	GUI CODE	////////////
 
 

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -12,25 +12,6 @@ import classes.internals.profiling.End;
 ////////////	GUI CODE	////////////
 public static const MAX_BUTTON_INDEX:int = 14;
 
-/**
- * Hides the up/down arrow on stats pane.
- */
-public function hideUpDown():void {
-	mainView.statsView.hideUpDown();
-	//Clear storage values so up/down arrows can be properly displayed
-	oldStats.oldStr = 0;
-	oldStats.oldTou = 0;
-	oldStats.oldSpe = 0;
-	oldStats.oldInte = 0;
-	oldStats.oldLib = 0;
-	oldStats.oldSens = 0;
-	oldStats.oldCor = 0;  
-	oldStats.oldHP = 0;
-	oldStats.oldLust = 0;
-	oldStats.oldFatigue = 0;
-	oldStats.oldHunger = 0;
-}
-
 ////////////	GUI CODE	////////////
 
 

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -13,14 +13,6 @@ import classes.internals.profiling.End;
 public static const MAX_BUTTON_INDEX:int = 14;
 
 /**
- * Hide the stats pane. (Name, stats and attributes)
- */
-public function hideStats():void {
-	if (!mainViewManager.buttonsTweened) mainView.statsView.hide();
-	mainViewManager.tweenOutStats();
-}
-
-/**
  * Hide the top buttons.
  */
 public function hideMenus():void {

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -22,8 +22,8 @@ public function buttonIsVisible(index:int):Boolean {
 }
 
 public function buttonText(buttonName:String):String {
-	var matches:*,
-		buttonIndex:int;
+	var matches:*;
+	var	buttonIndex:int;
 
 	if (buttonName is String) {
 		if ( /^buttons\[[0-9]\]/.test( buttonName ) ) {
@@ -42,8 +42,8 @@ public function buttonText(buttonName:String):String {
 }
 
 public function buttonTextIsOneOf(index:int, possibleLabels:Array):Boolean {
-	var label:String,
-	buttonText:String;
+	var label:String;
+	var buttonText:String;
 
 	buttonText = this.getButtonText(index);
 
@@ -229,9 +229,9 @@ public function showUpDown():void { //Moved from StatsView.
 		return 'old' + statName.charAt(0).toUpperCase() + statName.substr(1);
 	}
 
-	var statName:String,
-		oldStatName:String,
-		allStats:Array;
+	var statName:String;
+	var	oldStatName:String;
+	var allStats:Array;
 
 	allStats = ["str", "tou", "spe", "inte", "lib", "sens", "cor", "HP", "lust", "fatigue", "hunger"];
 

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -12,38 +12,6 @@ import classes.internals.profiling.End;
 ////////////	GUI CODE	////////////
 public static const MAX_BUTTON_INDEX:int = 14;
 
-/**
- * Adds a button.
- * @param	pos Determines the position. Starts at 0. (First row is 0-4, second row is 5-9, third row is 10-14.)
- * @param	text Determines the text that will appear on button.
- * @param	func1 Determines what function to trigger.
- * @param	arg1 Pass argument #1 to func1 parameter.
- * @param	arg2 Pass argument #1 to func1 parameter.
- * @param	arg3 Pass argument #1 to func1 parameter.
- * @param	toolTipText The text that will appear on tooltip when the mouse goes over the button.
- * @param	toolTipHeader The text that will appear on the tooltip header. If not specified, it defaults to button text.
- */
-public function addButton(pos:int, text:String = "", func1:Function = null, arg1:* = -9000, arg2:* = -9000, arg3:* = -9000, toolTipText:String = "", toolTipHeader:String = ""):CoCButton {
-	var btn:CoCButton = button(pos);
-	if (func1==null) {
-		return btn.hide();
-	}
-	var callback:Function;
-
-	//Removes sex-related button in SFW mode.
-	if (flags[kFLAGS.SFW_MODE] > 0) {
-		if (text.indexOf("Sex") != -1 || text.indexOf("Threesome") != -1 ||  text.indexOf("Foursome") != -1 || text == "Watersports" || text == "Make Love" || text == "Use Penis" || text == "Use Vagina" || text.indexOf("Fuck") != -1 || text.indexOf("Ride") != -1 || (text.indexOf("Mount") != -1 && text.indexOf("Mountain") == -1) || text.indexOf("Vagina") != -1) {
-			//trace("Button removed due to SFW mode.");
-			return btn.hide();
-		}
-	}
-	callback = createCallBackFunction(func1, arg1, arg2, arg3);
-
-	btn.show(text,callback, toolTipText, toolTipHeader);
-	output.flush();
-	return btn;
-}
-
 public function addButtonDisabled(pos:int, text:String = "", toolTipText:String = "", toolTipHeader:String = ""):CoCButton {
 	var btn:CoCButton = button(pos);
 	//Removes sex-related button in SFW mode.
@@ -98,8 +66,8 @@ public function menu():void { //The newer, simpler menu - blanks all buttons so 
  */
 public function doYesNo(eventYes:Function, eventNo:Function):void { //New typesafe version
 	menu();
-	addButton(0, "Yes", eventYes);
-	addButton(1, "No", eventNo);
+	output.addButton(0, "Yes", eventYes);
+	output.addButton(1, "No", eventNo);
 }
 
 /**
@@ -113,7 +81,7 @@ public function doNext(event:Function):void { //Now typesafe
 		return;
 	}
 	menu();
-	addButton(0, "Next", event);
+	output.addButton(0, "Next", event);
 }
 
 public function invertGo():void{ 

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -12,17 +12,6 @@ import classes.internals.profiling.End;
 ////////////	GUI CODE	////////////
 public static const MAX_BUTTON_INDEX:int = 14;
 
-public function getButtonText(index:int):String {
-	var matches:*;
-
-	if (index < 0 || index > MAX_BUTTON_INDEX) {
-		return '';
-	}
-	else {
-		return button(index).labelText;
-	}
-}
-
 /**
  * Adds a button.
  * @param	pos Determines the position. Starts at 0. (First row is 0-4, second row is 5-9, third row is 10-14.)

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -12,10 +12,6 @@ import classes.internals.profiling.End;
 ////////////	GUI CODE	////////////
 public static const MAX_BUTTON_INDEX:int = 14;
 
-public function invertGo():void{ 
-	mainView.invert();
-}
-
 /**
  * Used to update the display of statistics
  */

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -21,26 +21,6 @@ public function buttonIsVisible(index:int):Boolean {
 	}
 }
 
-public function buttonText(buttonName:String):String {
-	var matches:*;
-	var	buttonIndex:int;
-
-	if (buttonName is String) {
-		if ( /^buttons\[[0-9]\]/.test( buttonName ) ) {
-			matches = /^buttons\[([0-9])\]/.exec( buttonName );
-			buttonIndex = parseInt( matches[ 1 ], 10 );
-		}
-		else if ( /^b[0-9]Text$/.test( buttonName ) ) {
-			matches = /^b([0-9])Text$/.exec( buttonName );
-			buttonIndex = parseInt( matches[ 1 ], 10 );
-
-			buttonIndex = buttonIndex === 0 ? 9 : buttonIndex - 1;
-		}
-	}
-
-	return (getButtonText(buttonIndex) || "NULL");
-}
-
 public function buttonTextIsOneOf(index:int, possibleLabels:Array):Boolean {
 	var label:String;
 	var buttonText:String;

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -12,10 +12,6 @@ import classes.internals.profiling.End;
 ////////////	GUI CODE	////////////
 public static const MAX_BUTTON_INDEX:int = 14;
 
-public function button(pos:int):CoCButton {
-	return mainView.bottomButtons[pos];
-}
-
 /**
  * Removes a button.
  * @param	arg The position to remove a button. (First row is 0-4, second row is 5-9, third row is 10-14.)

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -29,13 +29,7 @@ public function addButton(pos:int, text:String = "", func1:Function = null, arg1
 		return btn.hide();
 	}
 	var callback:Function;
-/*
-	Let the mainView decide if index is valid
-	if(pos > 14) {
-		trace("INVALID BUTTON");
-		return;
-	}
-*/
+
 	//Removes sex-related button in SFW mode.
 	if (flags[kFLAGS.SFW_MODE] > 0) {
 		if (text.indexOf("Sex") != -1 || text.indexOf("Threesome") != -1 ||  text.indexOf("Foursome") != -1 || text == "Watersports" || text == "Make Love" || text == "Use Penis" || text == "Use Vagina" || text.indexOf("Fuck") != -1 || text.indexOf("Ride") != -1 || (text.indexOf("Mount") != -1 && text.indexOf("Mountain") == -1) || text.indexOf("Vagina") != -1) {

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -8,13 +8,6 @@ import classes.internals.Profiling;
 import classes.internals.profiling.Begin;
 import classes.internals.profiling.End;
 
-
-////////////	GUI CODE	////////////
-public static const MAX_BUTTON_INDEX:int = 14;
-
-////////////	GUI CODE	////////////
-
-
 public function silly():Boolean {
 	return flags[kFLAGS.SILLY_MODE_ENABLE_FLAG] == 1;
 }

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -12,20 +12,6 @@ import classes.internals.profiling.End;
 ////////////	GUI CODE	////////////
 public static const MAX_BUTTON_INDEX:int = 14;
 
-/**
- * Clears all button and adds a 'Next' button.
- * @param	event The event function to call if the button is pressed.
- */
-public function doNext(event:Function):void { //Now typesafe
-	//Prevent new events in combat from automatically overwriting a game over. 
-	if (mainView.getButtonText(0).indexOf("Game Over") != -1) {
-		//trace("Do next setup cancelled by game over");
-		return;
-	}
-	output.menu();
-	output.addButton(0, "Next", event);
-}
-
 public function invertGo():void{ 
 	mainView.invert();
 }
@@ -251,7 +237,7 @@ public function testDynStatsEvent():void {
 	player.dynStats("tou", 1, "spe+", 2, "int-", 3, "lib*", 2, "sen=", 25,"lust/",2);
 	outputText("Mod: 0 1 +2 -3 *2 =25 /2\n");
 	outputText("New: "+player.str+" "+player.tou+" "+player.spe+" "+player.inte+" "+player.lib+" "+player.sens+" "+player.lust+"\n");
-	doNext(playerMenu);
+	output.doNext(playerMenu);
 }
 
 /**
@@ -278,7 +264,7 @@ public function doSFWloss():Boolean {
 		if (player.HP <= 0) outputText("You collapse from your injuries.");
 		else outputText("You collapse from your overwhelming desires.");
 		if (combat.inCombat) combat.cleanupAfterCombat();
-		else doNext(camp.returnToCampUseOneHour)
+		else output.doNext(camp.returnToCampUseOneHour)
 		return true;
 	}
 	else return false;

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -13,17 +13,6 @@ import classes.internals.profiling.End;
 public static const MAX_BUTTON_INDEX:int = 14;
 
 /**
- * Clears all button and adds a 'Yes' and a 'No' button.
- * @param	eventYes The event parser or function to call if 'Yes' button is pressed.
- * @param	eventNo The event parser or function to call if 'No' button is pressed.
- */
-public function doYesNo(eventYes:Function, eventNo:Function):void { //New typesafe version
-	output.menu();
-	output.addButton(0, "Yes", eventYes);
-	output.addButton(1, "No", eventNo);
-}
-
-/**
  * Clears all button and adds a 'Next' button.
  * @param	event The event function to call if the button is pressed.
  */

--- a/includes/engineCore.as
+++ b/includes/engineCore.as
@@ -13,14 +13,6 @@ import classes.internals.profiling.End;
 public static const MAX_BUTTON_INDEX:int = 14;
 
 /**
- * Show the stats pane. (Name, stats and attributes)
- */
-public function showStats():void {
-	mainView.statsView.show();
-	mainViewManager.refreshStats();
-	mainViewManager.tweenInStats();
-}
-/**
  * Hide the stats pane. (Name, stats and attributes)
  */
 public function hideStats():void {

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -515,7 +515,7 @@ public function cheatTime(timeAmt:Number, needNext:Boolean = false):void {
 	if (time.minutes > 59) {
 		timeQ++;
 		time.minutes -= 60;
-		if (!buttonIsVisible(0)) goNext(timeQ, needNext);
+		if (!kGAMECLASS.output.buttonIsVisible(0)) goNext(timeQ, needNext);
 	}
 	timeAmt = Math.floor(timeAmt);
 	//Advance hours

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -21,7 +21,7 @@ public function playerMenu():void {
 	if (!inCombat) spriteSelect(null);
 	mainView.setMenuButton(MainView.MENU_NEW_MAIN, "New Game", charCreation.newGameGo);
 	mainView.nameBox.visible = false;
-	showStats();
+	output.showStats();
 	if (_gameState == 1 || _gameState == 2) {
 		kGAMECLASS.combat.combatMenu();
 		return;

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -498,7 +498,7 @@ private function goNextWrapped(timeAmt:Number, needNext:Boolean):Boolean  {
 		prison.goBackToPrisonBecauseQuestTimeIsUp();
 		return true;
 	}
-	statScreenRefresh();
+	output.statScreenRefresh();
 	if (needNext) {
 		output.doNext(playerMenu);
 		return true;
@@ -527,5 +527,5 @@ public function cheatTime(timeAmt:Number, needNext:Boolean = false):void {
 			time.hours = 0;
 		}
 	}
-	statScreenRefresh();
+	output.statScreenRefresh();
 }

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -73,7 +73,7 @@ public function gameOver(clear:Boolean = false):void { //Leaves text on screen u
 	}
 	flags[kFLAGS.TIMES_BAD_ENDED]++;
 	awardAchievement("Game Over!", kACHIEVEMENTS.GENERAL_GAME_OVER, true, true);
-	menu();
+	output.menu();
 	output.addButton(0, "Game Over", gameOverMenuOverride).hint("Your game has ended. Please load a saved file or start a new game.");
 	if (flags[kFLAGS.HARDCORE_MODE] <= 0) output.addButton(1, "Nightmare", camp.wakeFromBadEnd).hint("It's all just a dream. Wake up.");
 	//addButton(3, "NewGamePlus", charCreation.newGamePlus).hint("Start a new game with your equipment, experience, and gems carried over.");

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -118,7 +118,7 @@ public function errorPrint(details:* = null):void
 		rawOutputText(" (including the above stack trace copy&pasted into the details),");
 	rawOutputText(" to make tracking the issue down easier. Thanks!");
 
-	doNext(camp.returnToCampUseOneHour);
+	output.doNext(camp.returnToCampUseOneHour);
 }
 
 //Argument is time passed.  Pass to event parser if nothing happens.
@@ -195,7 +195,7 @@ private function goNextWrapped(timeAmt:Number, needNext:Boolean):Boolean  {
 			else if (temp > rand(100) && !player.hasStatusEffect(StatusEffects.DefenseCanopy)) {
 				if (player.gender > 0 && !(player.hasStatusEffect(StatusEffects.JojoNightWatch) && player.hasStatusEffect(StatusEffects.PureCampJojo)) && (flags[kFLAGS.HEL_GUARDING] == 0 || !helFollower.followerHel()) && flags[kFLAGS.ANEMONE_WATCH] == 0 && (flags[kFLAGS.HOLLI_DEFENSE_ON] == 0 || flags[kFLAGS.FUCK_FLOWER_KILLED] > 0) && (flags[kFLAGS.KIHA_CAMP_WATCH] == 0 || !kihaFollower.followerKiha()) && !(flags[kFLAGS.CAMP_BUILT_CABIN] > 0 && flags[kFLAGS.CAMP_CABIN_FURNITURE_BED] > 0 && (flags[kFLAGS.SLEEP_WITH] == "Marble" || flags[kFLAGS.SLEEP_WITH] == "")) && (flags[kFLAGS.IN_INGNAM] == 0 && flags[kFLAGS.IN_PRISON] == 0)) {
 					impScene.impGangabangaEXPLOSIONS();
-					doNext(playerMenu);
+					output.doNext(playerMenu);
 					return true;
 				}
 				else if (flags[kFLAGS.KIHA_CAMP_WATCH] > 0 && kihaFollower.followerKiha()) {
@@ -349,7 +349,7 @@ private function goNextWrapped(timeAmt:Number, needNext:Boolean):Boolean  {
 			if (!player.hasStatusEffect(StatusEffects.Eggs)) { //Handling of errors.
 				outputText("Oops, looks like something went wrong with the coding regarding gathering eggs after pregnancy. Hopefully this should never happen again. If you encounter this again, please let Kitteh6660 know so he can fix it.");
 				player.removeStatusEffect(StatusEffects.LootEgg);
-				doNext(playerMenu);
+				output.doNext(playerMenu);
 				return true;
 			}
 			//default
@@ -500,7 +500,7 @@ private function goNextWrapped(timeAmt:Number, needNext:Boolean):Boolean  {
 	}
 	statScreenRefresh();
 	if (needNext) {
-		doNext(playerMenu);
+		output.doNext(playerMenu);
 		return true;
 	}
 	playerMenu();

--- a/includes/eventParser.as
+++ b/includes/eventParser.as
@@ -74,8 +74,8 @@ public function gameOver(clear:Boolean = false):void { //Leaves text on screen u
 	flags[kFLAGS.TIMES_BAD_ENDED]++;
 	awardAchievement("Game Over!", kACHIEVEMENTS.GENERAL_GAME_OVER, true, true);
 	menu();
-	addButton(0, "Game Over", gameOverMenuOverride).hint("Your game has ended. Please load a saved file or start a new game.");
-	if (flags[kFLAGS.HARDCORE_MODE] <= 0) addButton(1, "Nightmare", camp.wakeFromBadEnd).hint("It's all just a dream. Wake up.");
+	output.addButton(0, "Game Over", gameOverMenuOverride).hint("Your game has ended. Please load a saved file or start a new game.");
+	if (flags[kFLAGS.HARDCORE_MODE] <= 0) output.addButton(1, "Nightmare", camp.wakeFromBadEnd).hint("It's all just a dream. Wake up.");
 	//addButton(3, "NewGamePlus", charCreation.newGamePlus).hint("Start a new game with your equipment, experience, and gems carried over.");
 	//if (flags[kFLAGS.EASY_MODE_ENABLE_FLAG] == 1 || debug) addButton(4, "Debug Cheat", playerMenu);
 	gameOverMenuOverride();

--- a/test/classes/CoCTest.as
+++ b/test/classes/CoCTest.as
@@ -25,7 +25,7 @@ package classes{
 			cut = new CoCForTest(StageLocator.stage);
 			cut.player.createVagina();
 			
-			fireButton = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
+			fireButton = new FireButtonEvent(kGAMECLASS.mainView, Output.MAX_BUTTON_INDEX);
 		}
 
 		[Test] 

--- a/test/classes/Scenes/NPCs/IsabellaFollowerSceneTest.as
+++ b/test/classes/Scenes/NPCs/IsabellaFollowerSceneTest.as
@@ -21,6 +21,7 @@ package classes.Scenes.NPCs
 	import classes.CockTypesEnum;
 	import classes.helper.FireButtonEvent;
 	import classes.CoC;
+	import classes.Output;
 	
 	public class IsabellaFollowerSceneTest 
 	{
@@ -61,7 +62,7 @@ package classes.Scenes.NPCs
 			player = new Player();
 			kGAMECLASS.player = player;
 			
-			fireButon = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
+			fireButon = new FireButtonEvent(kGAMECLASS.mainView, Output.MAX_BUTTON_INDEX);
         }
 		
 		[Test]

--- a/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
+++ b/test/classes/Scenes/Places/Bazaar/RoxanneTest.as
@@ -17,6 +17,7 @@ package classes.Scenes.Places.Bazaar{
 	import classes.Player;
 	import classes.CoC;
 	import classes.GlobalFlags.kFLAGS;
+	import classes.Output;
      
     public class RoxanneTest {
 		private static const EVENT_ITERATIONS:int = 5;
@@ -40,7 +41,7 @@ package classes.Scenes.Places.Bazaar{
 			player.rng = rng;
 			kGAMECLASS.player = player;
 			
-			fireButtons = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
+			fireButtons = new FireButtonEvent(kGAMECLASS.mainView, Output.MAX_BUTTON_INDEX);
 			
 			player.flags[kFLAGS.ROXANNE_TIME_WITHOUT_SEX] = 10;
 			player.flags[kFLAGS.ROXANNE_DRINKING_CONTEST_LOSE_ON_PURPOSE] = 1;

--- a/test/classes/helper/FireButtonEvent.as
+++ b/test/classes/helper/FireButtonEvent.as
@@ -17,7 +17,7 @@ package classes.helper
 		/**
 		 * Create a new instance that can be used to fire button events.
 		 * @param	mainView the view that caontains the buttons
-		 * @param	maxButtonIndex the maximum number of buttons, should usually be CoC.MAX_BUTTON_INDEX
+		 * @param	maxButtonIndex the maximum number of buttons, should usually be Output.MAX_BUTTON_INDEX
 		 */
 		public function FireButtonEvent(mainView:MainView, maxButtonIndex:int) 
 		{

--- a/test/classes/helper/FireButtonEventTest.as
+++ b/test/classes/helper/FireButtonEventTest.as
@@ -11,6 +11,7 @@ package classes.helper
 	import classes.helper.FireButtonEvent;
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.CoC;
+	import classes.Output;
 	
 	public class FireButtonEventTest
 	{
@@ -29,7 +30,7 @@ package classes.helper
 		[Before]
 		public function setUp():void
 		{
-			cut = new FireButtonEvent(kGAMECLASS.mainView, CoC.MAX_BUTTON_INDEX);
+			cut = new FireButtonEvent(kGAMECLASS.mainView, Output.MAX_BUTTON_INDEX);
 			eventTriggeredFlag = false;
 		}
 		

--- a/test/classes/helper/FireButtonEventTest.as
+++ b/test/classes/helper/FireButtonEventTest.as
@@ -65,14 +65,14 @@ package classes.helper
 		
 		[Test]
 		public function doNextEventNotTriggered():void {
-			kGAMECLASS.doNext(setFlagEvent);
+			kGAMECLASS.output.doNext(setFlagEvent);
 			
 			assertThat(eventTriggeredFlag, equalTo(false));
 		}
 		
 		[Test]
 		public function doNextEventTriggered():void {
-			kGAMECLASS.doNext(setFlagEvent);
+			kGAMECLASS.output.doNext(setFlagEvent);
 			
 			cut.fireNextButtonEvent();
 			


### PR DESCRIPTION
This PR moves GUI specific code from `engineCore.as` to `Output.as`.

- Move code to `Output.as`
- Remove commented out code
- Split up declarations to one per line