### PR TITLE
Implemented legacy racial stats toggle

### DIFF
--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -2979,7 +2979,7 @@ public static const UNKNOWN_FLAG_NUMBER_02970:int                               
 public static const UNKNOWN_FLAG_NUMBER_02971:int                                   = 2971;
 public static const UNKNOWN_FLAG_NUMBER_02972:int                                   = 2972;
 public static const UNKNOWN_FLAG_NUMBER_02973:int                                   = 2973;
-public static const UNKNOWN_FLAG_NUMBER_02974:int                                   = 2974;
+public static const LEGACY_RACIAL_STATS_ENABLED:int                                 = 2974;
 public static const ENEMY_STATS_BARS_ENABLED:int                                    = 2975; // 0 if enemy sidebar is disabled.
 public static const ANIMATE_STATS_BARS:int                                          = 2976;
 public static const DELETE_ITEMS:int                                                = 2977; // Inventory deletion toggle, 0=no, 1=one at a time, 2=stacks

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -2818,11 +2818,6 @@
 			var maxTou:Number = 100;
 			var maxSpe:Number = 100;
 			var maxInt:Number = 100;
-			//Apply New Game+
-			maxStr += ascensionFactor();
-			maxTou += ascensionFactor();
-			maxSpe += ascensionFactor();
-			maxInt += ascensionFactor();
 			/* [INTERMOD: xianxia]
 			var maxWis:int = 100;
 			var maxLib:int = 100;
@@ -2873,6 +2868,148 @@
 					maxSpe = UmasShop.NEEDLEWORK_DEFENSE_SPEED_CAP;
 				}
 			}
+			if (flags[kFLAGS.LEGACY_RACIAL_STATS_ENABLED] === 1) {
+				//Alter max stats depending on race
+				if (impScore() >= 4) {
+					maxSpe += 10;
+					maxInt -= 5;
+				}
+				if (sheepScore() >= 4) {
+					maxSpe += 10;
+					maxInt -= 10;
+					maxTou += 10;
+				}
+				if (wolfScore() >= 4) {
+					maxSpe -= 10;
+					maxInt += 5;
+					maxTou += 10;
+					maxStr += 5;
+				}
+				if (minoScore() >= 4) {
+					maxStr += 20;
+					maxTou += 10;
+					maxInt -= 10;
+				}
+				if (lizardScore() >= 4) {
+					maxInt += 10;
+					if (isBasilisk()) {
+						// Needs more balancing, especially other races, since dracolisks are quite OP right now!
+						maxTou += 5;
+						maxInt += 5;
+					}
+				}
+				if (cockatriceScore() >= 8) {
+					maxStr += 5;
+					maxSpe += 25;
+					maxInt += 15;
+				} else if (cockatriceScore() >= 6) {
+					maxSpe += 20;
+					maxInt += 5;
+				} else if (cockatriceScore() >= 4) {
+					maxStr -= 5;
+					maxSpe += 10;
+					maxInt += 5;
+				}
+				if (dragonScore() >= 4) {
+					maxStr += 5;
+					maxTou += 10;
+					maxInt += 10;
+				}
+				if (dogScore() >= 4) {
+					maxSpe += 10;
+					maxInt -= 10;
+				}
+				if (foxScore() >= 4) {
+					maxStr -= 10;
+					maxSpe += 5;
+					maxInt += 5;
+				}
+				if (catScore() >= 4) {
+					maxSpe += 5;
+				}
+				if (bunnyScore() >= 4) {
+					maxSpe += 10;
+				}
+				if (raccoonScore() >= 4) {
+					maxSpe += 15;
+				}
+				if (horseScore() >= 4 && !isTaur() && !isNaga()) {
+					maxSpe += 15;
+					maxTou += 10;
+					maxInt -= 10;
+				}
+				if (gooScore() >= 3) {
+					maxTou += 10;
+					maxSpe -= 10;
+				}
+				if (kitsuneScore() >= 4) {
+					if (tail.type == Tail.FOX) {
+						if (tail.venom == 1) {
+							maxStr -= 2;
+							maxSpe += 2;
+							maxInt += 1;
+						}
+						else if (tail.venom >= 2 && tail.venom < 9) {
+							maxStr -= tail.venom + 1;
+							maxSpe += tail.venom + 1;
+							maxInt += (tail.venom/2) + 0.5;
+						}
+						else if (tail.venom >= 9) {
+							maxStr -= 10;
+							maxSpe += 10;
+							maxInt += 5;
+						}
+					}
+				}
+				if (beeScore() >= 4) {
+					maxSpe += 5;
+					maxTou += 5;
+				}
+				if (spiderScore() >= 4) {
+					maxInt += 15;
+					maxTou += 5;
+					maxStr -= 10;
+				}
+				if (sharkScore() >= 4) {
+					maxStr += 10;
+					maxSpe += 5;
+					maxInt -= 5;
+				}
+				if (harpyScore() >= 4) {
+					maxSpe += 15;
+					maxTou -= 10;
+				}
+				if (sirenScore() >= 4) {
+					maxStr += 5;
+					maxSpe += 20;
+					maxTou -= 5;
+				}
+				if (demonScore() >= 4) {
+					maxSpe += 5;
+					maxInt += 5;
+				}
+				if (rhinoScore() >= 4) {
+					maxStr += 15;
+					maxTou += 15;
+					maxSpe -= 10;
+					maxInt -= 10;
+				}
+				if (satyrScore() >= 4) {
+					maxStr += 5;
+					maxSpe += 5;
+				}
+				if (salamanderScore() >= 4) {
+					maxStr += 5;
+					maxTou += 5;
+				}
+				if (isNaga()) maxSpe += 10;
+				if (isTaur() || isDrider()) maxSpe += 20;
+			}
+			//Apply New Game+
+			maxStr *= 1 + ascensionFactor(0.25);
+			maxTou *= 1 + ascensionFactor(0.25);
+			maxSpe *= 1 + ascensionFactor(0.25);
+			maxInt *= 1 + ascensionFactor(0.25);
 			//Might
 			if (hasStatusEffect(StatusEffects.Might)) {
 				maxStr += statusEffectv1(StatusEffects.Might);

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -2898,6 +2898,21 @@
 						maxInt += 5;
 					}
 				}
+				if (ferretScore() >= 8) {
+					maxStr += 15;
+					maxSpe += 25;
+				} else if (ferretScore() >= 4) {
+					maxStr += 5;
+					maxSpe += 15;
+				}
+				if (redPandaScore() >= 8) {
+					maxInt += 10;
+					maxSpe += 25;
+					maxStr += 5;
+				} else if (redPandaScore() >= 4) {
+					maxInt += 5;
+					maxSpe += 15;
+				}
 				if (cockatriceScore() >= 8) {
 					maxStr += 5;
 					maxSpe += 25;


### PR DESCRIPTION
### GamePlay changes
#### Changed maxStats calculations
Changed the maxStats by ascension calculation to scale better with the NG+-level. For example Basilisk Resistance caps your speed at 95 at NG+0 and at 190 at NG+4. In other words: It is now more, like -5% rather than a plain -5 (Moved that down just before applying StatusEffects like the Might buff).

In code:
```as3
//Apply New Game+
maxStr *= 1 + ascensionFactor(0.25);
maxTou *= 1 + ascensionFactor(0.25);
maxSpe *= 1 + ascensionFactor(0.25);
maxInt *= 1 + ascensionFactor(0.25);
```

Example table for a maxStat of let's say 90 str:

| New Game+-level | calculation | result  |
|-----------------|-------------|--------:|
| 0               | 90 * 1.00   |    90.0 |
| 1               | 90 * 1.25   |   112.5 |
| 2               | 90 * 1.50   |   135.0 |
| 3               | 90 * 1.75   |   157.5 |
| 4+              | 90 * 2.00   |   180.0 |

#### Legacy racial stats toggle (currently an internal flag)
Backported the racial stats from before they were removed. However: They are disabled by default and have to be enabled through a (currently) hidden flag through the flag editor in the debug menu (= set flag 2974 to 1).

### Internal changes

New flag used:
```as3
public static const LEGACY_RACIAL_STATS_ENABLED:int = 2974;
```

### Notes
Currently the legacy racial stats are disabled by default and to enable them again players have to access the **Flag Editor** in the **Debug Menu** and set flag `2974` manually to `1`.