### PR TITLE
Reworked monster scaling in New Game+

### DIFF
--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -1249,7 +1249,7 @@ public static const D3_ENTERED_MAGPIEHALL:int                                   
 public static const D3_BASILISKS_REMOVED_FROM_MAGPIE_HALL:int                       = 1241;
 public static const D3_MIRRORS_SHATTERED:int                                        = 1242;
 public static const D3_JEAN_CLAUDE_DEFEATED:int                                     = 1243;
-public static const D3_DOPPLEGANGER_DEFEATED:int                                    = 1244;
+public static const D3_DOPPELGANGER_DEFEATED:int                                    = 1244;
 public static const D3_MECHANIC_LAST_GREET:int                                      = 1245;
 public static const D3_MECHANIC_FIGHT_RESULT:int                                    = 1246;
 public static const D3_MECHANIC_COCK_TYPE_SELECTION:int                             = 1247; // This is the kinda shit that sounds like it might get referenced in future (HAHAHA YEAH RIGHT?)

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -10,8 +10,13 @@
 	import classes.Items.WeaponLib;
 	import classes.Items.ShieldLib;
 	import classes.Items.UndergarmentLib;
+	import classes.Scenes.Areas.Desert.SandTrap;
+	import classes.Scenes.Dungeons.DeepCave.EncapsulationPod;
 	import classes.Scenes.Dungeons.Factory.SecretarialSuccubus;
+	import classes.Scenes.Dungeons.LethicesKeep.Doppelganger;
+	import classes.Scenes.Dungeons.LethicesKeep.Lethice;
 	import classes.Scenes.NPCs.Kiha;
+	import classes.Scenes.Places.Boat.Marae;
 	import classes.Scenes.Quests.UrtaQuest.MilkySuccubus;
 	import classes.StatusEffects.Combat.BasiliskSlowDebuff;
 	import classes.internals.ChainedDrop;
@@ -160,34 +165,30 @@
 		public override function maxHP():Number
 		{
 			//Base HP
-			var temp:Number = 50 + this.bonusHP;
-			if (flags[kFLAGS.GRIMDARK_MODE] > 0) {
-				temp = (15 * level) + this.bonusHP;
-			}
-			temp += (this.tou * 2);
-			//Apply perks
-			if (findPerk(PerkLib.Tank) >= 0) temp += 50;
-			if (findPerk(PerkLib.Tank2) >= 0) temp += this.tou;
+			var hp:Number = (flags[kFLAGS.GRIMDARK_MODE] > 0 ? (15 * level) : 50) + this.bonusHP;
+
 			//Apply NG+, NG++, NG+++, etc.
-			if (short === "doppleganger" || short === "pod" || short === "sand trap" || short === "sand tarp") {
-				temp += 200 * player.newGamePlusMod();
-			}
-			else if (short === "Lethice") {
-				temp += 1200 * player.newGamePlusMod();
-			}
-			else if (short === "Marae") {
-				temp += 2500 * player.newGamePlusMod();
-			}
-			else {
-				temp += 1000 * player.newGamePlusMod();
-			}
+			hp = getAscensionHP(hp);
+
+			hp += (this.tou * 2);
+
+			//Apply perks
+			if (findPerk(PerkLib.Tank) >= 0) hp += 50;
+			if (findPerk(PerkLib.Tank2) >= 0) hp += this.tou;
+			if (findPerk(PerkLib.Tank3) >= 0) hp += level * 5;
+
 			//Apply difficulty
-			if (flags[kFLAGS.GAME_DIFFICULTY] <= 0) temp *= 1.0;
-			else if (flags[kFLAGS.GAME_DIFFICULTY] === 1) temp *= 1.25;
-			else if (flags[kFLAGS.GAME_DIFFICULTY] === 2) temp *= 1.5;
-			else temp *= 2.0;
-			temp = Math.round(temp);
-			return temp;
+			if (flags[kFLAGS.GAME_DIFFICULTY] <= 0) hp *= 1.0;
+			else if (flags[kFLAGS.GAME_DIFFICULTY] === 1) hp *= 1.25;
+			else if (flags[kFLAGS.GAME_DIFFICULTY] === 2) hp *= 1.5;
+			else hp *= 2.0;
+
+			return Math.round(hp);
+		}
+
+		public function getAscensionHP(hp:Number):Number
+		{
+			return hp * (1 + player.ascensionFactor(1.50)); // +150% per NG+-level
 		}
 
 		override public function maxLust():Number {

--- a/classes/classes/Scenes/Areas/Desert/SandTrap.as
+++ b/classes/classes/Scenes/Areas/Desert/SandTrap.as
@@ -108,6 +108,11 @@
 			}
 		}
 
+		override public function getAscensionHP(hp:Number):Number
+		{
+			return hp * (1 + player.ascensionFactor(1.00)); // +100% per NG+-level
+		}
+
 		public function SandTrap()
 		{
 			//1/3 have fertilized eggs!

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -506,10 +506,10 @@ package classes.Scenes.Combat
 				player.removeStatusEffect(StatusEffects.Confusion);
 				monster.doAI();
 			}
-			else if (monster is Doppleganger) {
+			else if (monster is Doppelganger) {
 				clearOutput();
 				outputText("You decide not to take any action this round.\n\n");
-				(monster as Doppleganger).handlePlayerWait();
+				(monster as Doppelganger).handlePlayerWait();
 				monster.doAI();
 			}
 			else {
@@ -916,7 +916,7 @@ package classes.Scenes.Combat
 			}
 
 			// Have to put it before doDamage, because doDamage applies the change, as well as status effects and shit.
-			if (monster is Doppleganger)
+			if (monster is Doppelganger)
 			{
 				if (!monster.hasStatusEffect(StatusEffects.Stunned))
 				{
@@ -924,11 +924,11 @@ package classes.Scenes.Combat
 					if (player.countCockSocks("red") > 0) damage *= (1 + player.countCockSocks("red") * 0.02);
 					if (damage > 0) damage = doDamage(damage, false);
 				
-					(monster as Doppleganger).mirrorAttack(damage);
+					(monster as Doppelganger).mirrorAttack(damage);
 					return;
 				}
 				
-				// Stunning the doppleganger should now "buy" you another round.
+				// Stunning the doppelganger should now "buy" you another round.
 			}
 			if (player.weapon == weapons.HNTCANE) {
 				switch(rand(2)) {
@@ -1778,11 +1778,13 @@ package classes.Scenes.Combat
 			if (player.findPerk(PerkLib.Spellsword) >= 0 && player.lust100 < combatAbilities.getWhiteMagicLustCap()) {
 				combatAbilities.spellChargeWeapon(true); // XXX: message?
 			}
-			monster.str += 25 * player.newGamePlusMod();
-			monster.tou += 25 * player.newGamePlusMod();
-			monster.spe += 25 * player.newGamePlusMod();
-			monster.inte += 25 * player.newGamePlusMod();
-			monster.level += 30 * player.newGamePlusMod();
+			if (!(monster is Doppelganger)) {
+				monster.str *= 1 + player.ascensionFactor(0.25);
+				monster.tou *= 1 + player.ascensionFactor(0.25);
+				monster.spe *= 1 + player.ascensionFactor(0.25);
+				monster.inte *= 1 + player.ascensionFactor(0.25);
+			}
+			monster.level += player.ascensionFactor(30);
 			if (flags[kFLAGS.GRIMDARK_MODE] > 0) {
 				monster.level = Math.round(Math.pow(monster.level, 1.4));
 			}

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -276,9 +276,9 @@ package classes.Scenes.Combat
 				monster.doAI();
 				return;
 			}
-			if (monster is Doppleganger)
+			if (monster is Doppelganger)
 			{
-				(monster as Doppleganger).handleSpellResistance("whitefire");
+				(monster as Doppelganger).handleSpellResistance("whitefire");
 				flags[kFLAGS.SPELLS_CAST]++;
 				spellPerkUnlock();
 				return;
@@ -511,9 +511,9 @@ package classes.Scenes.Combat
 				monster.doAI();
 				return;
 			}
-			if (monster is Doppleganger)
+			if (monster is Doppelganger)
 			{
-				(monster as Doppleganger).handleSpellResistance("blackfire");
+				(monster as Doppelganger).handleSpellResistance("blackfire");
 				flags[kFLAGS.SPELLS_CAST]++;
 				spellPerkUnlock();
 				return;
@@ -967,9 +967,9 @@ package classes.Scenes.Combat
 				monster.doAI();
 				return;
 			}
-			if (monster is Doppleganger)
+			if (monster is Doppelganger)
 			{
-				(monster as Doppleganger).handleSpellResistance("fireball");
+				(monster as Doppelganger).handleSpellResistance("fireball");
 				flags[kFLAGS.SPELLS_CAST]++;
 				spellPerkUnlock();
 				return;

--- a/classes/classes/Scenes/Combat/CombatTeases.as
+++ b/classes/classes/Scenes/Combat/CombatTeases.as
@@ -1410,7 +1410,7 @@ package classes.Scenes.Combat
 				damage = (damage + rand(bonusDamage)) * monster.lustVuln;
 				
 				if (monster is JeanClaude) (monster as JeanClaude).handleTease(damage, true);
-				else if (monster is Doppleganger && !monster.hasStatusEffect(StatusEffects.Stunned)) (monster as Doppleganger).mirrorTease(damage, true);
+				else if (monster is Doppelganger && !monster.hasStatusEffect(StatusEffects.Stunned)) (monster as Doppelganger).mirrorTease(damage, true);
 				else if (!justText) monster.teased(damage);
 				
 				if (flags[kFLAGS.PC_FETISH] >= 1 && !getGame().urtaQuest.isUrta()) 
@@ -1428,7 +1428,7 @@ package classes.Scenes.Combat
 				if (!justText && !getGame().urtaQuest.isUrta()) teaseXP(5);
 				
 				if (monster is JeanClaude) (monster as JeanClaude).handleTease(0, false);
-				else if (monster is Doppleganger) (monster as Doppleganger).mirrorTease(0, false);
+				else if (monster is Doppelganger) (monster as Doppelganger).mirrorTease(0, false);
 				else if (!justText) outputText("\n" + monster.capitalA + monster.short + " seems unimpressed.");
 			}
 			outputText("\n\n");

--- a/classes/classes/Scenes/Dungeons/DeepCave/EncapsulationPod.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/EncapsulationPod.as
@@ -201,6 +201,11 @@ package classes.Scenes.Dungeons.DeepCave
 			return _long;
 		}
 
+		override public function getAscensionHP(hp:Number):Number
+		{
+			return hp * (1 + player.ascensionFactor(1.00)); // +100% per NG+-level
+		}
+
 		public function EncapsulationPod()
 		{
 			this.a = "the ";

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/Doppelganger.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/Doppelganger.as
@@ -11,7 +11,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 	 * ...
 	 * @author Gedan
 	 */
-	public class Doppleganger extends Monster
+	public class Doppelganger extends Monster
 	{
 		private var _roundCount:int = 0;
 		
@@ -19,7 +19,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 		{
 			this.createStatusEffect(StatusEffects.MirroredAttack, 0, 0, 0, 0);
 			
-			outputText("As you swing your [weapon] at the doppleganger, " + player.mf("he", "she") + " smiles mockingly, and mirrors your move exactly, lunging forward with " + player.mf("his", "her") + " duplicate " + weaponName + ".");
+			outputText("As you swing your [weapon] at the doppelganger, " + player.mf("he", "she") + " smiles mockingly, and mirrors your move exactly, lunging forward with " + player.mf("his", "her") + " duplicate " + weaponName + ".");
 			
 			// Cribbing from combat mechanics - if the number we got here is <= 0, it was deflected, blocked or otherwise missed.
 			// We'll use this as our primary failure to hit, and then mix in a bit of random.
@@ -143,12 +143,12 @@ package classes.Scenes.Dungeons.LethicesKeep
 		
 		override public function defeated(hpVictory:Boolean):void
 		{
-			game.lethicesKeep.doppleganger.punchYourselfInTheBalls();
+			game.lethicesKeep.doppelganger.punchYourselfInTheBalls();
 		}
 		
 		override public function won(hpVictory:Boolean, pcCameWorms:Boolean):void
 		{
-			game.lethicesKeep.doppleganger.inSovietCoCSelfFucksYou();
+			game.lethicesKeep.doppelganger.inSovietCoCSelfFucksYou();
 		}
 		
 		public function handleSpellResistance(spell:String):void
@@ -175,7 +175,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 		
 		public function handlePlayerWait():void
 		{
-			outputText("Your doppleganger similarly opts to take a momentary break from the ebb and flow of combat.");
+			outputText("Your doppelganger similarly opts to take a momentary break from the ebb and flow of combat.");
 			addTalkShit();
 		}
 		
@@ -190,14 +190,19 @@ package classes.Scenes.Dungeons.LethicesKeep
 			outputText("Your duplicate chuckles in the face of your attacks.");
 			addTalkShit();
 		}
+
+		override public function getAscensionHP(hp:Number):Number
+		{
+			return hp * (1 + player.ascensionFactor(0.50)); // +50% per NG+-level
+		}
 		
-		public function Doppleganger() 
+		public function Doppelganger() 
 		{
 			this.a = "the ";
 			this.short = "doppelganger";
 			this.long = ""; // Needs to be set to supress validation errors, but is handled by an accessor override.
 			this.race = "Demon";
-			this.imageName = "doppleganger";
+			this.imageName = "doppelganger";
 			this.plural = false;
 			
 			this.tallness = player.tallness;

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/DoppelgangerScenes.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/DoppelgangerScenes.as
@@ -10,10 +10,10 @@
 	 * ...
 	 * @author Gedan
 	 */
-	public class DopplegangerScenes extends BaseContent
+	public class DoppelgangerScenes extends BaseContent
 	{
 		
-		public function DopplegangerScenes() 
+		public function DoppelgangerScenes() 
 		{
 			
 		}
@@ -37,12 +37,12 @@
 			outputText("\n\n“<i>Do you know what it is like to spend ten years without a form? To spend ten years imitating an empty room? Well, don’t worry, [name]. When I have taken your place and bound you to this thing I’ll make sure to put it somewhere nice and busy, so you will never have to know that torment!</i>” " + player.mf("He", "She") +" draws the mirror image of your [weapon] and advances upon you, your own features hiked into a rictus of madness.");
 			outputText("\n\nYou must fight yourself!");
 			
-			startCombat(new Doppleganger());
+			startCombat(new Doppelganger());
 		}
 		
 		public function punchYourselfInTheBalls():void
 		{
-			flags[kFLAGS.D3_DOPPLEGANGER_DEFEATED] = 1;
+			flags[kFLAGS.D3_DOPPELGANGER_DEFEATED] = 1;
 			player.createKeyItem("Laybans", 0, 0, 0, 0);
 			
 			clearOutput();

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/Lethice.as
@@ -66,6 +66,11 @@ package classes.Scenes.Dungeons.LethicesKeep
 			this.checkMonster();
 		}
 		
+		override public function getAscensionHP(hp:Number):Number
+		{
+			return hp * (1 + player.ascensionFactor(1.75)); // +175% per NG+-level --> = +1225 per level then
+		}
+
 		override public function get long():String
 		{
 			var str:* = "";

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/LethicesKeep.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/LethicesKeep.as
@@ -22,7 +22,7 @@ package classes.Scenes.Dungeons.LethicesKeep {
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(LethicesKeep);
 
 		public var jeanClaude:JeanClaudeScenes = new JeanClaudeScenes();
-		public var doppleganger:DopplegangerScenes = new DopplegangerScenes();
+		public var doppelganger:DoppelgangerScenes = new DoppelgangerScenes();
 		public var incubusMechanic:IncubusMechanicScenes = new IncubusMechanicScenes();
 		public var livingStatue:LivingStatueScenes = new LivingStatueScenes();
 		public var succubusGardener:SuccubusGardenerScenes = new SuccubusGardenerScenes();
@@ -281,7 +281,7 @@ package classes.Scenes.Dungeons.LethicesKeep {
 				outputText("\n\nNear the back, next to the broken stack is a white stand, displaying what appear to be a number of dark shades.");
 				if (flags[kFLAGS.D3_ENTERED_MAGPIEHALL] == 1) outputText("  Your spirits rise. They look like they may very well be made of the same material as the screen in the basilisk hall.");
 				if (player.inte >= 70 || player.sens >= 70) outputText("  Disquiet edges down your spine. Something about this place doesn’t feel right. The room seems faded at the corners, as if it’s not quite there.");
-				addButton(2, "Glasses", doppleganger.getDemGlasses);
+				addButton(2, "Glasses", doppelganger.getDemGlasses);
 			}
 			return false;
 		}

--- a/classes/classes/Scenes/Places/Boat/Marae.as
+++ b/classes/classes/Scenes/Places/Boat/Marae.as
@@ -119,6 +119,11 @@ package classes.Scenes.Places.Boat
 			}
 		}
 		
+		override public function getAscensionHP(hp:Number):Number
+		{
+			return hp * (1 + player.ascensionFactor(0.55)); // +55% per NG+-level --> = +2640 per level then
+		}
+
 		public function Marae() 
 		{
 			this.a = "";

--- a/classes/classes/Scenes/Quests/UrtaQuest.as
+++ b/classes/classes/Scenes/Quests/UrtaQuest.as
@@ -273,11 +273,11 @@ public function startUrtaQuest():void {
 	player.level = 15;
 	player.teaseLevel = 4;
 	//Apply new game plus modifier.
-	player.level += (player.newGamePlusMod() * 30);
-	player.str += (player.newGamePlusMod() * 25);
-	player.tou += (player.newGamePlusMod() * 25);
-	player.spe += (player.newGamePlusMod() * 25);
-	player.inte += (player.newGamePlusMod() * 25);
+	player.level += player.ascensionFactor(30);
+	player.str *= 1 + player.ascensionFactor(0.25);
+	player.tou *= 1 + player.ascensionFactor(0.25);
+	player.spe *= 1 + player.ascensionFactor(0.25);
+	player.inte *= 1 + player.ascensionFactor(0.25);
 	player.HP = player.maxHP();
 	player.fatigue = 0;
 

--- a/img/images.xml
+++ b/img/images.xml
@@ -109,9 +109,21 @@
 				<ImageFile>./img/akbal-deepwoods-taur-sumbitanal</ImageFile>
 				<ImageFile>./img/akbal-deepwoods-taur-sumbitanal_1</ImageFile>
 			</ImageSet>
-			<ImageSet id="amarok-chompo">
-				<ImageFile>./img/amarok-chompo</ImageFile>
-				<ImageFile>./img/amarok-chompo_1</ImageFile>
+			<ImageSet id="amarok-chompo-female">
+				<ImageFile>./img/amarok-chompo-female</ImageFile>
+				<ImageFile>./img/amarok-chompo-female_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="amarok-chompo-male">
+				<ImageFile>./img/amarok-chompo-male</ImageFile>
+				<ImageFile>./img/amarok-chompo-male_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="amarok-defeat">
+				<ImageFile>./img/amarok-defeat</ImageFile>
+				<ImageFile>./img/amarok-defeat_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="amarok-victory">
+				<ImageFile>./img/amarok-victory</ImageFile>
+				<ImageFile>./img/amarok-victory_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="amily-forest-fuckpreg">
 				<ImageFile>./img/amily-forest-fuckpreg</ImageFile>
@@ -1061,6 +1073,10 @@
 				<ImageFile>./img/camp-cabin</ImageFile>
 				<ImageFile>./img/camp-cabin_1</ImageFile>
 			</ImageSet>
+			<ImageSet id="camp-campfire">
+				<ImageFile>./img/camp-campfire</ImageFile>
+				<ImageFile>./img/camp-campfire_1</ImageFile>
+			</ImageSet>
 			<ImageSet id="camp-dream">
 				<ImageFile>./img/camp-dream</ImageFile>
 				<ImageFile>./img/camp-dream_1</ImageFile>
@@ -1164,10 +1180,6 @@
 			<ImageSet id="camp-watch-sunset">
 				<ImageFile>./img/camp-watch-sunset</ImageFile>
 				<ImageFile>./img/camp-watch-sunset_1</ImageFile>
-			</ImageSet>
-			<ImageSet id="campfire">
-				<ImageFile>./img/campfire</ImageFile>
-				<ImageFile>./img/campfire_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="chameleon-female-lose-facesit-tailfuck">
 				<ImageFile>./img/chameleon-female-lose-facesit-tailfuck</ImageFile>
@@ -1449,6 +1461,18 @@
 				<ImageFile>./img/ember-visit-at-camp</ImageFile>
 				<ImageFile>./img/ember-visit-at-camp_1</ImageFile>
 			</ImageSet>
+			<ImageSet id="encounter-amarok">
+				<ImageFile>./img/encounter-amarok</ImageFile>
+				<ImageFile>./img/encounter-amarok_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="encounter-chicken-harpy">
+				<ImageFile>./img/encounter-chicken-harpy</ImageFile>
+				<ImageFile>./img/encounter-chicken-harpy_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="encounter-harpy">
+				<ImageFile>./img/encounter-harpy</ImageFile>
+				<ImageFile>./img/encounter-harpy_1</ImageFile>
+			</ImageSet>
 			<ImageSet id="encounter-lumi">
 				<ImageFile>./img/encounter-lumi</ImageFile>
 				<ImageFile>./img/encounter-lumi_1</ImageFile>
@@ -1457,9 +1481,29 @@
 				<ImageFile>./img/encounter-lumi-repeat</ImageFile>
 				<ImageFile>./img/encounter-lumi-repeat_1</ImageFile>
 			</ImageSet>
+			<ImageSet id="encounter-minotaur">
+				<ImageFile>./img/encounter-minotaur</ImageFile>
+				<ImageFile>./img/encounter-minotaur_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="encounter-rathazul">
+				<ImageFile>./img/encounter-rathazul</ImageFile>
+				<ImageFile>./img/encounter-rathazul_1</ImageFile>
+			</ImageSet>
 			<ImageSet id="encounter-stranger">
 				<ImageFile>./img/encounter-stranger</ImageFile>
 				<ImageFile>./img/encounter-stranger_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="encounter-valkyrie">
+				<ImageFile>./img/encounter-valkyrie</ImageFile>
+				<ImageFile>./img/encounter-valkyrie_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="encounter-yeti">
+				<ImageFile>./img/encounter-yeti</ImageFile>
+				<ImageFile>./img/encounter-yeti_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="encounter-zetaz">
+				<ImageFile>./img/encounter-zetaz</ImageFile>
+				<ImageFile>./img/encounter-zetaz_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="essrayle-discussion">
 				<ImageFile>./img/essrayle-discussion</ImageFile>
@@ -1476,10 +1520,6 @@
 			<ImageSet id="event-arrow-up">
 				<ImageFile>./img/event-arrow-up</ImageFile>
 				<ImageFile>./img/event-arrow-up_1</ImageFile>
-			</ImageSet>
-			<ImageSet id="event-chicken">
-				<ImageFile>./img/event-chicken</ImageFile>
-				<ImageFile>./img/event-chicken_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="event-creation">
 				<ImageFile>./img/event-creation</ImageFile>
@@ -1520,6 +1560,18 @@
 			<ImageSet id="event-island">
 				<ImageFile>./img/event-island</ImageFile>
 				<ImageFile>./img/event-island_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="event-lake-bSword">
+				<ImageFile>./img/event-lake-bSword</ImageFile>
+				<ImageFile>./img/event-lake-bSword_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="event-lake-lights">
+				<ImageFile>./img/event-lake-lights</ImageFile>
+				<ImageFile>./img/event-lake-lights_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="event-lake-lights-adoption">
+				<ImageFile>./img/event-lake-lights-adoption</ImageFile>
+				<ImageFile>./img/event-lake-lights-adoption_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="event-lumi">
 				<ImageFile>./img/event-lumi</ImageFile>
@@ -2081,10 +2133,6 @@
 				<ImageFile>./img/item-Bread</ImageFile>
 				<ImageFile>./img/item-Bread_1</ImageFile>
 			</ImageSet>
-			<ImageSet id="item-Bsword">
-				<ImageFile>./img/item-Bsword</ImageFile>
-				<ImageFile>./img/item-Bsword_1</ImageFile>
-			</ImageSet>
 			<ImageSet id="item-bArmor-corrupt">
 				<ImageFile>./img/item-bArmor-corrupt</ImageFile>
 				<ImageFile>./img/item-bArmor-corrupt_1</ImageFile>
@@ -2097,9 +2145,17 @@
 				<ImageFile>./img/item-bChitin</ImageFile>
 				<ImageFile>./img/item-bChitin_1</ImageFile>
 			</ImageSet>
+			<ImageSet id="item-bSword">
+				<ImageFile>./img/item-bSword</ImageFile>
+				<ImageFile>./img/item-bSword_1</ImageFile>
+			</ImageSet>
 			<ImageSet id="item-bow">
 				<ImageFile>./img/item-bow</ImageFile>
 				<ImageFile>./img/item-bow_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="item-brokenSword">
+				<ImageFile>./img/item-brokenSword</ImageFile>
+				<ImageFile>./img/item-brokenSword_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="item-cBread">
 				<ImageFile>./img/item-cBread</ImageFile>
@@ -2221,10 +2277,6 @@
 				<ImageFile>./img/item-ebonVest</ImageFile>
 				<ImageFile>./img/item-ebonVest_1</ImageFile>
 			</ImageSet>
-			<ImageSet id="item-egg-NP">
-				<ImageFile>./img/item-egg-NP</ImageFile>
-				<ImageFile>./img/item-egg-NP_1</ImageFile>
-			</ImageSet>
 			<ImageSet id="item-egg-black">
 				<ImageFile>./img/item-egg-black</ImageFile>
 				<ImageFile>./img/item-egg-black_1</ImageFile>
@@ -2236,6 +2288,14 @@
 			<ImageSet id="item-egg-brown">
 				<ImageFile>./img/item-egg-brown</ImageFile>
 				<ImageFile>./img/item-egg-brown_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="item-egg-harpy">
+				<ImageFile>./img/item-egg-harpy</ImageFile>
+				<ImageFile>./img/item-egg-harpy_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="item-egg-neon">
+				<ImageFile>./img/item-egg-neon</ImageFile>
+				<ImageFile>./img/item-egg-neon_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="item-egg-pile">
 				<ImageFile>./img/item-egg-pile</ImageFile>
@@ -2289,9 +2349,9 @@
 				<ImageFile>./img/item-gems</ImageFile>
 				<ImageFile>./img/item-gems_1</ImageFile>
 			</ImageSet>
-			<ImageSet id="item-hEgg">
-				<ImageFile>./img/item-hEgg</ImageFile>
-				<ImageFile>./img/item-hEgg_1</ImageFile>
+			<ImageSet id="item-gro-plus">
+				<ImageFile>./img/item-gro-plus</ImageFile>
+				<ImageFile>./img/item-gro-plus_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="item-hPill">
 				<ImageFile>./img/item-hPill</ImageFile>
@@ -2345,6 +2405,10 @@
 				<ImageFile>./img/item-lactaid</ImageFile>
 				<ImageFile>./img/item-lactaid_1</ImageFile>
 			</ImageSet>
+			<ImageSet id="item-lactaid-pro">
+				<ImageFile>./img/item-lactaid-pro</ImageFile>
+				<ImageFile>./img/item-lactaid-pro_1</ImageFile>
+			</ImageSet>
 			<ImageSet id="item-letter">
 				<ImageFile>./img/item-letter</ImageFile>
 				<ImageFile>./img/item-letter_1</ImageFile>
@@ -2384,10 +2448,6 @@
 			<ImageSet id="item-pigTruffle">
 				<ImageFile>./img/item-pigTruffle</ImageFile>
 				<ImageFile>./img/item-pigTruffle_1</ImageFile>
-			</ImageSet>
-			<ImageSet id="item-proLactaid">
-				<ImageFile>./img/item-proLactaid</ImageFile>
-				<ImageFile>./img/item-proLactaid_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="item-purePotion">
 				<ImageFile>./img/item-purePotion</ImageFile>
@@ -2788,10 +2848,6 @@
 			<ImageSet id="kiha-vagfuck">
 				<ImageFile>./img/kiha-vagfuck</ImageFile>
 				<ImageFile>./img/kiha-vagfuck_1</ImageFile>
-			</ImageSet>
-			<ImageSet id="lake-lights">
-				<ImageFile>./img/lake-lights</ImageFile>
-				<ImageFile>./img/lake-lights_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="lethice-boob-male">
 				<ImageFile>./img/lethice-boob-male</ImageFile>
@@ -3693,9 +3749,13 @@
 				<ImageFile>./img/monster-demonmob</ImageFile>
 				<ImageFile>./img/monster-demonmob_1</ImageFile>
 			</ImageSet>
-			<ImageSet id="monster-doppleganger">
-				<ImageFile>./img/monster-doppleganger</ImageFile>
-				<ImageFile>./img/monster-doppleganger_1</ImageFile>
+			<ImageSet id="monster-doppelganger">
+				<ImageFile>./img/monster-doppelganger</ImageFile>
+				<ImageFile>./img/monster-doppelganger_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="monster-dryad">
+				<ImageFile>./img/monster-dryad</ImageFile>
+				<ImageFile>./img/monster-dryad_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="monster-ember">
 				<ImageFile>./img/monster-ember</ImageFile>
@@ -3912,6 +3972,10 @@
 			<ImageSet id="monster-minervapure">
 				<ImageFile>./img/monster-minervapure</ImageFile>
 				<ImageFile>./img/monster-minervapure_1</ImageFile>
+			</ImageSet>
+			<ImageSet id="monster-minoaxe">
+				<ImageFile>./img/monster-minoaxe</ImageFile>
+				<ImageFile>./img/monster-minoaxe_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="monster-minomob">
 				<ImageFile>./img/monster-minomob</ImageFile>
@@ -4352,10 +4416,6 @@
 			<ImageSet id="raphael-talk">
 				<ImageFile>./img/raphael-talk</ImageFile>
 				<ImageFile>./img/raphael-talk_1</ImageFile>
-			</ImageSet>
-			<ImageSet id="rathazul">
-				<ImageFile>./img/rathazul</ImageFile>
-				<ImageFile>./img/rathazul_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="rathazul-accident">
 				<ImageFile>./img/rathazul-accident</ImageFile>
@@ -5357,10 +5417,6 @@
 				<ImageFile>./img/wildhunt-catched-male-shark</ImageFile>
 				<ImageFile>./img/wildhunt-catched-male-shark_1</ImageFile>
 			</ImageSet>
-			<ImageSet id="wildhunt-catched-male-wolf">
-				<ImageFile>./img/wildhunt-catched-male-wolf</ImageFile>
-				<ImageFile>./img/wildhunt-catched-male-wolf_1</ImageFile>
-			</ImageSet>
 			<ImageSet id="wildhunt-chase">
 				<ImageFile>./img/wildhunt-chase</ImageFile>
 				<ImageFile>./img/wildhunt-chase_1</ImageFile>
@@ -5401,10 +5457,6 @@
 				<ImageFile>./img/wildhunt-prey-female-feline</ImageFile>
 				<ImageFile>./img/wildhunt-prey-female-feline_1</ImageFile>
 			</ImageSet>
-			<ImageSet id="wildhunt-prey-female-human">
-				<ImageFile>./img/wildhunt-prey-female-human</ImageFile>
-				<ImageFile>./img/wildhunt-prey-female-human_1</ImageFile>
-			</ImageSet>
 			<ImageSet id="wildhunt-prey-male">
 				<ImageFile>./img/wildhunt-prey-male</ImageFile>
 				<ImageFile>./img/wildhunt-prey-male_1</ImageFile>
@@ -5424,10 +5476,6 @@
 			<ImageSet id="wildhunt-prey-male-feline">
 				<ImageFile>./img/wildhunt-prey-male-feline</ImageFile>
 				<ImageFile>./img/wildhunt-prey-male-feline_1</ImageFile>
-			</ImageSet>
-			<ImageSet id="wildhunt-prey-male-human">
-				<ImageFile>./img/wildhunt-prey-male-human</ImageFile>
-				<ImageFile>./img/wildhunt-prey-male-human_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="wildhunt-prey-taur-female">
 				<ImageFile>./img/wildhunt-prey-taur-female</ImageFile>
@@ -5493,9 +5541,9 @@
 				<ImageFile>./img/wildhunt-princess-lickgina</ImageFile>
 				<ImageFile>./img/wildhunt-princess-lickgina_1</ImageFile>
 			</ImageSet>
-			<ImageSet id="wildhunt-princess-lickgina-big">
-				<ImageFile>./img/wildhunt-princess-lickgina-big</ImageFile>
-				<ImageFile>./img/wildhunt-princess-lickgina-big_1</ImageFile>
+			<ImageSet id="wildhunt-princess-lickgina-dragon">
+				<ImageFile>./img/wildhunt-princess-lickgina-dragon</ImageFile>
+				<ImageFile>./img/wildhunt-princess-lickgina-dragon_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="wildhunt-princess-lickgina-equine">
 				<ImageFile>./img/wildhunt-princess-lickgina-equine</ImageFile>
@@ -5513,6 +5561,10 @@
 				<ImageFile>./img/wildhunt-princess-orally-bovine</ImageFile>
 				<ImageFile>./img/wildhunt-princess-orally-bovine_1</ImageFile>
 			</ImageSet>
+			<ImageSet id="wildhunt-princess-orally-canine">
+				<ImageFile>./img/wildhunt-princess-orally-canine</ImageFile>
+				<ImageFile>./img/wildhunt-princess-orally-canine_1</ImageFile>
+			</ImageSet>
 			<ImageSet id="wildhunt-princess-orally-deer">
 				<ImageFile>./img/wildhunt-princess-orally-deer</ImageFile>
 				<ImageFile>./img/wildhunt-princess-orally-deer_1</ImageFile>
@@ -5524,10 +5576,6 @@
 			<ImageSet id="wildhunt-princess-orally-horse">
 				<ImageFile>./img/wildhunt-princess-orally-horse</ImageFile>
 				<ImageFile>./img/wildhunt-princess-orally-horse_1</ImageFile>
-			</ImageSet>
-			<ImageSet id="wildhunt-princess-orally-wolf">
-				<ImageFile>./img/wildhunt-princess-orally-wolf</ImageFile>
-				<ImageFile>./img/wildhunt-princess-orally-wolf_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="wildhunt-revenge">
 				<ImageFile>./img/wildhunt-revenge</ImageFile>
@@ -5556,10 +5604,6 @@
 			<ImageSet id="yeti-vag-ride">
 				<ImageFile>./img/yeti-vag-ride</ImageFile>
 				<ImageFile>./img/yeti-vag-ride_1</ImageFile>
-			</ImageSet>
-			<ImageSet id="zetaz-encounter-first">
-				<ImageFile>./img/zetaz-encounter-first</ImageFile>
-				<ImageFile>./img/zetaz-encounter-first_1</ImageFile>
 			</ImageSet>
 			<ImageSet id="zetaz-loss-female">
 				<ImageFile>./img/zetaz-loss-female</ImageFile>

--- a/img/xmlGen.py
+++ b/img/xmlGen.py
@@ -13,7 +13,9 @@ def getImageIDList():
 	ret = set()
 
 	scanPath = "../"
-	for root, dirs, files in os.walk(scanPath):
+	excludeDirs = set(["build-dep", "test", "bit101"])
+	for root, dirs, files in os.walk(scanPath, topdown=True):
+		dirs[:] = [d for d in dirs if d not in excludeDirs]
 		#print root, dir#, files
 		for fileN in files:
 			if fileN.endswith(".as"):


### PR DESCRIPTION
### GamePlay changes
- Base attributes now scale with ascension level so its not just plain +25 per NG+-level anymore.
  Example table (Values at New Game+ level 4 or higher)

  | Example                 | Base value | NG+4 (old, = +100) | NG+4 (new, = +100%) |
  |-------------------------|-----------:|-------------------:|--------------------:|
  | Lethice (Strength)      | 110        | 210                | 220                 |
  | Basilisk (Toughness)    | 70         | 170                | 140                 |
  | Imp (Strength)          | 20         | 120                | 40                  |
  | Imp Overlord (Strength) | 100        | 200                | 200                 |
  | Cockatrice (Speed)      | 85         | 185                | 170                 |

  **Note:** The ***Doppelganger*** is excluded because its values match the player values.

- Monster HP now scales with ascension. Monsters that had individual scaling now have nearly the same scaling. In other words: Their HP in New Game plus is now minimally higher than the old values.
  All other monsters now scale at +150% base HP (= 50 + bonusHP).
  For example an ***Imp*** now has far less HP, than an ***Imp Overlord***. IMHO ***Imps*** were too strong compared to ***Imp Overlords*** as an example.
- **[Fixed]** Due to typos in `monster.short` and/or checking for `monster.short` the ***Sand Trap***, the ***Encapsulation Pod*** and the ***Doppelganger*** had way more HP, than it was intended.
- **[Fixed]** In a few cases the ***Doppelganger*** was named ***Doppleganger***. Corrected that.

### Internal changes
- The new perk *Tank 3* is now applied to monsters too (not used so far)
- Instead of a bunch of `if (monster is WhateverNPC)`-checks in `Monster.maxHP` I've added the method:

  ```as3 
  public function getAscensionHP(hp:Number):Number 
  { 
  	return hp * (1 + player.ascensionFactor(1.50)); // +150% per NG+-level 
  } 
  ```
  ... which I `override` for enemys, like the ***Sand Trap***, the ***Doppelganger*** or ***Lethice***.
- Refactored `doppleganger` to `doppelganger` (vars, flags, classes)
- **[Unrelated]** Changed `xmlGen.py` so it now exludes the dirs `build-dep`, `test` and `bit101` and reran it.

### Notes
- I've tested those changes at New Game+ level >= 4 (e. g. Lethices Stronghold, standard Imp and Goblin encounters, Marae) and hadn't encountered any mob, thats unbeatable so far.
- I haven't tested it for Grimdark mode. Grimdark mode monsters should now have siginificantly more HP, when playing it in NG+ since their base HP calc is `15 * level + bonusHP`. So ascending in Grimdark may be significantly more challenging. Well ... I guess this may even be somewhat intended.