### PR TITLE
Static calls and no more singleton for the Measurements-class

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -43,11 +43,6 @@
 			return kGAMECLASS.credits;
 		}
 
-		protected function get measurements():Measurements
-		{
-			return kGAMECLASS.measurements;
-		}
-
 		protected function get timeQ():Number
 		{
 			return kGAMECLASS.timeQ;

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -304,7 +304,6 @@ package classes
 		public var bindings:Bindings = new Bindings();
 		public var output:Output = Output.init();
 		public var credits:Credits = Credits.init();
-		public var measurements:Measurements = Measurements.init();
 		/****
 		   This is used purely for bodges while we get things cleaned up.
 		   Hopefully, anything you stick to this object can be removed eventually.

--- a/classes/classes/Measurements.as
+++ b/classes/classes/Measurements.as
@@ -1,69 +1,59 @@
 package classes 
 {
 	import classes.GlobalFlags.kFLAGS;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.internals.Utils;
 	/**
 	 * Class to make the measurement methods taken from PlayerAppearance globally accessible
 	 * @since  19.08.2016
 	 * @author Stadler76
 	 */
-	public class Measurements extends BaseContent
+	public class Measurements
 	{
-		private static var _instance:Measurements = new Measurements();
-
-		public function Measurements()
+		public static function footInchOrMetres(inches:Number, precision:int = 2):String
 		{
-			if (_instance !== null)
-			{
-				throw new Error("Measurements can only be accessed through Measurements.init()");
-			}
-		}
-
-		public static function init():Measurements { return _instance; }
-
-		public function footInchOrMetres(inches:Number, precision:int = 2):String
-		{
-			if (flags[kFLAGS.USE_METRICS])
+			if (kGAMECLASS.flags[kFLAGS.USE_METRICS])
 				return (Math.round(inches * 2.54) / Math.pow(10, precision)).toFixed(precision) + " metres";
 
 			return Math.floor(inches / 12) + " foot " + inches % 12 + " inch";
 		}
 
-		public function numInchesOrCentimetres(inches:Number):String
+		public static function numInchesOrCentimetres(inches:Number):String
 		{
 			if (inches < 1) return inchesOrCentimetres(inches);
 
 			var value:int = Math.round(inches);
 
-			if (flags[kFLAGS.USE_METRICS]) {
+			if (kGAMECLASS.flags[kFLAGS.USE_METRICS]) {
 				value = Math.round(inches * 2.54);
-				return num2Text(value) + (value === 1 ? " centimetre" : " centimetres");
+				return Utils.num2Text(value) + (value === 1 ? " centimetre" : " centimetres");
 			}
 
 			if (inches % 12 === 0)
-				return (inches === 12 ? "a foot" : num2Text(inches / 12) + " feet");
+				return (inches === 12 ? "a foot" : Utils.num2Text(inches / 12) + " feet");
 
-			return num2Text(value) + (value === 1 ? " inch" : " inches");
+			return Utils.num2Text(value) + (value === 1 ? " inch" : " inches");
 		}
 
-		public function inchesOrCentimetres(inches:Number, precision:int = 1):String
+		public static function inchesOrCentimetres(inches:Number, precision:int = 1):String
 		{
 			var value:Number = Math.round(inchToCm(inches) * Math.pow(10, precision)) / Math.pow(10, precision);
-			var text:String = value + (flags[kFLAGS.USE_METRICS] ? " centimetre" : " inch");
+			var text:String = value + (kGAMECLASS.flags[kFLAGS.USE_METRICS] ? " centimetre" : " inch");
 
 			if (value === 1) return text;
 
-			return text + (flags[kFLAGS.USE_METRICS] ? "s" : "es");
+			return text + (kGAMECLASS.flags[kFLAGS.USE_METRICS] ? "s" : "es");
 		}
 
-		public function shortSuffix(inches:Number, precision:int = 1):String
+		public static function shortSuffix(inches:Number, precision:int = 1):String
 		{
 			var value:Number = Math.round(inchToCm(inches) * Math.pow(10, precision)) / Math.pow(10, precision);
-			return value + (flags[kFLAGS.USE_METRICS] ? "-cm" : "-inch");
+			return value + (kGAMECLASS.flags[kFLAGS.USE_METRICS] ? "-cm" : "-inch");
 		}
 
-		public function inchToCm(inches:Number):Number
+		public static function inchToCm(inches:Number):Number
 		{
-			return flags[kFLAGS.USE_METRICS] ? inches * 2.54 : inches;
+			return kGAMECLASS.flags[kFLAGS.USE_METRICS] ? inches * 2.54 : inches;
 		}
 	}
 }

--- a/classes/classes/Parser/singleArgLookups.as
+++ b/classes/classes/Parser/singleArgLookups.as
@@ -8,6 +8,7 @@
 		//Calls are now made through kGAMECLASS rather than thisPtr. This allows the compiler to detect if/when a function is inaccessible.
 		import classes.GlobalFlags.kFLAGS;
 		import classes.GlobalFlags.kGAMECLASS;
+		import classes.Measurements;
 		import classes.internals.Utils;
 		
 		public var singleArgConverters:Object =
@@ -100,7 +101,7 @@
 				"skindesc"					: function():* { return kGAMECLASS.player.skin.desc; },
 				"skinfurscales"				: function():* { return kGAMECLASS.player.skinFurScales(); },
 				"skintone"					: function():* { return kGAMECLASS.player.skin.tone; },
-				"tallness"					: function():* { return kGAMECLASS.measurements.footInchOrMetres(kGAMECLASS.player.tallness); },
+				"tallness"					: function():* { return Measurements.footInchOrMetres(kGAMECLASS.player.tallness); },
 				"tits"						: function():* { return kGAMECLASS.player.breastDescript(0); },
 				"lasttits"					: function():* { return kGAMECLASS.player.breastDescript(-1); },
 				"breastcup"					: function():* { return kGAMECLASS.player.breastCup(0); },

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -8,10 +8,10 @@ package classes
 	{
 		public function PlayerAppearance() {}
 
-		protected function footInchOrMetres(...args):String { return measurements.footInchOrMetres.apply(null, args); }
-		protected function numInchesOrCentimetres(inches:Number):String { return measurements.numInchesOrCentimetres(inches); }
-		protected function inchesOrCentimetres(...args):String { return measurements.inchesOrCentimetres.apply(null, args); }
-		protected function shortSuffix(...args):String { return measurements.shortSuffix.apply(null, args); }
+		protected function footInchOrMetres(...args):String { return Measurements.footInchOrMetres.apply(null, args); }
+		protected function numInchesOrCentimetres(inches:Number):String { return Measurements.numInchesOrCentimetres(inches); }
+		protected function inchesOrCentimetres(...args):String { return Measurements.inchesOrCentimetres.apply(null, args); }
+		protected function shortSuffix(...args):String { return Measurements.shortSuffix.apply(null, args); }
 
 		public function appearance():void {
 			if (CoC_Settings.charviewEnabled) mainViewManager.showPlayerDoll(debug);


### PR DESCRIPTION
- `extends BaseContent` was pointless and abusive ⇒ removed it
- Made all remaining methods aka functions static, so ...
- ... the singleton is/was pointless, too ⇒ removed it along with the constructor