### PR TITLE
Pregnancy Progress rework - anal pregnancy

### DIFF
--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -445,37 +445,37 @@ package classes
 		 * Create scenes that use the new pregnancy system. This method is public to allow for simple testing.
 		 * @param pregnancyProgress Pregnancy progression to use for scenes, which they use to register themself
 		 */
-		public function createScenes(pregnancyProgress:PregnancyProgression): void {
-			this.dungeons = new DungeonCore(pregnancyProgress);
+		public function createScenes(pregnancyProgression:PregnancyProgression): void {
+			this.dungeons = new DungeonCore(pregnancyProgression);
 			
-			this.bog = new Bog(pregnancyProgress, output);
-			this.mountain = new Mountain(pregnancyProgress, output);
-			this.highMountains = new HighMountains(pregnancyProgress, output);
-			this.volcanicCrag = new VolcanicCrag(pregnancyProgress, output);
-			this.swamp = new Swamp(pregnancyProgress, output);
-			this.plains = new Plains(pregnancyProgress, output);
-			this.forest = new Forest(pregnancyProgress, output);
+			this.bog = new Bog(pregnancyProgression, output);
+			this.mountain = new Mountain(pregnancyProgression, output);
+			this.highMountains = new HighMountains(pregnancyProgression, output);
+			this.volcanicCrag = new VolcanicCrag(pregnancyProgression, output);
+			this.swamp = new Swamp(pregnancyProgression, output);
+			this.plains = new Plains(pregnancyProgression, output);
+			this.forest = new Forest(pregnancyProgression, output);
 			this.deepWoods = new DeepWoods(forest);
-			this.desert = new Desert(pregnancyProgress, output);
+			this.desert = new Desert(pregnancyProgression, output);
 			
-			this.telAdre = new TelAdre(pregnancyProgress);
+			this.telAdre = new TelAdre(pregnancyProgression);
 			
-			this.impScene = new ImpScene(pregnancyProgress, output);
-			this.anemoneScene = new AnemoneScene(pregnancyProgress, output);
-			this.marbleScene = new MarbleScene(pregnancyProgress, output);
-			this.jojoScene = new JojoScene(pregnancyProgress, output);
-			this.amilyScene = new AmilyScene(pregnancyProgress, output);
-			this.izmaScene = new IzmaScene(pregnancyProgress, output);
-			this.lake = new Lake(pregnancyProgress, output);
+			this.impScene = new ImpScene(pregnancyProgression, output);
+			this.anemoneScene = new AnemoneScene(pregnancyProgression, output);
+			this.marbleScene = new MarbleScene(pregnancyProgression, output);
+			this.jojoScene = new JojoScene(pregnancyProgression, output);
+			this.amilyScene = new AmilyScene(pregnancyProgression, output);
+			this.izmaScene = new IzmaScene(pregnancyProgression, output);
+			this.lake = new Lake(pregnancyProgression, output);
 
 			// not assigned to a variable as it is self-registering, PregnancyProgress will keep a reference to the instance
-			new PlayerCentaurPregnancy(pregnancyProgress, output);
-			new PlayerBunnyPregnancy(pregnancyProgress, output, mutations);
-			new PlayerBenoitPregnancy(pregnancyProgress, output);
-			new PlayerOviElixirPregnancy(pregnancyProgress, output);
+			new PlayerCentaurPregnancy(pregnancyProgression, output);
+			new PlayerBunnyPregnancy(pregnancyProgression, output, mutations);
+			new PlayerBenoitPregnancy(pregnancyProgression, output);
+			new PlayerOviElixirPregnancy(pregnancyProgression, output);
 			
-			this.emberScene = new EmberScene(pregnancyProgress);
-			this.urtaPregs = new UrtaPregs(pregnancyProgress);
+			this.emberScene = new EmberScene(pregnancyProgression);
+			this.urtaPregs = new UrtaPregs(pregnancyProgression);
 		}
 		
 		/**

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -206,7 +206,7 @@ package classes
 		public var commonEncounters:CommonEncounters = new CommonEncounters(); // Common dependencies go first
 		
 		public var bog:Bog;
-		public var desert:Desert = new Desert();
+		public var desert:Desert;
 		public var forest:Forest;
 		public var deepWoods:DeepWoods = new DeepWoods(forest);
 		public var glacialRift:GlacialRift = new GlacialRift();
@@ -455,6 +455,7 @@ package classes
 			this.swamp = new Swamp(pregnancyProgress, output);
 			this.plains = new Plains(pregnancyProgress, output);
 			this.forest = new Forest(pregnancyProgress, output);
+			this.desert = new Desert(pregnancyProgress, output);
 			
 			this.telAdre = new TelAdre(pregnancyProgress);
 			

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -208,7 +208,7 @@ package classes
 		public var bog:Bog;
 		public var desert:Desert;
 		public var forest:Forest;
-		public var deepWoods:DeepWoods = new DeepWoods(forest);
+		public var deepWoods:DeepWoods;
 		public var glacialRift:GlacialRift = new GlacialRift();
 		public var highMountains:HighMountains;
 		public var lake:Lake;
@@ -455,6 +455,7 @@ package classes
 			this.swamp = new Swamp(pregnancyProgress, output);
 			this.plains = new Plains(pregnancyProgress, output);
 			this.forest = new Forest(pregnancyProgress, output);
+			this.deepWoods = new DeepWoods(forest);
 			this.desert = new Desert(pregnancyProgress, output);
 			
 			this.telAdre = new TelAdre(pregnancyProgress);

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -207,7 +207,7 @@ package classes
 		
 		public var bog:Bog;
 		public var desert:Desert = new Desert();
-		public var forest:Forest = new Forest();
+		public var forest:Forest;
 		public var deepWoods:DeepWoods = new DeepWoods(forest);
 		public var glacialRift:GlacialRift = new GlacialRift();
 		public var highMountains:HighMountains;
@@ -454,6 +454,8 @@ package classes
 			this.volcanicCrag = new VolcanicCrag(pregnancyProgress, output);
 			this.swamp = new Swamp(pregnancyProgress, output);
 			this.plains = new Plains(pregnancyProgress, output);
+			this.forest = new Forest(pregnancyProgress, output);
+			
 			this.telAdre = new TelAdre(pregnancyProgress);
 			
 			this.impScene = new ImpScene(pregnancyProgress, output);

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -448,7 +448,7 @@ package classes
 		public function createScenes(pregnancyProgress:PregnancyProgression): void {
 			this.dungeons = new DungeonCore(pregnancyProgress);
 			
-			this.bog = new Bog(pregnancyProgress);
+			this.bog = new Bog(pregnancyProgress, output);
 			this.mountain = new Mountain(pregnancyProgress, output);
 			this.highMountains = new HighMountains(pregnancyProgress, output);
 			this.volcanicCrag = new VolcanicCrag(pregnancyProgress, output);

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -446,27 +446,27 @@ package classes
 		 * @param pregnancyProgress Pregnancy progression to use for scenes, which they use to register themself
 		 */
 		public function createScenes(pregnancyProgression:PregnancyProgression): void {
-			this.dungeons = new DungeonCore(pregnancyProgression);
+			dungeons = new DungeonCore(pregnancyProgression);
 			
-			this.bog = new Bog(pregnancyProgression, output);
-			this.mountain = new Mountain(pregnancyProgression, output);
-			this.highMountains = new HighMountains(pregnancyProgression, output);
-			this.volcanicCrag = new VolcanicCrag(pregnancyProgression, output);
-			this.swamp = new Swamp(pregnancyProgression, output);
-			this.plains = new Plains(pregnancyProgression, output);
-			this.forest = new Forest(pregnancyProgression, output);
-			this.deepWoods = new DeepWoods(forest);
-			this.desert = new Desert(pregnancyProgression, output);
+			bog = new Bog(pregnancyProgression, output);
+			mountain = new Mountain(pregnancyProgression, output);
+			highMountains = new HighMountains(pregnancyProgression, output);
+			volcanicCrag = new VolcanicCrag(pregnancyProgression, output);
+			swamp = new Swamp(pregnancyProgression, output);
+			plains = new Plains(pregnancyProgression, output);
+			forest = new Forest(pregnancyProgression, output);
+			deepWoods = new DeepWoods(forest);
+			desert = new Desert(pregnancyProgression, output);
 			
-			this.telAdre = new TelAdre(pregnancyProgression);
+			telAdre = new TelAdre(pregnancyProgression);
 			
-			this.impScene = new ImpScene(pregnancyProgression, output);
-			this.anemoneScene = new AnemoneScene(pregnancyProgression, output);
-			this.marbleScene = new MarbleScene(pregnancyProgression, output);
-			this.jojoScene = new JojoScene(pregnancyProgression, output);
-			this.amilyScene = new AmilyScene(pregnancyProgression, output);
-			this.izmaScene = new IzmaScene(pregnancyProgression, output);
-			this.lake = new Lake(pregnancyProgression, output);
+			impScene = new ImpScene(pregnancyProgression, output);
+			anemoneScene = new AnemoneScene(pregnancyProgression, output);
+			marbleScene = new MarbleScene(pregnancyProgression, output);
+			jojoScene = new JojoScene(pregnancyProgression, output);
+			amilyScene = new AmilyScene(pregnancyProgression, output);
+			izmaScene = new IzmaScene(pregnancyProgression, output);
+			lake = new Lake(pregnancyProgression, output);
 
 			// not assigned to a variable as it is self-registering, PregnancyProgress will keep a reference to the instance
 			new PlayerCentaurPregnancy(pregnancyProgression, output);
@@ -474,8 +474,8 @@ package classes
 			new PlayerBenoitPregnancy(pregnancyProgression, output);
 			new PlayerOviElixirPregnancy(pregnancyProgression, output);
 			
-			this.emberScene = new EmberScene(pregnancyProgression);
-			this.urtaPregs = new UrtaPregs(pregnancyProgression);
+			emberScene = new EmberScene(pregnancyProgression);
+			urtaPregs = new UrtaPregs(pregnancyProgression);
 		}
 		
 		/**

--- a/classes/classes/Scenes/AnalPregnancy.as
+++ b/classes/classes/Scenes/AnalPregnancy.as
@@ -1,0 +1,21 @@
+package classes.Scenes 
+{
+	import classes.Creature;
+	/**
+	 * Interface for anal pregnancy.
+	 * The class must at least implement a birth scene.
+	 */
+	public interface AnalPregnancy 
+	{
+		/**
+		 * Progresses a active pregnancy. Updates should eventually lead to birth.
+		 * @return true if the display output needs to be updated.
+		 */
+		function updateAnalPregnancy(): Boolean;
+		
+		/**
+		 * Give birth. Should outout a birth scene.
+		 */
+		function analBirth(): void;
+	}
+}

--- a/classes/classes/Scenes/Areas/Bog.as
+++ b/classes/classes/Scenes/Areas/Bog.as
@@ -13,6 +13,7 @@ package classes.Scenes.Areas {
 	import classes.Scenes.API.IExplorable;
 	import classes.Scenes.Areas.Bog.*;
 	import classes.Scenes.PregnancyProgression;
+	import classes.internals.GuiOutput;
 
 	use namespace kGAMECLASS;
 
@@ -25,9 +26,9 @@ package classes.Scenes.Areas {
 		public var parasiteScene:ParasiteScene = new ParasiteScene();
 		public var infestedChameleonGirlScene:InfestedChameleonGirlScene = new InfestedChameleonGirlScene();
 		*/
-		public function Bog(pregnancyProgression:PregnancyProgression) {
+		public function Bog(pregnancyProgression:PregnancyProgression, output: GuiOutput) {
 			this.phoukaScene = new PhoukaScene(pregnancyProgression);
-			this.frogGirlScene = new FrogGirlScene(pregnancyProgression);
+			this.frogGirlScene = new FrogGirlScene(pregnancyProgression, output);
 		}
 		
 		public function isDiscovered():Boolean { return flags[kFLAGS.BOG_EXPLORED] > 0; }

--- a/classes/classes/Scenes/Areas/Bog/FrogGirlScene.as
+++ b/classes/classes/Scenes/Areas/Bog/FrogGirlScene.as
@@ -220,18 +220,22 @@ private function lessonFollowup():void {
  */
 public function updateAnalPregnancy():Boolean {
 	if (player.buttPregnancyIncubation === 8) {
-		//Egg Maturing
 		outputGui.text("\nYour gut churns, and with a squelching noise, a torrent of transparent slime gushes from your ass.  You immediately fall to your knees, landing wetly amidst the slime.  The world around briefly flashes with unbelievable colors, and you hear someone giggling.\n\nAfter a moment, you realize that it’s you.");
-		//pussy:
-		if (player.hasVagina()) outputGui.text("  Against your [vagina], the slime feels warm and cold at the same time, coaxing delightful tremors from your [clit].");
-		//[balls:
-		else if (player.balls > 0) outputGui.text("  Slathered in hallucinogenic frog slime, your balls tingle, sending warm pulses of pleasure all the way up into your brain.");
-		//[cock:
-		else if (player.hasCock()) outputGui.text("  Splashing against the underside of your " + player.multiCockDescriptLight() + ", the slime leaves a warm, oozy sensation that makes you just want to rub [eachCock] over and over and over again.");
-		//genderless: 
-		else outputGui.text("  Your asshole begins twitching, aching for something to push through it over and over again.");
+		
+		if (player.hasVagina()) {
+			outputGui.text("  Against your [vagina], the slime feels warm and cold at the same time, coaxing delightful tremors from your [clit].");
+		} else if (player.balls > 0) {
+			outputGui.text("  Slathered in hallucinogenic frog slime, your balls tingle, sending warm pulses of pleasure all the way up into your brain.");
+		} else if (player.hasCock()) {
+			outputGui.text("  Splashing against the underside of your " + player.multiCockDescriptLight() + ", the slime leaves a warm, oozy sensation that makes you just want to rub [eachCock] over and over and over again.");
+		} else {
+			//genderless
+			outputGui.text("  Your asshole begins twitching, aching for something to push through it over and over again.");
+		}
+		
 		outputGui.text("  Seated in your own slime, you moan softly, unable to keep your hands off yourself.");
 		dynStats("lus=", player.maxLust(), "scale", false);
+		
 		return true;
 	}
 	
@@ -242,21 +246,25 @@ public function updateAnalPregnancy():Boolean {
  * @inheritDoc
  */
 public function analBirth():void {
-	//Picture is here
 	outputGui.text(images.showImage("birth-froggirl-anal"));
 	outputGui.text("\n<b>Oh no...</b>\nYou groan, feeling a shudder from deep inside, a churning from your gut.  A trickle of slime leaks from your [asshole] down your [legs] and you feel a pressure from deep inside.");
 	outputGui.text("\n\nWater - you need to be near water!  The instinct is sudden and clear, and you stagger toward the small creek near your camp.  You crouch low on the river bank, hands on the ground, and knees angled up in an oddly frog-like pose.");
 	outputGui.text("\n\nSlime pools beneath you, running down into the water as he first egg begins shoving out of you.  It feels... weird.  The pressure isn’t as intense as some of the things you’ve encountered in Mareth, but it’s still incredibly large.  Your asshole stretches wide, numbed a bit by the slime, but still far larger than you would have thought possible.  As the egg squelches to the ground, you realize that the eggs are jelly-like, and pliant enough to give you some leeway in laying them.");
 	outputGui.text("\n\nThe first egg rolls down into the water, anchored by the pooling slime, but you can’t spare it more than a moment’s glance.  The next egg pushes against you, and you groan, shuddering and panting as you try to force it out.  Your asshole aches with every lurch of your body, but finally, the second watermelon-sized egg wobbles free from your ass.  You’re already exhausted as you feel the next one coming, but you manage to force this one out, too, collapsing face-forward onto the ground.");
+	
 	player.buttChange(80,true,true,false);
+	
 	outputGui.text("\n\nNature pushes onward, though, and your body works to push the next egg out.  You moan, only half conscious, the frog slime on your skin once again lifting you into a state of hazy awareness as egg after egg pushes out of your body.");
 	outputGui.text("\n\n<b>Later, you wake up to the sound of splashing....</b>\nIn the river are a dozen tiny figures, each no more than a foot long, and each one a mirror of the frog girl from the waist-up, but oddly featureless from the waist-down. Their lower halves ending in vaguely-finned tails, like tadpoles.");
 	outputGui.text("\n\nThe tadgirls splash each other, playing in the water, but take notice as you wake up.  It seems that they were waiting for you - displaying a level of concern that their original mother lacked.  Maybe they got that from you?  They wave and swim away downstream, and you notice that a few of them have a few unusual splashes of color in their hair and skin, looking a bit more like you than their mother.");
 	outputGui.text("\n\nYou nod to yourself, happy to be finished with that ordeal.  As you stand, you notice a bit of heaviness to your hips, and some added slickness to your asshole.\n");
-	//[Anal moistness +2, Hips +1]
 	player.hips.rating++;
 	player.ass.analWetness += 1;
-	if (player.ass.analWetness > 5) player.ass.analWetness = 5;
+	
+	if (player.ass.analWetness > 5) {
+		player.ass.analWetness = 5;
+	}
+	
 	player.orgasm('Anal');
 	dynStats("sen", 1);
 	

--- a/classes/classes/Scenes/Areas/Bog/FrogGirlScene.as
+++ b/classes/classes/Scenes/Areas/Bog/FrogGirlScene.as
@@ -2,17 +2,23 @@ package classes.Scenes.Areas.Bog {
 	import classes.*;
 	import classes.BodyParts.*;
 	import classes.GlobalFlags.kFLAGS;
+	import classes.Scenes.AnalPregnancy;
 	import classes.Scenes.VaginalPregnancy;
 	import classes.Scenes.PregnancyProgression;
+	import classes.internals.GuiOutput;
 
-	public class FrogGirlScene extends BaseContent implements VaginalPregnancy{
+	public class FrogGirlScene extends BaseContent implements VaginalPregnancy, AnalPregnancy {
 		//TODO remove after PregnancyProgression cleanup
-		private var pregnancyProgression:PregnancyProgression; 
+		private var pregnancyProgression:PregnancyProgression;
+		private var outputGui:GuiOutput;
 		
-	public function FrogGirlScene(pregnancyProgression:PregnancyProgression)
+	public function FrogGirlScene(pregnancyProgression:PregnancyProgression, output:GuiOutput)
 	{
 		this.pregnancyProgression = pregnancyProgression;
+		this.outputGui = output;
+		
 		pregnancyProgression.registerVaginalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_FROG_GIRL, this);
+		pregnancyProgression.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_FROG_GIRL, this);
 	}
 
 //const TIMES_ENCOUNTERED_FROG:int = 1017;
@@ -209,26 +215,54 @@ private function lessonFollowup():void {
 	doNext(camp.returnToCampUseTwoHours);
 }
 
-//Laying the Eggs
-public function birthFrogEggsAnal():void {
+/**
+ * @inheritDoc
+ */
+public function updateAnalPregnancy():Boolean {
+	if (player.buttPregnancyIncubation === 8) {
+		//Egg Maturing
+		outputGui.text("\nYour gut churns, and with a squelching noise, a torrent of transparent slime gushes from your ass.  You immediately fall to your knees, landing wetly amidst the slime.  The world around briefly flashes with unbelievable colors, and you hear someone giggling.\n\nAfter a moment, you realize that it’s you.");
+		//pussy:
+		if (player.hasVagina()) outputGui.text("  Against your [vagina], the slime feels warm and cold at the same time, coaxing delightful tremors from your [clit].");
+		//[balls:
+		else if (player.balls > 0) outputGui.text("  Slathered in hallucinogenic frog slime, your balls tingle, sending warm pulses of pleasure all the way up into your brain.");
+		//[cock:
+		else if (player.hasCock()) outputGui.text("  Splashing against the underside of your " + player.multiCockDescriptLight() + ", the slime leaves a warm, oozy sensation that makes you just want to rub [eachCock] over and over and over again.");
+		//genderless: 
+		else outputGui.text("  Your asshole begins twitching, aching for something to push through it over and over again.");
+		outputGui.text("  Seated in your own slime, you moan softly, unable to keep your hands off yourself.");
+		dynStats("lus=", player.maxLust(), "scale", false);
+		return true;
+	}
+	
+	return false;
+}
+
+/**
+ * @inheritDoc
+ */
+public function analBirth():void {
 	//Picture is here
-	outputText(images.showImage("birth-froggirl-anal"));
-	outputText("\n<b>Oh no...</b>\nYou groan, feeling a shudder from deep inside, a churning from your gut.  A trickle of slime leaks from your [asshole] down your [legs] and you feel a pressure from deep inside.");
-	outputText("\n\nWater - you need to be near water!  The instinct is sudden and clear, and you stagger toward the small creek near your camp.  You crouch low on the river bank, hands on the ground, and knees angled up in an oddly frog-like pose.");
-	outputText("\n\nSlime pools beneath you, running down into the water as he first egg begins shoving out of you.  It feels... weird.  The pressure isn’t as intense as some of the things you’ve encountered in Mareth, but it’s still incredibly large.  Your asshole stretches wide, numbed a bit by the slime, but still far larger than you would have thought possible.  As the egg squelches to the ground, you realize that the eggs are jelly-like, and pliant enough to give you some leeway in laying them.");
-	outputText("\n\nThe first egg rolls down into the water, anchored by the pooling slime, but you can’t spare it more than a moment’s glance.  The next egg pushes against you, and you groan, shuddering and panting as you try to force it out.  Your asshole aches with every lurch of your body, but finally, the second watermelon-sized egg wobbles free from your ass.  You’re already exhausted as you feel the next one coming, but you manage to force this one out, too, collapsing face-forward onto the ground.");
+	outputGui.text(images.showImage("birth-froggirl-anal"));
+	outputGui.text("\n<b>Oh no...</b>\nYou groan, feeling a shudder from deep inside, a churning from your gut.  A trickle of slime leaks from your [asshole] down your [legs] and you feel a pressure from deep inside.");
+	outputGui.text("\n\nWater - you need to be near water!  The instinct is sudden and clear, and you stagger toward the small creek near your camp.  You crouch low on the river bank, hands on the ground, and knees angled up in an oddly frog-like pose.");
+	outputGui.text("\n\nSlime pools beneath you, running down into the water as he first egg begins shoving out of you.  It feels... weird.  The pressure isn’t as intense as some of the things you’ve encountered in Mareth, but it’s still incredibly large.  Your asshole stretches wide, numbed a bit by the slime, but still far larger than you would have thought possible.  As the egg squelches to the ground, you realize that the eggs are jelly-like, and pliant enough to give you some leeway in laying them.");
+	outputGui.text("\n\nThe first egg rolls down into the water, anchored by the pooling slime, but you can’t spare it more than a moment’s glance.  The next egg pushes against you, and you groan, shuddering and panting as you try to force it out.  Your asshole aches with every lurch of your body, but finally, the second watermelon-sized egg wobbles free from your ass.  You’re already exhausted as you feel the next one coming, but you manage to force this one out, too, collapsing face-forward onto the ground.");
 	player.buttChange(80,true,true,false);
-	outputText("\n\nNature pushes onward, though, and your body works to push the next egg out.  You moan, only half conscious, the frog slime on your skin once again lifting you into a state of hazy awareness as egg after egg pushes out of your body.");
-	outputText("\n\n<b>Later, you wake up to the sound of splashing....</b>\nIn the river are a dozen tiny figures, each no more than a foot long, and each one a mirror of the frog girl from the waist-up, but oddly featureless from the waist-down. Their lower halves ending in vaguely-finned tails, like tadpoles.");
-	outputText("\n\nThe tadgirls splash each other, playing in the water, but take notice as you wake up.  It seems that they were waiting for you - displaying a level of concern that their original mother lacked.  Maybe they got that from you?  They wave and swim away downstream, and you notice that a few of them have a few unusual splashes of color in their hair and skin, looking a bit more like you than their mother.");
-	outputText("\n\nYou nod to yourself, happy to be finished with that ordeal.  As you stand, you notice a bit of heaviness to your hips, and some added slickness to your asshole.\n");
+	outputGui.text("\n\nNature pushes onward, though, and your body works to push the next egg out.  You moan, only half conscious, the frog slime on your skin once again lifting you into a state of hazy awareness as egg after egg pushes out of your body.");
+	outputGui.text("\n\n<b>Later, you wake up to the sound of splashing....</b>\nIn the river are a dozen tiny figures, each no more than a foot long, and each one a mirror of the frog girl from the waist-up, but oddly featureless from the waist-down. Their lower halves ending in vaguely-finned tails, like tadpoles.");
+	outputGui.text("\n\nThe tadgirls splash each other, playing in the water, but take notice as you wake up.  It seems that they were waiting for you - displaying a level of concern that their original mother lacked.  Maybe they got that from you?  They wave and swim away downstream, and you notice that a few of them have a few unusual splashes of color in their hair and skin, looking a bit more like you than their mother.");
+	outputGui.text("\n\nYou nod to yourself, happy to be finished with that ordeal.  As you stand, you notice a bit of heaviness to your hips, and some added slickness to your asshole.\n");
 	//[Anal moistness +2, Hips +1]
 	player.hips.rating++;
 	player.ass.analWetness += 1;
 	if (player.ass.analWetness > 5) player.ass.analWetness = 5;
 	player.orgasm('Anal');
 	dynStats("sen", 1);
+	
+	pregnancyProgression.detectAnalBirth(PregnancyStore.PREGNANCY_FROG_GIRL);
 }
+
 //Superbonus Vaginal Eggs!
 private function superBonusFrogEggsInYerCooch():void {
 	clearOutput();

--- a/classes/classes/Scenes/Areas/DeepWoods.as
+++ b/classes/classes/Scenes/Areas/DeepWoods.as
@@ -11,7 +11,23 @@ package classes.Scenes.Areas {
 	public class DeepWoods extends BaseContent implements IExplorable {
 		private var forest:Forest;
 
-		public function DeepWoods(forest:Forest) { this.forest = forest; }
+		/**
+		 * Create a new deepwoods instance for exploring.
+		 * 
+		 * The constructor will fail if the forest is not valid. This fail-fast
+		 * behaviour is used because explore() is only called much later, making it harder
+		 * to figure out what happened.
+		 * @param	forest the forest to use for encounters
+		 * @throws ArgumentError if the forest is null or undefined
+		 */
+		public function DeepWoods(forest:Forest)
+		{
+			if (forest === null) {
+				throw ArgumentError("Forest cannot be null");
+			}
+			
+			this.forest = forest;
+		}
 
 		public function isDiscovered():Boolean {
 			//TODO refactor all areas to use class fields as counters

--- a/classes/classes/Scenes/Areas/Desert.as
+++ b/classes/classes/Scenes/Areas/Desert.as
@@ -9,6 +9,8 @@ package classes.Scenes.Areas {
 	import classes.Scenes.API.FnHelpers;
 	import classes.Scenes.API.IExplorable;
 	import classes.Scenes.Areas.Desert.*;
+	import classes.Scenes.PregnancyProgression;
+	import classes.internals.GuiOutput;
 
 	use namespace kGAMECLASS;
 
@@ -16,12 +18,14 @@ package classes.Scenes.Areas {
 		public var antsScene:AntsScene = new AntsScene();
 		public var nagaScene:NagaScene = new NagaScene();
 		public var oasis:Oasis = new Oasis();
-		public var sandTrapScene:SandTrapScene = new SandTrapScene();
+		public var sandTrapScene:SandTrapScene;
 		public var sandWitchScene:SandWitchScene = new SandWitchScene();
 		public var ghoulScene:GhoulScene = new GhoulScene();
 		public var wanderer:Wanderer = new Wanderer();
 
-		public function Desert() {}
+		public function Desert(pregnancyProgression:PregnancyProgression, output:GuiOutput) {
+			this.sandTrapScene = new SandTrapScene(pregnancyProgression, output);
+		}
 
 		public function isDiscovered():Boolean { return flags[kFLAGS.TIMES_EXPLORED_DESERT] > 0; }
 		public function discover():void {

--- a/classes/classes/Scenes/Areas/Desert/SandTrapScene.as
+++ b/classes/classes/Scenes/Areas/Desert/SandTrapScene.as
@@ -3,6 +3,9 @@ package classes.Scenes.Areas.Desert {
 	import classes.BodyParts.*;
 	import classes.GlobalFlags.kFLAGS;
 	import classes.Items.Armors.LustyMaidensArmor;
+	import classes.Scenes.Monsters.pregnancies.PlayerSandTrapFertilePregnancy;
+	import classes.Scenes.Monsters.pregnancies.PlayerSandTrapPregnancy;
+	import classes.Scenes.PregnancyProgression;
 	import classes.display.SpriteDb;
 	import classes.internals.*;
 
@@ -11,8 +14,10 @@ package classes.Scenes.Areas.Desert {
 			return monster as SandTrap;
 		}
 
-		public function SandTrapScene()
+		public function SandTrapScene(pregnancyProgression:PregnancyProgression, output:GuiOutput)
 		{
+			new PlayerSandTrapPregnancy(pregnancyProgression, output);
+			new PlayerSandTrapFertilePregnancy(pregnancyProgression, output);
 		}
 
 //const TIMES_ENCOUNTERED_SAND_TRAPS:int = 578;

--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -8,12 +8,14 @@ package classes.Scenes.Areas {
 	import classes.Scenes.API.FnHelpers;
 	import classes.Scenes.API.IExplorable;
 	import classes.Scenes.Areas.Forest.*;
+	import classes.Scenes.PregnancyProgression;
+	import classes.internals.GuiOutput;
 
 	use namespace kGAMECLASS;
 
 	public class Forest extends BaseContent implements IExplorable {
 		public var akbalScene:AkbalScene = new AkbalScene();
-		public var beeGirlScene:BeeGirlScene = new BeeGirlScene();
+		public var beeGirlScene:BeeGirlScene;
 		public var corruptedGlade:CorruptedGlade = new CorruptedGlade();
 		public var essrayle:Essrayle = new Essrayle();
 		public var faerie:Faerie = new Faerie();
@@ -24,7 +26,9 @@ package classes.Scenes.Areas {
 //		public var dullahanScene:DullahanScene = new DullahanScene(); //[INTERMOD:8chan]
 		public var dryadScene:DryadScene = new DryadScene();
 
-		public function Forest() {}
+		public function Forest(pregnancyProgression:PregnancyProgression, output:GuiOutput) {
+			this.beeGirlScene = new BeeGirlScene(pregnancyProgression, output);
+		}
 
 		public function isDiscovered():Boolean { return flags[kFLAGS.TIMES_EXPLORED_FOREST] > 0; }
 		public function discover():void {

--- a/classes/classes/Scenes/Areas/Forest/BeeGirlScene.as
+++ b/classes/classes/Scenes/Areas/Forest/BeeGirlScene.as
@@ -8,6 +8,8 @@ package classes.Scenes.Areas.Forest
 	import classes.BodyParts.*;
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Scenes.Monsters.pregnancies.PlayerBeePregnancy;
+	import classes.Scenes.PregnancyProgression;
 	import classes.display.SpriteDb;
 	import classes.internals.*;
 	import classes.VaginaClass;
@@ -24,7 +26,9 @@ package classes.Scenes.Areas.Forest
 		private static const BEE_GIRL_PLAYER_DISGUSTED:int			=          6;
 		private static const BEE_GIRL_PLAYER_DUTY:int				=          7;
 		
-		public function BeeGirlScene() {}
+		public function BeeGirlScene(pregnancyProgression:PregnancyProgression, output:GuiOutput) {
+			new PlayerBeePregnancy(pregnancyProgression, output);
+		}
 		
 		public function setTalked():void { flags[kFLAGS.BEE_GIRL_STATUS] = BEE_GIRL_TALKED; }
 		

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerBeePregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerBeePregnancy.as
@@ -42,25 +42,49 @@ package classes.Scenes.Monsters.pregnancies
 			
 			if (player.buttPregnancyIncubation === 36) {
 				output.text("<b>\nYou feel bloated, your bowels shifting uncomfortably from time to time.</b>\n");
+				
 				displayedUpdate = true;
 			}
+			
 			if (player.buttPregnancyIncubation === 20) {
 				output.text("<b>\nA honey-scented fluid drips from your rectum.</b>  At first it worries you, but as the smell fills the air around you, you realize anything with such a beautiful scent must be good.  ");
-				if (player.cockTotal() > 0) output.text("The aroma seems to permeate your very being, slowly congregating in your ");
+				
+				if (player.cockTotal() > 0) {
+					output.text("The aroma seems to permeate your very being, slowly congregating in your ");
+				}
+				
 				if (player.cockTotal() === 1) {
 					output.text(player.cockDescript(0));
-					if (player.countCocksOfType(CockTypesEnum.HORSE) === 1) output.text(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air, until your " + player.cockDescript(0) + " is twitching and dripping, the flare swollen and purple.  ");
-					if (player.dogCocks() === 1) output.text(", each inhalation making it thicker, harder, and firmer.  You suck in huge lungfuls of air, desperate for more, until your " + player.cockDescript(0) + " is twitching and dripping, its knot swollen to the max.  ");
-					if (player.countCocksOfType(CockTypesEnum.HUMAN) === 1) output.text(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air, until your " + player.cockDescript(0) + " is twitching and dripping, the head swollen and purple.  ");
+					
+					if (player.countCocksOfType(CockTypesEnum.HORSE) === 1) {
+						output.text(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air, until your " + player.cockDescript(0) + " is twitching and dripping, the flare swollen and purple.  ");
+					}
+					
+					if (player.dogCocks() === 1) {
+						output.text(", each inhalation making it thicker, harder, and firmer.  You suck in huge lungfuls of air, desperate for more, until your " + player.cockDescript(0) + " is twitching and dripping, its knot swollen to the max.  ");
+					}
+					
+					if (player.countCocksOfType(CockTypesEnum.HUMAN) === 1) {
+						output.text(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air, until your " + player.cockDescript(0) + " is twitching and dripping, the head swollen and purple.  ");
+					}
+					
 					//FAILSAFE FOR NEW COCKS
-					if (player.countCocksOfType(CockTypesEnum.HUMAN) === 0 && player.dogCocks() === 0 && player.countCocksOfType(CockTypesEnum.HORSE) === 0) output.text(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air until your " + player.cockDescript(0) + " is twitching and dripping.  ");
+					if (player.countCocksOfType(CockTypesEnum.HUMAN) === 0 && player.dogCocks() === 0 && player.countCocksOfType(CockTypesEnum.HORSE) === 0) {
+						output.text(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air until your " + player.cockDescript(0) + " is twitching and dripping.  ");
+					}
 				}
-				if (player.cockTotal() > 1) output.text("groin.  Your " + player.multiCockDescriptLight() + " fill and grow with every lungful of the stuff you breathe in.  You suck in great lungfuls of the tainted air, desperate for more, your cocks twitching and dripping with need.  ");
+				
+				if (player.cockTotal() > 1) {
+					output.text("groin.  Your " + player.multiCockDescriptLight() + " fill and grow with every lungful of the stuff you breathe in.  You suck in great lungfuls of the tainted air, desperate for more, your cocks twitching and dripping with need.  ");
+				}
+				
 				output.text("You smile knowing you couldn't stop from masturbating if you wanted to.\n");
+				
 				kGAMECLASS.dynStats("int", -.5, "lus", 500);
+				
 				displayedUpdate = true;
 			}
-				
+			
 			return displayedUpdate;
 		}
 		
@@ -74,35 +98,69 @@ package classes.Scenes.Monsters.pregnancies
 			var displayedUpdate:Boolean = false;
 			
 			output.text("\n");
+			
 			output.text(kGAMECLASS.images.showImage("birth-beegirl"));
+			
 			output.text("There is a sudden gush of honey-colored fluids from your ass.  Before panic can set in, a wonderful scent overtakes you, making everything ok.  ");
-			if (player.cockTotal() > 0) output.text("The muzzy feeling that fills your head seems to seep downwards, making your equipment hard and tight.  ");
-			if (player.vaginas.length > 0) output.text("Your " + player.vaginaDescript(0) + " becomes engorged and sensitive.  ");
+			
+			if (player.cockTotal() > 0) {
+				output.text("The muzzy feeling that fills your head seems to seep downwards, making your equipment hard and tight.  ");
+			}
+			
+			if (player.vaginas.length > 0) {
+				output.text("Your " + player.vaginaDescript(0) + " becomes engorged and sensitive.  ");
+			}
+			
 			output.text("Your hand darts down to the amber, scooping up a handful of the sticky stuff.  You wonder what your hand is doing as it brings it up to your mouth, which instinctively opens.  You shudder in revulsion as you swallow the sweet-tasting stuff, your mind briefly wondering why it would do that.  The stuff seems to radiate warmth, quickly pushing those nagging thoughts away as you scoop up more.\n\n");
 			output.text("A sudden slip from below surprises you; a white sphere escapes from your anus along with another squirt of honey.  Your drugged brain tries to understand what's happening, but it gives up, your hands idly slathering honey over your loins.  The next orb pops out moments later, forcing a startled moan from your mouth.  That felt GOOD.  You begin masturbating to the thought of laying more eggs... yes, that's what those are.  You nearly cum as egg number three squeezes out.  ");
-			if (player.averageLactation() >= 1 && player.biggestTitSize() > 2) output.text("Seeking even greater sensation, your hands gather the honey and massage it into your " + player.breastDescript(0) + ", slowly working up to your nipples.  Milk immediately begins pouring out from the attention, flooding your chest with warmth.  ");
+			
+			if (player.averageLactation() >= 1 && player.biggestTitSize() > 2) {
+				output.text("Seeking even greater sensation, your hands gather the honey and massage it into your " + player.breastDescript(0) + ", slowly working up to your nipples.  Milk immediately begins pouring out from the attention, flooding your chest with warmth.  ");
+			}
+			
 			output.text("Each egg seems to come out closer on the heels of the one before, and each time your conscious mind loses more of its ability to do anything but masturbate and wallow in honey.\n\n");
 			output.text("Some time later, your mind begins to return, brought to wakefulness by an incredibly loud buzzing...  You sit up and see a pile of dozens of eggs resting in a puddle of sticky honey.  Most are empty, but a few have hundreds of honey-bees emptying from them, joining the massive swarms above you.  ");
-			if (player.cor < 35) output.text("You are disgusted, but glad you were not stung during the ordeal.  You stagger away and find a brook to wash out your mouth with.");
-			if (player.cor >= 35 && player.cor < 65) output.text("You are amazed you could lay so many eggs, and while the act was strange there was something definitely arousing about it.");
-			if (player.cor >= 65 && player.cor < 90) output.text("You stretch languidly, noting that most of the drugged honey is gone.  Maybe you can find the Bee again and remember to bottle it next time.");
-			if (player.cor >= 90) output.text("You lick your lips, savoring the honeyed residue on them as you admire your thousands of children.  If only every night could be like this...\n");
+			
+			if (player.cor < 35) {
+				output.text("You are disgusted, but glad you were not stung during the ordeal.  You stagger away and find a brook to wash out your mouth with.");
+			}
+			
+			if (player.cor >= 35 && player.cor < 65) {
+				output.text("You are amazed you could lay so many eggs, and while the act was strange there was something definitely arousing about it.");
+			}
+			
+			if (player.cor >= 65 && player.cor < 90) {
+				output.text("You stretch languidly, noting that most of the drugged honey is gone.  Maybe you can find the Bee again and remember to bottle it next time.");
+			}
+			
+			if (player.cor >= 90) {
+				output.text("You lick your lips, savoring the honeyed residue on them as you admire your thousands of children.  If only every night could be like this...\n");
+			}
+			
 			player.orgasm('Anal');
+			
 			kGAMECLASS.dynStats("int", 1, "lib", 4, "sen", 3);
-			if (player.buttChange(20, true)) output.text("\n");
+			
+			if (player.buttChange(20, true)) {
+				output.text("\n");
+			}
+			
 			if (player.butt.rating < 17) {
-				//Guaranteed increase up to level 10
 				if (player.butt.rating < 13) {
+					//Guaranteed increase up to level 10
 					player.butt.rating++;
+					
+					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.");
+				} else if (Utils.rand(2) === 0) {
+					//Big butts only increase 50% of the time.
+					player.butt.rating++;
+					
 					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.");
 				}
-				//Big butts only increase 50% of the time.
-				else if (Utils.rand(2) === 0){
-					player.butt.rating++;
-					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.");				
-				}
 			}
+			
 			output.text("\n");
+			
 			displayedUpdate = true;
 			
 			pregnancyProgression.detectAnalBirth(PregnancyStore.PREGNANCY_BEE_EGGS);

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerBeePregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerBeePregnancy.as
@@ -1,0 +1,111 @@
+package classes.Scenes.Monsters.pregnancies 
+{
+	import classes.CockTypesEnum;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.PregnancyStore;
+	import classes.Scenes.AnalPregnancy;
+	import classes.Scenes.PregnancyProgression;
+	import classes.Scenes.VaginalPregnancy;
+	import classes.internals.GuiOutput;
+	import classes.internals.Utils;
+	
+	/**
+	 * Contains pregnancy progression and birth scenes for a Player impregnated by bee.
+	 */
+	public class PlayerBeePregnancy implements AnalPregnancy
+	{
+		private var pregnancyProgression:PregnancyProgression;
+		private var output:GuiOutput;
+		
+		/**
+		 * Create a new bee pregnancy for the player. Registers pregnancy for bee.
+		 * @param	pregnancyProgression instance used for registering pregnancy scenes
+		 * @param	output instance for gui output
+		 */
+		public function PlayerBeePregnancy(pregnancyProgression:PregnancyProgression, output:GuiOutput) 
+		{
+			this.output = output;
+			this.pregnancyProgression = pregnancyProgression;
+			
+			pregnancyProgression.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_BEE_EGGS, this);
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function updateAnalPregnancy():Boolean 
+		{
+			//TODO remove this once new Player calls have been removed
+			var player:Player = kGAMECLASS.player;
+			var displayedUpdate:Boolean = false;
+			
+			if (player.buttPregnancyIncubation === 36) {
+				output.text("<b>\nYou feel bloated, your bowels shifting uncomfortably from time to time.</b>\n");
+				displayedUpdate = true;
+			}
+			if (player.buttPregnancyIncubation === 20) {
+				output.text("<b>\nA honey-scented fluid drips from your rectum.</b>  At first it worries you, but as the smell fills the air around you, you realize anything with such a beautiful scent must be good.  ");
+				if (player.cockTotal() > 0) output.text("The aroma seems to permeate your very being, slowly congregating in your ");
+				if (player.cockTotal() === 1) {
+					output.text(player.cockDescript(0));
+					if (player.countCocksOfType(CockTypesEnum.HORSE) === 1) output.text(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air, until your " + player.cockDescript(0) + " is twitching and dripping, the flare swollen and purple.  ");
+					if (player.dogCocks() === 1) output.text(", each inhalation making it thicker, harder, and firmer.  You suck in huge lungfuls of air, desperate for more, until your " + player.cockDescript(0) + " is twitching and dripping, its knot swollen to the max.  ");
+					if (player.countCocksOfType(CockTypesEnum.HUMAN) === 1) output.text(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air, until your " + player.cockDescript(0) + " is twitching and dripping, the head swollen and purple.  ");
+					//FAILSAFE FOR NEW COCKS
+					if (player.countCocksOfType(CockTypesEnum.HUMAN) === 0 && player.dogCocks() === 0 && player.countCocksOfType(CockTypesEnum.HORSE) === 0) output.text(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air until your " + player.cockDescript(0) + " is twitching and dripping.  ");
+				}
+				if (player.cockTotal() > 1) output.text("groin.  Your " + player.multiCockDescriptLight() + " fill and grow with every lungful of the stuff you breathe in.  You suck in great lungfuls of the tainted air, desperate for more, your cocks twitching and dripping with need.  ");
+				output.text("You smile knowing you couldn't stop from masturbating if you wanted to.\n");
+				kGAMECLASS.dynStats("int", -.5, "lus", 500);
+				displayedUpdate = true;
+			}
+				
+			return displayedUpdate;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function analBirth():void 
+		{
+			//TODO remove this once new Player calls have been removed
+			var player:Player = kGAMECLASS.player;
+			var displayedUpdate:Boolean = false;
+			
+			output.text("\n");
+			output.text(kGAMECLASS.images.showImage("birth-beegirl"));
+			output.text("There is a sudden gush of honey-colored fluids from your ass.  Before panic can set in, a wonderful scent overtakes you, making everything ok.  ");
+			if (player.cockTotal() > 0) output.text("The muzzy feeling that fills your head seems to seep downwards, making your equipment hard and tight.  ");
+			if (player.vaginas.length > 0) output.text("Your " + player.vaginaDescript(0) + " becomes engorged and sensitive.  ");
+			output.text("Your hand darts down to the amber, scooping up a handful of the sticky stuff.  You wonder what your hand is doing as it brings it up to your mouth, which instinctively opens.  You shudder in revulsion as you swallow the sweet-tasting stuff, your mind briefly wondering why it would do that.  The stuff seems to radiate warmth, quickly pushing those nagging thoughts away as you scoop up more.\n\n");
+			output.text("A sudden slip from below surprises you; a white sphere escapes from your anus along with another squirt of honey.  Your drugged brain tries to understand what's happening, but it gives up, your hands idly slathering honey over your loins.  The next orb pops out moments later, forcing a startled moan from your mouth.  That felt GOOD.  You begin masturbating to the thought of laying more eggs... yes, that's what those are.  You nearly cum as egg number three squeezes out.  ");
+			if (player.averageLactation() >= 1 && player.biggestTitSize() > 2) output.text("Seeking even greater sensation, your hands gather the honey and massage it into your " + player.breastDescript(0) + ", slowly working up to your nipples.  Milk immediately begins pouring out from the attention, flooding your chest with warmth.  ");
+			output.text("Each egg seems to come out closer on the heels of the one before, and each time your conscious mind loses more of its ability to do anything but masturbate and wallow in honey.\n\n");
+			output.text("Some time later, your mind begins to return, brought to wakefulness by an incredibly loud buzzing...  You sit up and see a pile of dozens of eggs resting in a puddle of sticky honey.  Most are empty, but a few have hundreds of honey-bees emptying from them, joining the massive swarms above you.  ");
+			if (player.cor < 35) output.text("You are disgusted, but glad you were not stung during the ordeal.  You stagger away and find a brook to wash out your mouth with.");
+			if (player.cor >= 35 && player.cor < 65) output.text("You are amazed you could lay so many eggs, and while the act was strange there was something definitely arousing about it.");
+			if (player.cor >= 65 && player.cor < 90) output.text("You stretch languidly, noting that most of the drugged honey is gone.  Maybe you can find the Bee again and remember to bottle it next time.");
+			if (player.cor >= 90) output.text("You lick your lips, savoring the honeyed residue on them as you admire your thousands of children.  If only every night could be like this...\n");
+			player.orgasm('Anal');
+			kGAMECLASS.dynStats("int", 1, "lib", 4, "sen", 3);
+			if (player.buttChange(20, true)) output.text("\n");
+			if (player.butt.rating < 17) {
+				//Guaranteed increase up to level 10
+				if (player.butt.rating < 13) {
+					player.butt.rating++;
+					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.");
+				}
+				//Big butts only increase 50% of the time.
+				else if (Utils.rand(2) === 0){
+					player.butt.rating++;
+					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.");				
+				}
+			}
+			output.text("\n");
+			displayedUpdate = true;
+			
+			pregnancyProgression.detectAnalBirth(PregnancyStore.PREGNANCY_BEE_EGGS);
+		}
+	}
+}

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerBunnyPregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerBunnyPregnancy.as
@@ -4,6 +4,7 @@ package classes.Scenes.Monsters.pregnancies
 	import classes.Items.Mutations;
 	import classes.Player;
 	import classes.PregnancyStore;
+	import classes.Scenes.AnalPregnancy;
 	import classes.Scenes.PregnancyProgression;
 	import classes.Scenes.VaginalPregnancy;
 	import classes.StatusEffects;
@@ -13,7 +14,7 @@ package classes.Scenes.Monsters.pregnancies
 	/**
 	 * Contains pregnancy progression and birth scenes for a Player impregnated by a bunny.
 	 */
-	public class PlayerBunnyPregnancy implements VaginalPregnancy 
+	public class PlayerBunnyPregnancy implements VaginalPregnancy, AnalPregnancy
 	{
 		private var pregnancyProgression:PregnancyProgression;
 		private var output:GuiOutput;
@@ -31,6 +32,7 @@ package classes.Scenes.Monsters.pregnancies
 			this.mutations = mutations;
 			
 			pregnancyProgression.registerVaginalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_BUNNY, this);
+			pregnancyProgression.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_BUNNY, this);
 		}
 		
 		/**
@@ -203,6 +205,50 @@ package classes.Scenes.Monsters.pregnancies
 			
 			player.orgasm('Vaginal');
 			kGAMECLASS.dynStats("lib", 1, "sen", 10, "cor", -2);
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function updateAnalPregnancy():Boolean 
+		{
+			//TODO remove this once new Player calls have been removed
+			var player:Player = kGAMECLASS.player;
+			var displayedUpdate:Boolean = false;
+			
+			if (player.buttPregnancyIncubation === 800) {
+				output.text("\nYour gut gurgles strangely.\n");
+				displayedUpdate = true;
+			}
+			if (player.buttPregnancyIncubation === 785) {
+				kGAMECLASS.mutations.neonPinkEgg(true,player);
+				output.text("\n");
+				displayedUpdate = true;
+			}
+			if (player.buttPregnancyIncubation === 776) {
+				output.text("\nYour gut feels full and bloated.\n");
+				displayedUpdate = true;
+			}
+			if (player.buttPregnancyIncubation === 765) {
+				kGAMECLASS.mutations.neonPinkEgg(true,player);
+				output.text("\n");
+				displayedUpdate = true;
+			}
+			if (player.buttPregnancyIncubation === 745) {
+				output.text("\n<b>After dealing with the discomfort and bodily changes for the past day or so, you finally get the feeling that the eggs in your ass have dissolved.</b>\n");
+				displayedUpdate = true;
+				player.buttKnockUpForce(); //Clear Butt Pregnancy
+			}
+			
+			return displayedUpdate;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function analBirth():void 
+		{
+			// there is no bunny anal birth, see PlayerBunnyPregnancy#updateAnalPregnancy()
 		}
 	}
 }

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerBunnyPregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerBunnyPregnancy.as
@@ -218,26 +218,36 @@ package classes.Scenes.Monsters.pregnancies
 			
 			if (player.buttPregnancyIncubation === 800) {
 				output.text("\nYour gut gurgles strangely.\n");
+				
 				displayedUpdate = true;
 			}
+			
 			if (player.buttPregnancyIncubation === 785) {
 				kGAMECLASS.mutations.neonPinkEgg(true,player);
 				output.text("\n");
+				
 				displayedUpdate = true;
 			}
+			
 			if (player.buttPregnancyIncubation === 776) {
 				output.text("\nYour gut feels full and bloated.\n");
+				
 				displayedUpdate = true;
 			}
+			
 			if (player.buttPregnancyIncubation === 765) {
 				kGAMECLASS.mutations.neonPinkEgg(true,player);
 				output.text("\n");
+				
 				displayedUpdate = true;
 			}
+			
 			if (player.buttPregnancyIncubation === 745) {
 				output.text("\n<b>After dealing with the discomfort and bodily changes for the past day or so, you finally get the feeling that the eggs in your ass have dissolved.</b>\n");
+				
 				displayedUpdate = true;
-				player.buttKnockUpForce(); //Clear Butt Pregnancy
+				
+				player.buttKnockUpForce();
 			}
 			
 			return displayedUpdate;

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerDriderPregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerDriderPregnancy.as
@@ -3,6 +3,7 @@ package classes.Scenes.Monsters.pregnancies
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Player;
 	import classes.PregnancyStore;
+	import classes.Scenes.AnalPregnancy;
 	import classes.Scenes.PregnancyProgression;
 	import classes.Scenes.VaginalPregnancy;
 	import classes.internals.GuiOutput;
@@ -10,7 +11,7 @@ package classes.Scenes.Monsters.pregnancies
 	/**
 	 * Contains pregnancy progression and birth scenes for a Player impregnated by a drider .
 	 */
-	public class PlayerDriderPregnancy implements VaginalPregnancy
+	public class PlayerDriderPregnancy implements VaginalPregnancy, AnalPregnancy
 	{
 		private var output:GuiOutput;
 		private var pregnancyProgression:PregnancyProgression;
@@ -148,6 +149,48 @@ package classes.Scenes.Monsters.pregnancies
 		{
 			pregnancyProgression.detectVaginalBirth(PregnancyStore.PREGNANCY_DRIDER_EGGS);
 			kGAMECLASS.swamp.corruptedDriderScene.driderPregVagBirth();
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function updateAnalPregnancy():Boolean 
+		{
+			//TODO remove this once new Player calls have been removed
+			var player:Player = kGAMECLASS.player;
+			var displayedUpdate:Boolean = false;
+			
+			if (player.buttPregnancyIncubation === 199) {
+				output.text("\n<b>After your session with the drider, you feel so nice and... full.  There is no outward change on your body, aside from the egg-packed bulge of your belly, but your " + player.assholeDescript() + " tingles slightly and leaks green goop from time to time. Hopefully it's nothing to be alarmed about.</b>\n");
+				displayedUpdate = true;
+			}
+			if (player.buttPregnancyIncubation === 180) {
+				output.text(kGAMECLASS.images.showImage("cDrider-loss-butt"));
+				output.text("\n<b>A hot flush works its way through you, and visions of aroused driders quickly come to dominate your thoughts.  You start playing with a nipple while you lose yourself in the fantasy, imagining being tied up in webs and packed completely full of eggs, stuffing your belly completely with burgeoning spheres of love.  You shake free of the fantasy and notice your hands rubbing over your slightly bloated belly.  Perhaps it wouldn't be so bad?</b>\n");
+				kGAMECLASS.dynStats("lib", 1, "sen", 1, "lus", 20);
+				displayedUpdate = true;				
+			}
+			if (player.buttPregnancyIncubation === 120) {
+				output.text("\n<b>Your belly is bulging from the size of the eggs growing inside you and gurgling just about any time you walk.  Green goo runs down your " + player.legs() + " frequently, drooling out of your pregnant asshole.</b>\n");
+				displayedUpdate = true;
+			}
+			if (player.buttPregnancyIncubation === 72) {
+				output.text("\n<b>The huge size of your pregnant belly constantly impedes your movement, but the constant squirming and shaking of your unborn offspring makes you pretty sure you won't have to carry them much longer.");
+				output.text("</b>\n");
+				displayedUpdate = true;
+			}
+			
+			return displayedUpdate;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function analBirth():void 
+		{
+			kGAMECLASS.swamp.corruptedDriderScene.birthSpiderEggsFromAnusITSBLEEDINGYAYYYYY();
+			
+			pregnancyProgression.detectAnalBirth(PregnancyStore.PREGNANCY_DRIDER_EGGS);
 		}
 	}
 }

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerDriderPregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerDriderPregnancy.as
@@ -28,6 +28,7 @@ package classes.Scenes.Monsters.pregnancies
 			this.output = output;
 			
 			pregnancyProgression.registerVaginalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_DRIDER_EGGS, this);
+			pregnancyProgression.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_DRIDER_EGGS, this);
 		}
 		
 		/**
@@ -162,21 +163,29 @@ package classes.Scenes.Monsters.pregnancies
 			
 			if (player.buttPregnancyIncubation === 199) {
 				output.text("\n<b>After your session with the drider, you feel so nice and... full.  There is no outward change on your body, aside from the egg-packed bulge of your belly, but your " + player.assholeDescript() + " tingles slightly and leaks green goop from time to time. Hopefully it's nothing to be alarmed about.</b>\n");
+				
 				displayedUpdate = true;
 			}
+			
 			if (player.buttPregnancyIncubation === 180) {
 				output.text(kGAMECLASS.images.showImage("cDrider-loss-butt"));
 				output.text("\n<b>A hot flush works its way through you, and visions of aroused driders quickly come to dominate your thoughts.  You start playing with a nipple while you lose yourself in the fantasy, imagining being tied up in webs and packed completely full of eggs, stuffing your belly completely with burgeoning spheres of love.  You shake free of the fantasy and notice your hands rubbing over your slightly bloated belly.  Perhaps it wouldn't be so bad?</b>\n");
+				
 				kGAMECLASS.dynStats("lib", 1, "sen", 1, "lus", 20);
-				displayedUpdate = true;				
-			}
-			if (player.buttPregnancyIncubation === 120) {
-				output.text("\n<b>Your belly is bulging from the size of the eggs growing inside you and gurgling just about any time you walk.  Green goo runs down your " + player.legs() + " frequently, drooling out of your pregnant asshole.</b>\n");
+				
 				displayedUpdate = true;
 			}
+			
+			if (player.buttPregnancyIncubation === 120) {
+				output.text("\n<b>Your belly is bulging from the size of the eggs growing inside you and gurgling just about any time you walk.  Green goo runs down your " + player.legs() + " frequently, drooling out of your pregnant asshole.</b>\n");
+				
+				displayedUpdate = true;
+			}
+			
 			if (player.buttPregnancyIncubation === 72) {
 				output.text("\n<b>The huge size of your pregnant belly constantly impedes your movement, but the constant squirming and shaking of your unborn offspring makes you pretty sure you won't have to carry them much longer.");
 				output.text("</b>\n");
+				
 				displayedUpdate = true;
 			}
 			

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerSandTrapFertilePregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerSandTrapFertilePregnancy.as
@@ -1,0 +1,86 @@
+package classes.Scenes.Monsters.pregnancies 
+{
+	import classes.CockTypesEnum;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.PregnancyStore;
+	import classes.Scenes.AnalPregnancy;
+	import classes.Scenes.PregnancyProgression;
+	import classes.Scenes.VaginalPregnancy;
+	import classes.internals.GuiOutput;
+	import classes.internals.Utils;
+	
+	/**
+	 * Contains pregnancy progression and birth scenes for a Player impregnated by sandtrap.
+	 */
+	public class PlayerSandTrapFertilePregnancy implements AnalPregnancy
+	{
+		private var pregnancyProgression:PregnancyProgression;
+		private var output:GuiOutput;
+		
+		/**
+		 * Create a new sandtrap pregnancy for the player. Registers pregnancy for sandtrap.
+		 * @param	pregnancyProgression instance used for registering pregnancy scenes
+		 * @param	output instance for gui output
+		 */
+		public function PlayerSandTrapFertilePregnancy(pregnancyProgression:PregnancyProgression, output:GuiOutput) 
+		{
+			this.output = output;
+			this.pregnancyProgression = pregnancyProgression;
+			
+			pregnancyProgression.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_SANDTRAP_FERTILE, this);
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function updateAnalPregnancy():Boolean 
+		{
+			//TODO remove this once new Player calls have been removed
+			var player:Player = kGAMECLASS.player;
+			var displayedUpdate:Boolean = false;
+			
+			if (player.buttPregnancyIncubation === 36) {
+				//(Eggs take 2-3 days to lay)
+				output.text("<b>\nYour bowels make a strange gurgling noise and shift uneasily.  You feel ");
+				output.text(" bloated and full; the sensation isn't entirely unpleasant.");
+				output.text("</b>\n");
+				displayedUpdate = true;
+			}
+			if (player.buttPregnancyIncubation === 20) {
+				//end eggpreg here if unfertilized
+				output.text("\nSomething oily drips from your sphincter, staining the ground.  You suppose you should feel worried about this, but the overriding emotion which simmers in your gut is one of sensual, yielding calm.  The pressure in your bowels which has been building over the last few days feels right somehow, and the fact that your back passage is dribbling lubricant makes you incredibly, perversely hot.  As you stand there and savor the wet, soothing sensation a fantasy pushes itself into your mind, one of being on your hands and knees and letting any number of beings use your ass, of being bred over and over by beautiful, irrepressible insect creatures.  With some effort you suppress these alien emotions and carry on, trying to ignore the oil which occasionally beads out of your " + player.assholeDescript() + " and stains your [armor].\n");
+				kGAMECLASS.dynStats("int", -.5, "lus", 500);
+				displayedUpdate = true;
+			}
+			
+			return displayedUpdate;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function analBirth():void 
+		{
+			//TODO remove this once new Player calls have been removed
+			var player:Player = kGAMECLASS.player;
+			var displayedUpdate:Boolean = false;
+			
+			kGAMECLASS.desert.sandTrapScene.birfSandTarps();
+			if (player.butt.rating < 17) {
+				//Guaranteed increase up to level 10
+				if (player.butt.rating < 13) {
+					player.butt.rating++;
+					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.\n");
+				}
+				//Big butts only increase 50% of the time.
+				else if (Utils.rand(2) === 0){
+					player.butt.rating++;
+					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.\n");				
+				}
+			}
+			displayedUpdate = true;
+			pregnancyProgression.detectAnalBirth(PregnancyStore.PREGNANCY_SANDTRAP_FERTILE);
+		}
+	}
+}

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerSandTrapFertilePregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerSandTrapFertilePregnancy.as
@@ -45,12 +45,16 @@ package classes.Scenes.Monsters.pregnancies
 				output.text("<b>\nYour bowels make a strange gurgling noise and shift uneasily.  You feel ");
 				output.text(" bloated and full; the sensation isn't entirely unpleasant.");
 				output.text("</b>\n");
+				
 				displayedUpdate = true;
 			}
+			
 			if (player.buttPregnancyIncubation === 20) {
 				//end eggpreg here if unfertilized
 				output.text("\nSomething oily drips from your sphincter, staining the ground.  You suppose you should feel worried about this, but the overriding emotion which simmers in your gut is one of sensual, yielding calm.  The pressure in your bowels which has been building over the last few days feels right somehow, and the fact that your back passage is dribbling lubricant makes you incredibly, perversely hot.  As you stand there and savor the wet, soothing sensation a fantasy pushes itself into your mind, one of being on your hands and knees and letting any number of beings use your ass, of being bred over and over by beautiful, irrepressible insect creatures.  With some effort you suppress these alien emotions and carry on, trying to ignore the oil which occasionally beads out of your " + player.assholeDescript() + " and stains your [armor].\n");
+				
 				kGAMECLASS.dynStats("int", -.5, "lus", 500);
+				
 				displayedUpdate = true;
 			}
 			
@@ -68,18 +72,19 @@ package classes.Scenes.Monsters.pregnancies
 			
 			kGAMECLASS.desert.sandTrapScene.birfSandTarps();
 			if (player.butt.rating < 17) {
-				//Guaranteed increase up to level 10
 				if (player.butt.rating < 13) {
+					//Guaranteed increase up to level 10
+					player.butt.rating++;
+					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.\n");
+				} else if (Utils.rand(2) === 0) {
+					//Big butts only increase 50% of the time.
 					player.butt.rating++;
 					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.\n");
 				}
-				//Big butts only increase 50% of the time.
-				else if (Utils.rand(2) === 0){
-					player.butt.rating++;
-					output.text("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.\n");				
-				}
 			}
+			
 			displayedUpdate = true;
+			
 			pregnancyProgression.detectAnalBirth(PregnancyStore.PREGNANCY_SANDTRAP_FERTILE);
 		}
 	}

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerSandTrapPregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerSandTrapPregnancy.as
@@ -1,0 +1,64 @@
+package classes.Scenes.Monsters.pregnancies 
+{
+	import classes.CockTypesEnum;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.PregnancyStore;
+	import classes.Scenes.AnalPregnancy;
+	import classes.Scenes.PregnancyProgression;
+	import classes.Scenes.VaginalPregnancy;
+	import classes.internals.GuiOutput;
+	import classes.internals.Utils;
+	
+	/**
+	 * Contains pregnancy progression and birth scenes for a Player impregnated by sandtrap.
+	 */
+	public class PlayerSandTrapPregnancy implements AnalPregnancy
+	{
+		private var pregnancyProgression:PregnancyProgression;
+		private var output:GuiOutput;
+		
+		/**
+		 * Create a new sandtrap pregnancy for the player. Registers pregnancy for sandtrap.
+		 * @param	pregnancyProgression instance used for registering pregnancy scenes
+		 * @param	output instance for gui output
+		 */
+		public function PlayerSandTrapPregnancy(pregnancyProgression:PregnancyProgression, output:GuiOutput) 
+		{
+			this.output = output;
+			this.pregnancyProgression = pregnancyProgression;
+			
+			pregnancyProgression.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_SANDTRAP, this);
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function updateAnalPregnancy():Boolean 
+		{
+			//TODO remove this once new Player calls have been removed
+			var player:Player = kGAMECLASS.player;
+			var displayedUpdate:Boolean = false;
+			
+			if (player.buttPregnancyIncubation === 36) {
+				output.text("<b>\nYour bowels make a strange gurgling noise and shift uneasily.  You feel ");
+				output.text("increasingly empty, as though some obstructions inside you were being broken down.");
+				output.text("</b>\n");
+				
+				player.buttKnockUpForce();
+				
+				displayedUpdate = true;
+			}
+			
+			return displayedUpdate;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function analBirth():void 
+		{
+			// there is no birth, since the sand trap was not fertile
+		}
+	}
+}

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerSatyrPregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerSatyrPregnancy.as
@@ -3,6 +3,7 @@ package classes.Scenes.Monsters.pregnancies
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Player;
 	import classes.PregnancyStore;
+	import classes.Scenes.AnalPregnancy;
 	import classes.Scenes.PregnancyProgression;
 	import classes.Scenes.VaginalPregnancy;
 	import classes.internals.GuiOutput;
@@ -10,8 +11,9 @@ package classes.Scenes.Monsters.pregnancies
 	/**
 	 * Contains pregnancy progression and birth scenes for a Player impregnated by Satyr.
 	 */
-	public class PlayerSatyrPregnancy implements VaginalPregnancy
+	public class PlayerSatyrPregnancy implements VaginalPregnancy, AnalPregnancy
 	{
+		private var pregnancyProgression:PregnancyProgression;
 		private var output:GuiOutput;
 		
 		/**
@@ -22,8 +24,10 @@ package classes.Scenes.Monsters.pregnancies
 		public function PlayerSatyrPregnancy(pregnancyProgression:PregnancyProgression, output:GuiOutput) 
 		{
 			this.output = output;
+			this.pregnancyProgression = pregnancyProgression;
 			
 			pregnancyProgression.registerVaginalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_SATYR, this);
+			pregnancyProgression.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_SATYR, this);
 		}
 		
 		/**
@@ -88,6 +92,61 @@ package classes.Scenes.Monsters.pregnancies
 		public function vaginalBirth():void 
 		{
 			kGAMECLASS.plains.satyrScene.satyrBirth(true);
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function updateAnalPregnancy():Boolean 
+		{
+			//TODO remove this once new Player calls have been removed
+			var player:Player = kGAMECLASS.player;
+			var displayedUpdate:Boolean = false;
+			
+			//Stage 1: 
+			if (player.buttPregnancyIncubation === 150) {
+				output.text("\n<b>You find that you're feeling quite sluggish these days; you just don't have as much energy as you used to.  You're also putting on weight.</b>\n");
+				displayedUpdate = true;
+			}
+			//Stage 2: 
+			if (player.buttPregnancyIncubation === 125) {
+				output.text("\n<b>Your belly is getting bigger and bigger.  Maybe your recent urges are to blame for this development?</b>\n");
+				displayedUpdate = true;
+			}
+			//Stage 3: 
+			if (player.buttPregnancyIncubation === 100) {
+				output.text("\n<b>You can feel the strangest fluttering sensations in your distended belly; it must be a pregnancy.  You should eat more and drink plenty of wine so your baby can grow properly.  Wait, wine...?</b>\n");
+				displayedUpdate = true;
+			}
+			//Stage 4: 
+			if (player.buttPregnancyIncubation === 75) {
+				output.text("\n<b>Sometimes you feel a bump in your pregnant belly.  You wonder if it's your baby complaining about your moving about.</b>\n");
+				displayedUpdate = true;
+			}
+			//Stage 5: 
+			if (player.buttPregnancyIncubation === 50) {
+				output.text("\n<b>With your bloating gut, you are loathe to exert yourself in any meaningful manner; you feel horny and hungry all the time...</b>\n");
+				displayedUpdate = true;
+				//temp min lust up +5
+			}
+			//Stage 6: 
+			if (player.buttPregnancyIncubation === 30) {
+				output.text("\n<b>The baby you're carrying constantly kicks your belly in demand for food and wine, and you feel sluggish and horny.  You can't wait to birth this little one so you can finally rest for a while.</b>\n");
+				displayedUpdate = true;
+				//temp min lust up addl +5
+			}
+			
+			return displayedUpdate;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function analBirth():void 
+		{
+			kGAMECLASS.plains.satyrScene.satyrBirth(false);
+			
+			pregnancyProgression.detectAnalBirth(PregnancyStore.PREGNANCY_SATYR);
 		}
 	}
 }

--- a/classes/classes/Scenes/Monsters/pregnancies/PlayerSatyrPregnancy.as
+++ b/classes/classes/Scenes/Monsters/pregnancies/PlayerSatyrPregnancy.as
@@ -108,32 +108,35 @@ package classes.Scenes.Monsters.pregnancies
 				output.text("\n<b>You find that you're feeling quite sluggish these days; you just don't have as much energy as you used to.  You're also putting on weight.</b>\n");
 				displayedUpdate = true;
 			}
+			
 			//Stage 2: 
 			if (player.buttPregnancyIncubation === 125) {
 				output.text("\n<b>Your belly is getting bigger and bigger.  Maybe your recent urges are to blame for this development?</b>\n");
 				displayedUpdate = true;
 			}
+			
 			//Stage 3: 
 			if (player.buttPregnancyIncubation === 100) {
 				output.text("\n<b>You can feel the strangest fluttering sensations in your distended belly; it must be a pregnancy.  You should eat more and drink plenty of wine so your baby can grow properly.  Wait, wine...?</b>\n");
 				displayedUpdate = true;
 			}
+			
 			//Stage 4: 
 			if (player.buttPregnancyIncubation === 75) {
 				output.text("\n<b>Sometimes you feel a bump in your pregnant belly.  You wonder if it's your baby complaining about your moving about.</b>\n");
 				displayedUpdate = true;
 			}
+			
 			//Stage 5: 
 			if (player.buttPregnancyIncubation === 50) {
 				output.text("\n<b>With your bloating gut, you are loathe to exert yourself in any meaningful manner; you feel horny and hungry all the time...</b>\n");
 				displayedUpdate = true;
-				//temp min lust up +5
 			}
+			
 			//Stage 6: 
 			if (player.buttPregnancyIncubation === 30) {
 				output.text("\n<b>The baby you're carrying constantly kicks your belly in demand for food and wine, and you feel sluggish and horny.  You can't wait to birth this little one so you can finally rest for a while.</b>\n");
 				displayedUpdate = true;
-				//temp min lust up addl +5
 			}
 			
 			return displayedUpdate;

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -236,28 +236,11 @@ package classes.Scenes
 			if (hasRegisteredAnalScene(PregnancyStore.PREGNANCY_PLAYER, analPregnancyType)) {
 				var scene:AnalPregnancy = analPregnancyScenes[analPregnancyType] as AnalPregnancy;
 				LOGGER.debug("Updating anal pregnancy for mother {0}, father {1} by using class {2}", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType, scene);
-				return scene.updateAnalPregnancy();
+				return scene.updateAnalPregnancy() || displayedUpdate;
 			} else {
 				LOGGER.debug("Could not find a mapped anal pregnancy for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType);
 			}
 			
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_FROG_GIRL) {
-				if (player.buttPregnancyIncubation === 8) {
-					//Egg Maturing
-					outputText("\nYour gut churns, and with a squelching noise, a torrent of transparent slime gushes from your ass.  You immediately fall to your knees, landing wetly amidst the slime.  The world around briefly flashes with unbelievable colors, and you hear someone giggling.\n\nAfter a moment, you realize that it’s you.");
-					//pussy:
-					if (player.hasVagina()) outputText("  Against your [vagina], the slime feels warm and cold at the same time, coaxing delightful tremors from your [clit].");
-					//[balls:
-					else if (player.balls > 0) outputText("  Slathered in hallucinogenic frog slime, your balls tingle, sending warm pulses of pleasure all the way up into your brain.");
-					//[cock:
-					else if (player.hasCock()) outputText("  Splashing against the underside of your " + player.multiCockDescriptLight() + ", the slime leaves a warm, oozy sensation that makes you just want to rub [eachCock] over and over and over again.");
-					//genderless: 
-					else outputText("  Your asshole begins twitching, aching for something to push through it over and over again.");
-					outputText("  Seated in your own slime, you moan softly, unable to keep your hands off yourself.");
-					dynStats("lus=", player.maxLust(), "scale", false);
-					displayedUpdate = true;
-				}
-			}
 			//Pregnancy 4 Satyrs
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SATYR) {
 				//Stage 1: 
@@ -498,12 +481,6 @@ package classes.Scenes
 				LOGGER.debug("Could not find a mapped anal pregnancy scene for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType);
 			}
 			
-			//Give birf if its time... to ANAL EGGS
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_FROG_GIRL) {
-				getGame().bog.frogGirlScene.birthFrogEggsAnal();
-				displayedUpdate = true;
-				detectAnalBirth(PregnancyStore.PREGNANCY_FROG_GIRL);
-			}
 			//Give birf if its time... to ANAL EGGS
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_DRIDER_EGGS) {
 				getGame().swamp.corruptedDriderScene.birthSpiderEggsFromAnusITSBLEEDINGYAYYYYY();

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -502,20 +502,17 @@ package classes.Scenes
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_FROG_GIRL) {
 				getGame().bog.frogGirlScene.birthFrogEggsAnal();
 				displayedUpdate = true;
-				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				detectAnalBirth(PregnancyStore.PREGNANCY_FROG_GIRL);
 			}
 			//Give birf if its time... to ANAL EGGS
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_DRIDER_EGGS) {
 				getGame().swamp.corruptedDriderScene.birthSpiderEggsFromAnusITSBLEEDINGYAYYYYY();
 				displayedUpdate = true;
-				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				detectAnalBirth(PregnancyStore.PREGNANCY_DRIDER_EGGS);
 			}
 			//GIVE BIRF TO TRAPS
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP_FERTILE) {
 				getGame().desert.sandTrapScene.birfSandTarps();
-				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				if (player.butt.rating < 17) {
 					//Guaranteed increase up to level 10
 					if (player.butt.rating < 13) {
@@ -547,7 +544,6 @@ package classes.Scenes
 				if (player.cor >= 35 && player.cor < 65) outputText("You are amazed you could lay so many eggs, and while the act was strange there was something definitely arousing about it.");
 				if (player.cor >= 65 && player.cor < 90) outputText("You stretch languidly, noting that most of the drugged honey is gone.  Maybe you can find the Bee again and remember to bottle it next time.");
 				if (player.cor >= 90) outputText("You lick your lips, savoring the honeyed residue on them as you admire your thousands of children.  If only every night could be like this...\n");
-				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				player.orgasm('Anal');
 				dynStats("int", 1, "lib", 4, "sen", 3);
 				if (player.buttChange(20, true)) outputText("\n");
@@ -571,11 +567,12 @@ package classes.Scenes
 
 			//Satyr butt preg
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SATYR) {
-				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				displayedUpdate = true;
 				getGame().plains.satyrScene.satyrBirth(false);
 				detectAnalBirth(PregnancyStore.PREGNANCY_SATYR);
 			}
+			
+			player.buttKnockUpForce();
 			
 			return displayedUpdate;
 		}

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -426,12 +426,14 @@ package classes.Scenes
 				getGame().bog.frogGirlScene.birthFrogEggsAnal();
 				displayedUpdate = true;
 				player.buttKnockUpForce(); //Clear Butt Pregnancy
+				detectAnalBirth(PregnancyStore.PREGNANCY_FROG_GIRL);
 			}
 			//Give birf if its time... to ANAL EGGS
 			if (player.buttPregnancyIncubation === 1 && player.buttPregnancyType === PregnancyStore.PREGNANCY_DRIDER_EGGS) {
 				getGame().swamp.corruptedDriderScene.birthSpiderEggsFromAnusITSBLEEDINGYAYYYYY();
 				displayedUpdate = true;
 				player.buttKnockUpForce(); //Clear Butt Pregnancy
+				detectAnalBirth(PregnancyStore.PREGNANCY_DRIDER_EGGS);
 			}
 			//GIVE BIRF TO TRAPS
 			if (player.buttPregnancyIncubation === 1 && player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP_FERTILE) {
@@ -450,6 +452,7 @@ package classes.Scenes
 					}
 				}
 				displayedUpdate = true;
+				detectAnalBirth(PregnancyStore.PREGNANCY_SANDTRAP_FERTILE);
 			}	
 			//Give birth (if it's time) to beeeeeeez
 			if (player.buttPregnancyIncubation === 1 && player.buttPregnancyType === PregnancyStore.PREGNANCY_BEE_EGGS) {
@@ -485,6 +488,8 @@ package classes.Scenes
 				}
 				outputText("\n");
 				displayedUpdate = true;
+				
+				detectAnalBirth(PregnancyStore.PREGNANCY_BEE_EGGS);
 			}
 
 			//Satyr butt preg
@@ -492,6 +497,7 @@ package classes.Scenes
 				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				displayedUpdate = true;
 				getGame().plains.satyrScene.satyrBirth(false);
+				detectAnalBirth(PregnancyStore.PREGNANCY_SATYR);
 			}
 			
 			return displayedUpdate;

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -241,33 +241,6 @@ package classes.Scenes
 				LOGGER.debug("Could not find a mapped anal pregnancy for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType);
 			}
 			
-			//Bunny TF buttpreggoz
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_BUNNY) {
-				if (player.buttPregnancyIncubation === 800) {
-					outputText("\nYour gut gurgles strangely.\n");
-					displayedUpdate = true;
-				}
-				if (player.buttPregnancyIncubation === 785) {
-					getGame().mutations.neonPinkEgg(true,player);
-					outputText("\n");
-					displayedUpdate = true;
-				}
-				if (player.buttPregnancyIncubation === 776) {
-					outputText("\nYour gut feels full and bloated.\n");
-					displayedUpdate = true;
-				}
-				if (player.buttPregnancyIncubation === 765) {
-					getGame().mutations.neonPinkEgg(true,player);
-					outputText("\n");
-					displayedUpdate = true;
-				}
-				if (player.buttPregnancyIncubation === 745) {
-					outputText("\n<b>After dealing with the discomfort and bodily changes for the past day or so, you finally get the feeling that the eggs in your ass have dissolved.</b>\n");
-					displayedUpdate = true;
-					player.buttKnockUpForce(); //Clear Butt Pregnancy
-				}
-			}
-			
 			return displayedUpdate;
 		}
 

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -20,6 +20,14 @@ package classes.Scenes
 		public var senseVaginalBirth:Vector.<int>;
 		
 		/**
+		 * This sensing variable is used by tests to detect if
+		 * the anal birth code has been called. This is used for pregnancies
+		 * that do not provide any other means of detection (e.g. counter variables).
+		 */
+		public var senseAnalBirth:Vector.<int>;
+		
+		
+		/**
 		 * Map pregnancy type to the class that contains the matching scenes.
 		 * Currently only stores player pregnancies.
 		 */
@@ -27,6 +35,8 @@ package classes.Scenes
 		
 		public function PregnancyProgression() {
 			this.senseVaginalBirth = new Vector.<int>();
+			this.senseAnalBirth = new Vector.<int>();
+			
 			this.vaginalPregnancyScenes = new Dictionary();
 		}
 		
@@ -37,6 +47,16 @@ package classes.Scenes
 		 */
 		public function detectVaginalBirth(pregnancyType:int):void {
 			senseVaginalBirth.push(pregnancyType);
+		}
+		
+		/**
+		 * Record a call to a anal birth function.
+		 * This method is used for testing.
+		 * @param	pregnancyType to record
+		 */
+		public function detectAnalBirth(pregnancyType:int):void
+		{
+			senseAnalBirth.push(pregnancyType);
 		}
 		
 		/**

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -241,28 +241,6 @@ package classes.Scenes
 				LOGGER.debug("Could not find a mapped anal pregnancy for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType);
 			}
 			
-			//DRIDAH BUTT Pregnancy!
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_DRIDER_EGGS) {	
-				if (player.buttPregnancyIncubation === 199) {
-					outputText("\n<b>After your session with the drider, you feel so nice and... full.  There is no outward change on your body, aside from the egg-packed bulge of your belly, but your " + player.assholeDescript() + " tingles slightly and leaks green goop from time to time. Hopefully it's nothing to be alarmed about.</b>\n");
-					displayedUpdate = true;
-				}
-				if (player.buttPregnancyIncubation === 180) {
-					outputText(images.showImage("cDrider-loss-butt"));
-					outputText("\n<b>A hot flush works its way through you, and visions of aroused driders quickly come to dominate your thoughts.  You start playing with a nipple while you lose yourself in the fantasy, imagining being tied up in webs and packed completely full of eggs, stuffing your belly completely with burgeoning spheres of love.  You shake free of the fantasy and notice your hands rubbing over your slightly bloated belly.  Perhaps it wouldn't be so bad?</b>\n");
-					dynStats("lib", 1, "sen", 1, "lus", 20);
-					displayedUpdate = true;				
-				}
-				if (player.buttPregnancyIncubation === 120) {
-					outputText("\n<b>Your belly is bulging from the size of the eggs growing inside you and gurgling just about any time you walk.  Green goo runs down your " + player.legs() + " frequently, drooling out of your pregnant asshole.</b>\n");
-					displayedUpdate = true;
-				}
-				if (player.buttPregnancyIncubation === 72) {
-					outputText("\n<b>The huge size of your pregnant belly constantly impedes your movement, but the constant squirming and shaking of your unborn offspring makes you pretty sure you won't have to carry them much longer.");
-					outputText("</b>\n");
-					displayedUpdate = true;
-				}
-			}
 			//Bee Egg's in butt pregnancy
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_BEE_EGGS) {
 				if (player.buttPregnancyIncubation === 36) {
@@ -446,12 +424,6 @@ package classes.Scenes
 				LOGGER.debug("Could not find a mapped anal pregnancy scene for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType);
 			}
 			
-			//Give birf if its time... to ANAL EGGS
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_DRIDER_EGGS) {
-				getGame().swamp.corruptedDriderScene.birthSpiderEggsFromAnusITSBLEEDINGYAYYYYY();
-				displayedUpdate = true;
-				detectAnalBirth(PregnancyStore.PREGNANCY_DRIDER_EGGS);
-			}
 			//GIVE BIRF TO TRAPS
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP_FERTILE) {
 				getGame().desert.sandTrapScene.birfSandTarps();

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -241,26 +241,6 @@ package classes.Scenes
 				LOGGER.debug("Could not find a mapped anal pregnancy for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType);
 			}
 			
-			//Sand Traps in butt pregnancy
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP || player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP_FERTILE) {
-				if (player.buttPregnancyIncubation === 36) {
-					//(Eggs take 2-3 days to lay)
-					outputText("<b>\nYour bowels make a strange gurgling noise and shift uneasily.  You feel ");
-					if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP_FERTILE) outputText(" bloated and full; the sensation isn't entirely unpleasant.");
-					else {
-						outputText("increasingly empty, as though some obstructions inside you were being broken down.");
-						player.buttKnockUpForce(); //Clear Butt Pregnancy
-					}
-					outputText("</b>\n");
-					displayedUpdate = true;
-				}
-				if (player.buttPregnancyIncubation === 20) {
-					//end eggpreg here if unfertilized
-					outputText("\nSomething oily drips from your sphincter, staining the ground.  You suppose you should feel worried about this, but the overriding emotion which simmers in your gut is one of sensual, yielding calm.  The pressure in your bowels which has been building over the last few days feels right somehow, and the fact that your back passage is dribbling lubricant makes you incredibly, perversely hot.  As you stand there and savor the wet, soothing sensation a fantasy pushes itself into your mind, one of being on your hands and knees and letting any number of beings use your ass, of being bred over and over by beautiful, irrepressible insect creatures.  With some effort you suppress these alien emotions and carry on, trying to ignore the oil which occasionally beads out of your " + player.assholeDescript() + " and stains your [armor].\n");
-					dynStats("int", -.5, "lus", 500);
-					displayedUpdate = true;
-				}
-			}
 			//Bunny TF buttpreggoz
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_BUNNY) {
 				if (player.buttPregnancyIncubation === 800) {
@@ -400,25 +380,6 @@ package classes.Scenes
 			} else {
 				LOGGER.debug("Could not find a mapped anal pregnancy scene for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType);
 			}
-			
-			//GIVE BIRF TO TRAPS
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP_FERTILE) {
-				getGame().desert.sandTrapScene.birfSandTarps();
-				if (player.butt.rating < 17) {
-					//Guaranteed increase up to level 10
-					if (player.butt.rating < 13) {
-						player.butt.rating++;
-						outputText("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.\n");
-					}
-					//Big butts only increase 50% of the time.
-					else if (rand(2) === 0){
-						player.butt.rating++;
-						outputText("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.\n");				
-					}
-				}
-				displayedUpdate = true;
-				detectAnalBirth(PregnancyStore.PREGNANCY_SANDTRAP_FERTILE);
-			}	
 			
 			player.buttKnockUpForce();
 			

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -189,7 +189,9 @@ package classes.Scenes
 				displayedUpdate = updateVaginalBirth(displayedUpdate);
 			}
 			
-			displayedUpdate = updateAnalBirth(displayedUpdate);
+			if (player.buttPregnancyIncubation === 1) {
+				displayedUpdate = updateAnalBirth(displayedUpdate);
+			}
 
 			return displayedUpdate;
 		}
@@ -497,21 +499,21 @@ package classes.Scenes
 			}
 			
 			//Give birf if its time... to ANAL EGGS
-			if (player.buttPregnancyIncubation === 1 && player.buttPregnancyType === PregnancyStore.PREGNANCY_FROG_GIRL) {
+			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_FROG_GIRL) {
 				getGame().bog.frogGirlScene.birthFrogEggsAnal();
 				displayedUpdate = true;
 				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				detectAnalBirth(PregnancyStore.PREGNANCY_FROG_GIRL);
 			}
 			//Give birf if its time... to ANAL EGGS
-			if (player.buttPregnancyIncubation === 1 && player.buttPregnancyType === PregnancyStore.PREGNANCY_DRIDER_EGGS) {
+			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_DRIDER_EGGS) {
 				getGame().swamp.corruptedDriderScene.birthSpiderEggsFromAnusITSBLEEDINGYAYYYYY();
 				displayedUpdate = true;
 				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				detectAnalBirth(PregnancyStore.PREGNANCY_DRIDER_EGGS);
 			}
 			//GIVE BIRF TO TRAPS
-			if (player.buttPregnancyIncubation === 1 && player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP_FERTILE) {
+			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP_FERTILE) {
 				getGame().desert.sandTrapScene.birfSandTarps();
 				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				if (player.butt.rating < 17) {
@@ -530,7 +532,7 @@ package classes.Scenes
 				detectAnalBirth(PregnancyStore.PREGNANCY_SANDTRAP_FERTILE);
 			}	
 			//Give birth (if it's time) to beeeeeeez
-			if (player.buttPregnancyIncubation === 1 && player.buttPregnancyType === PregnancyStore.PREGNANCY_BEE_EGGS) {
+			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_BEE_EGGS) {
 				outputText("\n");
 				outputText(images.showImage("birth-beegirl"));
 				outputText("There is a sudden gush of honey-colored fluids from your ass.  Before panic can set in, a wonderful scent overtakes you, making everything ok.  ");
@@ -568,7 +570,7 @@ package classes.Scenes
 			}
 
 			//Satyr butt preg
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SATYR && player.buttPregnancyIncubation === 1) {
+			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SATYR) {
 				player.buttKnockUpForce(); //Clear Butt Pregnancy
 				displayedUpdate = true;
 				getGame().plains.satyrScene.satyrBirth(false);

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -241,41 +241,6 @@ package classes.Scenes
 				LOGGER.debug("Could not find a mapped anal pregnancy for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType);
 			}
 			
-			//Pregnancy 4 Satyrs
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SATYR) {
-				//Stage 1: 
-				if (player.buttPregnancyIncubation === 150) {
-					outputText("\n<b>You find that you're feeling quite sluggish these days; you just don't have as much energy as you used to.  You're also putting on weight.</b>\n");
-					displayedUpdate = true;
-				}
-				//Stage 2: 
-				if (player.buttPregnancyIncubation === 125) {
-					outputText("\n<b>Your belly is getting bigger and bigger.  Maybe your recent urges are to blame for this development?</b>\n");
-					displayedUpdate = true;
-				}
-				//Stage 3: 
-				if (player.buttPregnancyIncubation === 100) {
-					outputText("\n<b>You can feel the strangest fluttering sensations in your distended belly; it must be a pregnancy.  You should eat more and drink plenty of wine so your baby can grow properly.  Wait, wine...?</b>\n");
-					displayedUpdate = true;
-				}
-				//Stage 4: 
-				if (player.buttPregnancyIncubation === 75) {
-					outputText("\n<b>Sometimes you feel a bump in your pregnant belly.  You wonder if it's your baby complaining about your moving about.</b>\n");
-					displayedUpdate = true;
-				}
-				//Stage 5: 
-				if (player.buttPregnancyIncubation === 50) {
-					outputText("\n<b>With your bloating gut, you are loathe to exert yourself in any meaningful manner; you feel horny and hungry all the time...</b>\n");
-					displayedUpdate = true;
-					//temp min lust up +5
-				}
-				//Stage 6: 
-				if (player.buttPregnancyIncubation === 30) {
-					outputText("\n<b>The baby you're carrying constantly kicks your belly in demand for food and wine, and you feel sluggish and horny.  You can't wait to birth this little one so you can finally rest for a while.</b>\n");
-					displayedUpdate = true;
-					//temp min lust up addl +5
-				}
-			}
 			//DRIDAH BUTT Pregnancy!
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_DRIDER_EGGS) {	
 				if (player.buttPregnancyIncubation === 199) {
@@ -540,13 +505,6 @@ package classes.Scenes
 				displayedUpdate = true;
 				
 				detectAnalBirth(PregnancyStore.PREGNANCY_BEE_EGGS);
-			}
-
-			//Satyr butt preg
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SATYR) {
-				displayedUpdate = true;
-				getGame().plains.satyrScene.satyrBirth(false);
-				detectAnalBirth(PregnancyStore.PREGNANCY_SATYR);
 			}
 			
 			player.buttKnockUpForce();

--- a/classes/classes/Scenes/PregnancyProgression.as
+++ b/classes/classes/Scenes/PregnancyProgression.as
@@ -241,29 +241,6 @@ package classes.Scenes
 				LOGGER.debug("Could not find a mapped anal pregnancy for mother {0}, father {1} - using legacy pregnancy progression", PregnancyStore.PREGNANCY_PLAYER, analPregnancyType);
 			}
 			
-			//Bee Egg's in butt pregnancy
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_BEE_EGGS) {
-				if (player.buttPregnancyIncubation === 36) {
-					outputText("<b>\nYou feel bloated, your bowels shifting uncomfortably from time to time.</b>\n");
-					displayedUpdate = true;
-				}
-				if (player.buttPregnancyIncubation === 20) {
-					outputText("<b>\nA honey-scented fluid drips from your rectum.</b>  At first it worries you, but as the smell fills the air around you, you realize anything with such a beautiful scent must be good.  ");
-					if (player.cockTotal() > 0) outputText("The aroma seems to permeate your very being, slowly congregating in your ");
-					if (player.cockTotal() === 1) {
-						outputText(player.cockDescript(0));
-						if (player.countCocksOfType(CockTypesEnum.HORSE) === 1) outputText(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air, until your " + player.cockDescript(0) + " is twitching and dripping, the flare swollen and purple.  ");
-						if (player.dogCocks() === 1) outputText(", each inhalation making it thicker, harder, and firmer.  You suck in huge lungfuls of air, desperate for more, until your " + player.cockDescript(0) + " is twitching and dripping, its knot swollen to the max.  ");
-						if (player.countCocksOfType(CockTypesEnum.HUMAN) === 1) outputText(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air, until your " + player.cockDescript(0) + " is twitching and dripping, the head swollen and purple.  ");
-						//FAILSAFE FOR NEW COCKS
-						if (player.countCocksOfType(CockTypesEnum.HUMAN) === 0 && player.dogCocks() === 0 && player.countCocksOfType(CockTypesEnum.HORSE) === 0) outputText(", each inhalation making it bigger, harder, and firmer.  You suck in huge lungfuls of air until your " + player.cockDescript(0) + " is twitching and dripping.  ");
-					}
-					if (player.cockTotal() > 1) outputText("groin.  Your " + player.multiCockDescriptLight() + " fill and grow with every lungful of the stuff you breathe in.  You suck in great lungfuls of the tainted air, desperate for more, your cocks twitching and dripping with need.  ");
-					outputText("You smile knowing you couldn't stop from masturbating if you wanted to.\n");
-					dynStats("int", -.5, "lus", 500);
-					displayedUpdate = true;
-				}
-			}
 			//Sand Traps in butt pregnancy
 			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP || player.buttPregnancyType === PregnancyStore.PREGNANCY_SANDTRAP_FERTILE) {
 				if (player.buttPregnancyIncubation === 36) {
@@ -442,42 +419,6 @@ package classes.Scenes
 				displayedUpdate = true;
 				detectAnalBirth(PregnancyStore.PREGNANCY_SANDTRAP_FERTILE);
 			}	
-			//Give birth (if it's time) to beeeeeeez
-			if (player.buttPregnancyType === PregnancyStore.PREGNANCY_BEE_EGGS) {
-				outputText("\n");
-				outputText(images.showImage("birth-beegirl"));
-				outputText("There is a sudden gush of honey-colored fluids from your ass.  Before panic can set in, a wonderful scent overtakes you, making everything ok.  ");
-				if (player.cockTotal() > 0) outputText("The muzzy feeling that fills your head seems to seep downwards, making your equipment hard and tight.  ");
-				if (player.vaginas.length > 0) outputText("Your " + player.vaginaDescript(0) + " becomes engorged and sensitive.  ");
-				outputText("Your hand darts down to the amber, scooping up a handful of the sticky stuff.  You wonder what your hand is doing as it brings it up to your mouth, which instinctively opens.  You shudder in revulsion as you swallow the sweet-tasting stuff, your mind briefly wondering why it would do that.  The stuff seems to radiate warmth, quickly pushing those nagging thoughts away as you scoop up more.\n\n");
-				outputText("A sudden slip from below surprises you; a white sphere escapes from your anus along with another squirt of honey.  Your drugged brain tries to understand what's happening, but it gives up, your hands idly slathering honey over your loins.  The next orb pops out moments later, forcing a startled moan from your mouth.  That felt GOOD.  You begin masturbating to the thought of laying more eggs... yes, that's what those are.  You nearly cum as egg number three squeezes out.  ");
-				if (player.averageLactation() >= 1 && player.biggestTitSize() > 2) outputText("Seeking even greater sensation, your hands gather the honey and massage it into your " + player.breastDescript(0) + ", slowly working up to your nipples.  Milk immediately begins pouring out from the attention, flooding your chest with warmth.  ");
-				outputText("Each egg seems to come out closer on the heels of the one before, and each time your conscious mind loses more of its ability to do anything but masturbate and wallow in honey.\n\n");
-				outputText("Some time later, your mind begins to return, brought to wakefulness by an incredibly loud buzzing...  You sit up and see a pile of dozens of eggs resting in a puddle of sticky honey.  Most are empty, but a few have hundreds of honey-bees emptying from them, joining the massive swarms above you.  ");
-				if (player.cor < 35) outputText("You are disgusted, but glad you were not stung during the ordeal.  You stagger away and find a brook to wash out your mouth with.");
-				if (player.cor >= 35 && player.cor < 65) outputText("You are amazed you could lay so many eggs, and while the act was strange there was something definitely arousing about it.");
-				if (player.cor >= 65 && player.cor < 90) outputText("You stretch languidly, noting that most of the drugged honey is gone.  Maybe you can find the Bee again and remember to bottle it next time.");
-				if (player.cor >= 90) outputText("You lick your lips, savoring the honeyed residue on them as you admire your thousands of children.  If only every night could be like this...\n");
-				player.orgasm('Anal');
-				dynStats("int", 1, "lib", 4, "sen", 3);
-				if (player.buttChange(20, true)) outputText("\n");
-				if (player.butt.rating < 17) {
-					//Guaranteed increase up to level 10
-					if (player.butt.rating < 13) {
-						player.butt.rating++;
-						outputText("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.");
-					}
-					//Big butts only increase 50% of the time.
-					else if (rand(2) === 0){
-						player.butt.rating++;
-						outputText("\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.");				
-					}
-				}
-				outputText("\n");
-				displayedUpdate = true;
-				
-				detectAnalBirth(PregnancyStore.PREGNANCY_BEE_EGGS);
-			}
 			
 			player.buttKnockUpForce();
 			

--- a/test/classes/Scenes/Areas/DeepWoodsTest.as
+++ b/test/classes/Scenes/Areas/DeepWoodsTest.as
@@ -1,0 +1,46 @@
+package classes.Scenes.Areas 
+{
+	import classes.Scenes.PregnancyProgression;
+	import classes.helper.DummyOutput;
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import classes.CoC;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.helper.StageLocator;
+	
+	public class DeepWoodsTest 
+	{
+		private var cut:DeepWoods;
+		private var forest:Forest;
+		
+		[Before]
+		public function setUp():void
+		{
+			this.forest = new Forest(new PregnancyProgression(), new DummyOutput());
+		}
+		
+		[Test(expected='ArgumentError')]
+		public function throwExceptionOnNullForest():void
+		{
+			new DeepWoods(null);
+		}
+		
+		[Test(expected='ArgumentError')]
+		public function throwExceptionOnUndefinedForest():void
+		{
+			new DeepWoods(undefined);
+		}
+		
+		[Test]
+		public function createDeepwoodsWithValidForest():void
+		{
+			new DeepWoods(forest);
+		}
+	}
+}

--- a/test/classes/Scenes/AreasSuit.as
+++ b/test/classes/Scenes/AreasSuit.as
@@ -1,6 +1,7 @@
 package classes.Scenes 
 {
 	import classes.Scenes.Areas.BogSuit;
+	import classes.Scenes.Areas.DeepWoodsTest;
 	import classes.Scenes.Areas.ForestSuit;
 	import classes.Scenes.Areas.MountainSuit;
 	
@@ -11,5 +12,7 @@ package classes.Scenes
 		public var mountainSuit:MountainSuit;
 		public var forestSuit:ForestSuit;
 		public var bogSuit:BogSuit;
+		
+		public var deepWoodsTest:DeepWoodsTest;
 	}
 }

--- a/test/classes/Scenes/PregnancyProgressionAnalBirthTest.as
+++ b/test/classes/Scenes/PregnancyProgressionAnalBirthTest.as
@@ -1,0 +1,126 @@
+package classes.Scenes
+{
+	import classes.Scenes.Monsters.ImpScene;
+	import classes.Scenes.NPCs.EmberScene;
+	import classes.Scenes.NPCs.UrtaPregs;
+	import classes.Scenes.Places.TelAdre;
+	import classes.helper.DummyOutput;
+	import classes.internals.GuiOutput;
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import classes.helper.StageLocator;
+	
+	import classes.DefaultDict;
+	import classes.CoC;
+	import classes.Player;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.GlobalFlags.kFLAGS;
+	import classes.PregnancyStore;
+	import classes.StatusEffects;
+	import classes.VaginaClass;
+	import classes.StatusEffects;
+	import classes.Scenes.Areas.Bog;
+	
+	import org.flexunit.runners.Parameterized;
+	
+	[RunWith("org.flexunit.runners.Parameterized")]
+	public class PregnancyProgressionAnalBirthTest 
+	{
+		private static var cut:PregProgForTest; // static so I can be lazy and don't need to pass it as a parameter
+		private var player:Player;
+		private var output:GuiOutput;
+		
+		private var pregnancyType:int;
+
+		[BeforeClass]
+		public static function setUpClass():void
+		{
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+		
+		[Parameters]
+		public static var testData:Array =
+		[
+			[PregnancyStore.PREGNANCY_FROG_GIRL],
+			[PregnancyStore.PREGNANCY_SATYR],
+			[PregnancyStore.PREGNANCY_DRIDER_EGGS],
+			[PregnancyStore.PREGNANCY_BEE_EGGS],
+			[PregnancyStore.PREGNANCY_SANDTRAP_FERTILE],
+		];
+
+		public function PregnancyProgressionAnalBirthTest(pregnancyType:int):void
+		{
+			this.pregnancyType = pregnancyType;
+		}
+		
+		[Before]
+		public function setUp():void
+		{
+			player = new Player();
+			kGAMECLASS.player = player;
+			
+			kGAMECLASS.flags = new DefaultDict();
+			
+			output = new DummyOutput();
+			
+			cut = new PregProgForTest();
+			kGAMECLASS.createScenes(cut);
+			
+			player.buttKnockUpForce(pregnancyType, 1);
+		}
+		
+		[Test]
+		public function giveBirth():void
+		{
+			cut.updatePregnancy();
+			
+			assertThat(cut.senseAnalBirth, hasItem(pregnancyType));
+		}
+		
+		[Test]
+		public function displayText():void
+		{
+			assertThat(cut.updatePregnancy(), equalTo(true));
+		}
+		
+		[Test]
+		public function pregnancyCleared():void
+		{
+			cut.updatePregnancy();
+			
+			assertThat(player.isButtPregnant(), equalTo(false));
+		}
+		
+		[Test]
+		public function chainDisplayUpdate():void
+		{
+			player.goIntoHeat(false);
+			player.buttKnockUpForce(pregnancyType, 1);
+			
+			assertThat(cut.updatePregnancy(), equalTo(true));
+		}
+	}
+}
+
+import classes.Scenes.PregnancyProgression;
+
+class PregProgForTest extends PregnancyProgression
+{
+	public var collectedOutput:Vector.<String> = new Vector.<String>(); 
+	
+	override protected function outputText(output:String):void
+	{
+		collectedOutput.push(output);
+	}
+	
+	public function pregUpdate():Boolean
+	{
+		return updatePregnancy();
+	}
+}

--- a/test/classes/Scenes/PregnancyProgressionTest.as
+++ b/test/classes/Scenes/PregnancyProgressionTest.as
@@ -61,6 +61,7 @@ package classes.Scenes
 			kGAMECLASS.impScene = new ImpScene(scenePregProg, output);
 			kGAMECLASS.amilyScene = new AmilyScene(scenePregProg, output);
 			kGAMECLASS.swamp = new Swamp(scenePregProg, output);
+			kGAMECLASS.bog = new Bog(scenePregProg, output);
 			
 			new PlayerMousePregnancy(scenePregProg, output);
 			new PlayerBenoitPregnancy(scenePregProg, output);
@@ -90,16 +91,16 @@ package classes.Scenes
 		public function updateFrogAnalPregnancyOutput():void {
 			player.buttKnockUpForce(PregnancyStore.PREGNANCY_FROG_GIRL, 8);
 			
-			cut.updatePregnancy();
+			scenePregProg.updatePregnancy();
 			
-			assertThat(cut.collectedOutput, hasItem(containsString(FROG_ANAL_8_MESSAGE)));
+			assertThat(output.collectedOutput, hasItem(containsString(FROG_ANAL_8_MESSAGE)));
 		}
 		
 		[Test]
 		public function updateFrogAnalPregnancyDisplayChange():void {
 			player.buttKnockUpForce(PregnancyStore.PREGNANCY_FROG_GIRL, 8);
 			
-			assertThat(cut.updatePregnancy(), equalTo(true));
+			assertThat(scenePregProg.updatePregnancy(), equalTo(true));
 		}
 		
 		[Test]

--- a/test/classes/Scenes/PregnancyProgressionTest.as
+++ b/test/classes/Scenes/PregnancyProgressionTest.as
@@ -258,6 +258,44 @@ package classes.Scenes
 			assertThat(output.collectedOutput, hasItem(containsString("driders")));
 			assertThat(output.collectedOutput, not(hasItem(containsString("spider-morph"))));
 		}
+		
+		[Test]
+		public function sandTrapAnalNormalNoBirth():void
+		{
+			player.buttKnockUpForce(PregnancyStore.PREGNANCY_SANDTRAP, 1);
+			
+			scenePregProg.updatePregnancy();
+			
+			assertThat(scenePregProg.senseAnalBirth, not(hasItem(PregnancyStore.PREGNANCY_SANDTRAP)));
+		}
+		
+		[Test]
+		public function sandTrapAnalNormalClearsPregnancy():void
+		{
+			player.buttKnockUpForce(PregnancyStore.PREGNANCY_SANDTRAP, 36);
+			
+			scenePregProg.updatePregnancy();
+			
+			assertThat(player.isButtPregnant(), false);
+		}
+		
+		[Test]
+		public function bunnyAnalClearedWithoutBirth():void
+		{
+			player.buttKnockUpForce(PregnancyStore.PREGNANCY_BUNNY, 745);
+			
+			scenePregProg.updatePregnancy();
+			
+			assertThat(player.isButtPregnant(), false);
+		}
+		
+		[Test]
+		public function bunnyAnalUpdateText():void
+		{
+			player.buttKnockUpForce(PregnancyStore.PREGNANCY_BUNNY, 745);
+			
+			assertThat(scenePregProg.updatePregnancy(), true);
+		}
 	}
 }
 

--- a/test/classes/Scenes/PregnancyProgressionTest.as
+++ b/test/classes/Scenes/PregnancyProgressionTest.as
@@ -240,6 +240,80 @@ package classes.Scenes
 		}
 		
 		[Test]
+		public function registerPlayerAsMotherAnalPregnancy():void
+		{
+			var replacedPrevious:Boolean = cut.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_IMP, scene);
+			
+			assertThat(replacedPrevious, equalTo(false));
+		}
+		
+		[Test]
+		public function registerPlayerAsMotherAnalPregnancyReplaceExisting():void
+		{
+			cut.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_IMP, scene);
+			var replacedPrevious:Boolean = cut.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_IMP, scene);
+			
+			assertThat(replacedPrevious, equalTo(true));
+		}
+		
+		[Test]
+		public function registerMultipleAnalScenes():void
+		{
+			var minoScene:DummyScene = new DummyScene();
+			
+			cut.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_IMP, scene);
+			cut.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_MINOTAUR, minoScene);
+			
+			player.buttKnockUpForce(PregnancyStore.PREGNANCY_IMP, 1);
+			cut.updatePregnancy();
+			
+			assertThat(scene.birthAnal, equalTo(true));
+			assertThat(minoScene.birthAnal, equalTo(false));
+		}
+		
+		[Test(expected="ArgumentError")]
+		public function registerAnalNonPlayerNotSupported():void
+		{
+			cut.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_MARBLE, PregnancyStore.PREGNANCY_PLAYER, scene);
+		}
+		
+		[Test]
+		public function callsAnalPregnancyUpdate():void
+		{
+			cut.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_IMP, scene);
+			
+			player.buttKnockUpForce(PregnancyStore.PREGNANCY_IMP, 337);
+			cut.updatePregnancy();
+			
+			assertThat(scene.updatedAnal, equalTo(true));
+		}
+		
+		[Test]
+		public function callsAnalPregnancyBirth():void
+		{
+			cut.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_IMP, scene);
+			
+			player.buttKnockUpForce(PregnancyStore.PREGNANCY_IMP, 1);
+			cut.updatePregnancy();
+			
+			assertThat(scene.birthAnal, equalTo(true));
+		}
+		
+		[Test]
+		public function hasNoRegistreredAnalScene():void
+		{
+			assertThat(cut.hasRegisteredAnalScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_IMP), equalTo(false));
+		}
+		
+		[Test]
+		public function hasRegistreredAnalScene():void
+		{
+			cut.registerAnalPregnancyScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_IMP, scene);
+			
+			assertThat(cut.hasRegisteredAnalScene(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.PREGNANCY_IMP), equalTo(true));
+		}
+		
+		[Test]
 		public function spiderPregnancyText():void {
 			player.knockUpForce(PregnancyStore.PREGNANCY_SPIDER, 180);
 			
@@ -314,10 +388,13 @@ class PregProgForTest extends PregnancyProgression {
 }
 
 import classes.Scenes.VaginalPregnancy;
+import classes.Scenes.AnalPregnancy;
 
-class DummyScene implements VaginalPregnancy {
+class DummyScene implements VaginalPregnancy, AnalPregnancy {
 	public var updated:Boolean = false;
+	public var updatedAnal:Boolean = false;
 	public var birth:Boolean = false;
+	public var birthAnal:Boolean = false;
 	
 	public function updateVaginalPregnancy():Boolean 
 	{
@@ -328,5 +405,16 @@ class DummyScene implements VaginalPregnancy {
 	public function vaginalBirth():void 
 	{
 		this.birth = true;
+	}
+	
+	public function updateAnalPregnancy():Boolean 
+	{
+		this.updatedAnal = true;
+		return true;
+	}
+	
+	public function analBirth():void 
+	{
+		this.birthAnal = true;
 	}
 }

--- a/test/classes/Scenes/PregnancyProgressionTest.as
+++ b/test/classes/Scenes/PregnancyProgressionTest.as
@@ -3,6 +3,7 @@ package classes.Scenes
 
 	import classes.DefaultDict;
 	import classes.Scenes.Areas.Bog;
+	import classes.Scenes.Areas.Desert;
 	import classes.Scenes.Areas.Swamp;
 	import classes.Scenes.Monsters.ImpScene;
 	import classes.Scenes.NPCs.AmilyScene;
@@ -62,6 +63,7 @@ package classes.Scenes
 			kGAMECLASS.amilyScene = new AmilyScene(scenePregProg, output);
 			kGAMECLASS.swamp = new Swamp(scenePregProg, output);
 			kGAMECLASS.bog = new Bog(scenePregProg, output);
+			kGAMECLASS.desert = new Desert(scenePregProg, output);
 			
 			new PlayerMousePregnancy(scenePregProg, output);
 			new PlayerBenoitPregnancy(scenePregProg, output);

--- a/test/classes/Scenes/PregnancyProgressionTest.as
+++ b/test/classes/Scenes/PregnancyProgressionTest.as
@@ -370,6 +370,14 @@ package classes.Scenes
 			
 			assertThat(scenePregProg.updatePregnancy(), true);
 		}
+		
+		[Test]
+		public function noTextDisplayUnsupportedAnalPregnancy():void
+		{
+			player.buttKnockUpForce(PregnancyStore.INCUBATION_IMP, 1);
+			
+			assertThat(cut.updatePregnancy(), equalTo(false));
+		}
 	}
 }
 

--- a/test/classes/Scenes/PregnancyProgressionTest.as
+++ b/test/classes/Scenes/PregnancyProgressionTest.as
@@ -2,10 +2,12 @@ package classes.Scenes
 {
 
 	import classes.DefaultDict;
+	import classes.Items.Mutations;
 	import classes.Scenes.Areas.Bog;
 	import classes.Scenes.Areas.Desert;
 	import classes.Scenes.Areas.Swamp;
 	import classes.Scenes.Monsters.ImpScene;
+	import classes.Scenes.Monsters.pregnancies.PlayerBunnyPregnancy;
 	import classes.Scenes.NPCs.AmilyScene;
 	import classes.Scenes.NPCs.pregnancies.PlayerBenoitPregnancy;
 	import classes.Scenes.NPCs.pregnancies.PlayerMousePregnancy;
@@ -67,6 +69,7 @@ package classes.Scenes
 			
 			new PlayerMousePregnancy(scenePregProg, output);
 			new PlayerBenoitPregnancy(scenePregProg, output);
+			new PlayerBunnyPregnancy(scenePregProg, output, Mutations.init());
 			
 			scene = new DummyScene();
 		}

--- a/test/classes/ScenesSuit.as
+++ b/test/classes/ScenesSuit.as
@@ -2,6 +2,7 @@ package classes {
 	import classes.Scenes.NPCsSuit;
 	import classes.Scenes.PlacesSuit;
 	import classes.Scenes.AreasSuit;
+	import classes.Scenes.PregnancyProgressionAnalBirthTest;
 	import classes.Scenes.PregnancyProgressionTest;
 	import classes.Scenes.PregnancyProgressionVagBirthTest;
 
@@ -14,5 +15,6 @@ package classes {
 		 public var areasSuit:AreasSuit;
 		 public var pregnancyProgressionTest:PregnancyProgressionTest
 		 public var pregnancyProgressionVagBirthTest:PregnancyProgressionVagBirthTest
+		 public var pregnancyProgressionAnalBirthTest:PregnancyProgressionAnalBirthTest;
 	}
 }


### PR DESCRIPTION
This PR is ongoing work in response to #322. 

- Characterisation tests for anal birth
- Interface for anal pregnancy
- Use map / associative array / dictionary for scene lookup
- Extract pregnancy content into own files where applicable
- Code cleanup (spacing, curly brackets) for extracted code

TODO:
 - Extend `PregnancyProgression` where player is not the mother, using nested maps
   - e.g. Cotton impregnated by player, SandWitch impregnated by player, etc.
   - Allow for any pregnancy combination (NPC/NPC, NPC/Monster, Player/Player [Sheila scene, see #261], etc.)
 - How to deal with non-standard pregnancies (Benoit), Pre / Post hooks?
 - If possible extract default progression code ("Your belly has gotten larger", etc.)