### PR TITLE
Fix birth count not incremented

### DIFF
--- a/classes/classes/Scenes/NPCs/pregnancies/PlayerBenoitPregnancy.as
+++ b/classes/classes/Scenes/NPCs/pregnancies/PlayerBenoitPregnancy.as
@@ -145,7 +145,7 @@ package classes.Scenes.NPCs.pregnancies
 			pregnancyProgression.detectVaginalBirth(PregnancyStore.PREGNANCY_BASILISK);
 			
 			player.knockUpForce(); //Clear Pregnancy
-			giveBirth();
+			pregnancyProgression.giveBirth();
 			kGAMECLASS.bazaar.benoit.popOutBenoitEggs();
 		}
 		
@@ -161,35 +161,6 @@ package classes.Scenes.NPCs.pregnancies
 			}
 			
 			return false;
-		}
-		
-		private function giveBirth():void
-		{
-			//TODO remove this once new Player calls have been removed
-			var player:Player = kGAMECLASS.player;
-			
-			if (player.fertility < 15) {
-				player.fertility++;
-			}
-			
-			if (player.fertility < 25) {
-				player.fertility++;
-			}
-			
-			if (player.fertility < 40) {
-				player.fertility++;
-			}
-			
-			if (!player.hasStatusEffect(StatusEffects.Birthed)) {
-				player.createStatusEffect(StatusEffects.Birthed,1,0,0,0);
-			} else {
-				player.addStatusValue(StatusEffects.Birthed,1,1);
-				
-				if (player.findPerk(PerkLib.BroodMother) < 0 && player.statusEffectv1(StatusEffects.Birthed) >= 10) {
-					output.text("\n<b>You have gained the Brood Mother perk</b> (Pregnancies progress twice as fast as a normal woman's).\n");
-					player.createPerk(PerkLib.BroodMother,0,0,0,0);
-				}
-			}
 		}
 	}
 }

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -345,6 +345,12 @@ package classes.Scenes
 				var scene:VaginalPregnancy = vaginalPregnancyScenes[player.pregnancyType] as VaginalPregnancy;
 				LOGGER.debug("Updating vaginal birth for mother {0}, father {1} by using class {2}", PregnancyStore.PREGNANCY_PLAYER, player.pregnancyType, scene);
 				scene.vaginalBirth();
+				
+				// TODO find a cleaner way to solve this
+				// ignores Benoit pregnancy because that is a special case
+				if (player.pregnancyType !== PregnancyStore.PREGNANCY_BENOIT) {
+					giveBirth();
+				}
 			} else {
 				LOGGER.debug("Could not find a mapped vaginal pregnancy scene for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, player.pregnancyType);;
 			}
@@ -358,6 +364,39 @@ package classes.Scenes
 			player.knockUpForce();
 			
 			return true;
+		}
+		
+		/**
+		 * Updates fertility and tracks number of births. If the player has birthed
+		 * enough children, gain the broodmother perk.
+		 */
+		public function giveBirth():void
+		{
+			//TODO remove this once new Player calls have been removed
+			var player:Player = kGAMECLASS.player;
+			
+			if (player.fertility < 15) {
+				player.fertility++;
+			}
+			
+			if (player.fertility < 25) {
+				player.fertility++;
+			}
+			
+			if (player.fertility < 40) {
+				player.fertility++;
+			}
+			
+			if (!player.hasStatusEffect(StatusEffects.Birthed)) {
+				player.createStatusEffect(StatusEffects.Birthed,1,0,0,0);
+			} else {
+				player.addStatusValue(StatusEffects.Birthed,1,1);
+				
+				if (player.findPerk(PerkLib.BroodMother) < 0 && player.statusEffectv1(StatusEffects.Birthed) >= 10) {
+					output.text("\n<b>You have gained the Brood Mother perk</b> (Pregnancies progress twice as fast as a normal woman's).\n");
+					player.createPerk(PerkLib.BroodMother,0,0,0,0);
+				}
+			}
 		}
 
 		private function updateAnalBirth(displayedUpdate:Boolean):Boolean 

--- a/test/classes/Scenes/PregnancyProgressionVagBirthTest.as
+++ b/test/classes/Scenes/PregnancyProgressionVagBirthTest.as
@@ -46,6 +46,7 @@ package classes.Scenes
 		private var testFunction:Function;
 		private var shouldDisplayText:Boolean;
 		private var autoCreatesVaginaOnBirth:Boolean;
+		private var childrenOnBirth:int;
 		
 		[BeforeClass]
 		public static function setUpClass():void {
@@ -76,43 +77,44 @@ package classes.Scenes
 		// function():void{assertThat(kGAMECLASS.player.fatigue, equalTo(40))}
 		[Parameters]
 		public static var testData:Array = [
-			[PregnancyStore.PREGNANCY_FAERIE, function():void{assertThat(kGAMECLASS.flags[kFLAGS.BIRTHS_FAERIE], equalTo(1))}, true],
+			[PregnancyStore.PREGNANCY_FAERIE, function():void{assertThat(kGAMECLASS.flags[kFLAGS.BIRTHS_FAERIE], equalTo(1))}, true, 1],
 			[PregnancyStore.PREGNANCY_EMBER, function():void{assertThat(kGAMECLASS.flags[kFLAGS.EMBER_CHILDREN_MALES] + 
 																			kGAMECLASS.flags[kFLAGS.EMBER_CHILDREN_FEMALES] +
-																			kGAMECLASS.flags[kFLAGS.EMBER_CHILDREN_HERMS], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_URTA, function():void{assertThat(kGAMECLASS.flags[kFLAGS.URTA_TIMES_PC_BIRTHED], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_SAND_WITCH, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_SAND_WITCH))}, true],
-			[PregnancyStore.PREGNANCY_IZMA, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_IZMA))}, true],
-			[PregnancyStore.PREGNANCY_SPIDER, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_SPIDER))}, true],
-			[PregnancyStore.PREGNANCY_DRIDER_EGGS, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_DRIDER_EGGS))}, true],
-			[PregnancyStore.PREGNANCY_COTTON, function():void{assertThat(kGAMECLASS.flags[kFLAGS.COTTON_KID_COUNT], equalTo(1)); }, true],
-			[PregnancyStore.PREGNANCY_GOO_GIRL, function():void{assertThat(kGAMECLASS.flags[kFLAGS.GOOGIRL_BIRTHS], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_BASILISK, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_BASILISK))}, true],
-			[PregnancyStore.PREGNANCY_COCKATRICE, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_COCKATRICE))}, true],
-			[PregnancyStore.PREGNANCY_SATYR, function():void{assertThat(kGAMECLASS.flags[kFLAGS.SATYR_KIDS], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_FROG_GIRL, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_FROG_GIRL))}, true],
-			[PregnancyStore.PREGNANCY_BUNNY, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_BUNNY))}, true],
-			[PregnancyStore.PREGNANCY_ANEMONE, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_ANEMONE))}, true],
-			[PregnancyStore.PREGNANCY_IMP, function():void{assertThat(kGAMECLASS.player.statusEffectv1(StatusEffects.BirthedImps), equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_MARBLE, function():void{assertThat(kGAMECLASS.flags[kFLAGS.MARBLE_KIDS], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_MINOTAUR, function():void{assertThat(kGAMECLASS.flags[kFLAGS.MINOTAUR_SONS_PENDING], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_BENOIT, function():void{assertThat(kGAMECLASS.flags[kFLAGS.BENOIT_EGGS], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_CENTAUR, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_CENTAUR))}, true],
-			[PregnancyStore.PREGNANCY_KELT, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_CENTAUR))}, true],
-			[PregnancyStore.PREGNANCY_HELL_HOUND, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_HELL_HOUND))}, true],
-			[PregnancyStore.PREGNANCY_MINERVA, function():void{assertThat(kGAMECLASS.flags[kFLAGS.TIMES_BIRTHED_SHARPIES], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_BEHEMOTH, function():void{assertThat(kGAMECLASS.flags[kFLAGS.BEHEMOTH_CHILDREN], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_OVIELIXIR_EGGS, function():void{assertThat(kGAMECLASS.player.hasStatusEffect(StatusEffects.LootEgg), equalTo(true))}, false],
-			[PregnancyStore.PREGNANCY_AMILY, function():void{assertThat(kGAMECLASS.flags[kFLAGS.PC_TIMES_BIRTHED_AMILYKIDS], equalTo(1))}, true],
-			[PregnancyStore.PREGNANCY_MOUSE, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_MOUSE))}, true],
-			[PregnancyStore.PREGNANCY_JOJO, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_MOUSE))}, true]
+																			kGAMECLASS.flags[kFLAGS.EMBER_CHILDREN_HERMS], equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_URTA, function():void{assertThat(kGAMECLASS.flags[kFLAGS.URTA_TIMES_PC_BIRTHED], equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_SAND_WITCH, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_SAND_WITCH))}, true, 1],
+			[PregnancyStore.PREGNANCY_IZMA, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_IZMA))}, true, 1],
+			[PregnancyStore.PREGNANCY_SPIDER, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_SPIDER))}, true, 1],
+			[PregnancyStore.PREGNANCY_DRIDER_EGGS, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_DRIDER_EGGS))}, true, 1],
+			[PregnancyStore.PREGNANCY_COTTON, function():void{assertThat(kGAMECLASS.flags[kFLAGS.COTTON_KID_COUNT], equalTo(1)); }, true, 1],
+			[PregnancyStore.PREGNANCY_GOO_GIRL, function():void{assertThat(kGAMECLASS.flags[kFLAGS.GOOGIRL_BIRTHS], equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_BASILISK, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_BASILISK))}, true, 1],
+			[PregnancyStore.PREGNANCY_COCKATRICE, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_COCKATRICE))}, true, 1],
+			[PregnancyStore.PREGNANCY_SATYR, function():void{assertThat(kGAMECLASS.flags[kFLAGS.SATYR_KIDS], equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_FROG_GIRL, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_FROG_GIRL))}, true, 1],
+			[PregnancyStore.PREGNANCY_BUNNY, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_BUNNY))}, true, 1],
+			[PregnancyStore.PREGNANCY_ANEMONE, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_ANEMONE))}, true, 1],
+			[PregnancyStore.PREGNANCY_IMP, function():void{assertThat(kGAMECLASS.player.statusEffectv1(StatusEffects.BirthedImps), equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_MARBLE, function():void{assertThat(kGAMECLASS.flags[kFLAGS.MARBLE_KIDS], equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_MINOTAUR, function():void{assertThat(kGAMECLASS.flags[kFLAGS.MINOTAUR_SONS_PENDING], equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_BENOIT, function():void{assertThat(kGAMECLASS.flags[kFLAGS.BENOIT_EGGS], equalTo(1))}, true, 2],
+			[PregnancyStore.PREGNANCY_CENTAUR, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_CENTAUR))}, true, 1],
+			[PregnancyStore.PREGNANCY_KELT, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_CENTAUR))}, true, 1],
+			[PregnancyStore.PREGNANCY_HELL_HOUND, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_HELL_HOUND))}, true, 1],
+			[PregnancyStore.PREGNANCY_MINERVA, function():void{assertThat(kGAMECLASS.flags[kFLAGS.TIMES_BIRTHED_SHARPIES], equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_BEHEMOTH, function():void{assertThat(kGAMECLASS.flags[kFLAGS.BEHEMOTH_CHILDREN], equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_OVIELIXIR_EGGS, function():void{assertThat(kGAMECLASS.player.hasStatusEffect(StatusEffects.LootEgg), equalTo(true))}, false, 1],
+			[PregnancyStore.PREGNANCY_AMILY, function():void{assertThat(kGAMECLASS.flags[kFLAGS.PC_TIMES_BIRTHED_AMILYKIDS], equalTo(1))}, true, 1],
+			[PregnancyStore.PREGNANCY_MOUSE, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_MOUSE))}, true, 1],
+			[PregnancyStore.PREGNANCY_JOJO, function():void{assertThat(cut.senseVaginalBirth, hasItem(PregnancyStore.PREGNANCY_MOUSE))}, true, 1]
 			];
 
-		public function PregnancyProgressionVagBirthTest(pregnancyType:int, testFunction:Function, autoCreatesVaginaOnBirth:Boolean):void {
+		public function PregnancyProgressionVagBirthTest(pregnancyType:int, testFunction:Function, autoCreatesVaginaOnBirth:Boolean, childrenOnBirth:int):void {
 			this.pregnancyType = pregnancyType;
 			this.testFunction = testFunction;
 			this.shouldDisplayText = shouldDisplayText;
 			this.autoCreatesVaginaOnBirth = autoCreatesVaginaOnBirth;
+			this.childrenOnBirth = childrenOnBirth;
 		}
 		
 		[Test]
@@ -156,6 +158,15 @@ package classes.Scenes
 			player.knockUpForce(pregnancyType, 1);
 			
 			assertThat(cut.updatePregnancy(), equalTo(true));
+		}
+		
+		[Test]
+		public function birthCounterIncremented():void {
+			player.knockUpForce(pregnancyType, 1);
+	
+			cut.updatePregnancy();
+			
+			assertThat(player.statusEffectv1(StatusEffects.Birthed), equalTo(childrenOnBirth));
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes the birth count regression (#1271) introduced in PR #1263.

- Moved `giveBirth` back to `PregnancyProgression`
- Excluded Benoit pregnancy from default `giveBirth` call
- Added Test to check birth count