### PR TITLE
History Perk for special character 'Leah'

### DIFF
--- a/classes/classes/CharSpecial.as
+++ b/classes/classes/CharSpecial.as
@@ -546,7 +546,9 @@ package classes
 			player.setWeapon(weapons.W_STAFF);
 			player.itemSlot1.setItemAndQty(consumables.B__BOOK, 1);
 			player.itemSlot2.setItemAndQty(consumables.W__BOOK, 2);
-	
+			
+			player.createPerk(PerkLib.HistoryScholar, 0, 0, 0, 0);
+
 			player.createBreastRow();
 			player.createVagina();
 			player.breastRows[0].breastRating = 4;

--- a/test/classes/CharSpecialTest.as
+++ b/test/classes/CharSpecialTest.as
@@ -357,5 +357,12 @@ package classes{
 			
 			assertThat(player.HP, equalTo(50));
 		}
+		
+		[Test]
+		public function leahHasHistoryPerk(): void {
+			createCharByName(CharSpecial.LEAH_NAME);
+			
+			assertThat(player.hasPerk(PerkLib.HistoryScholar), equalTo(true));
+		}
 	}
 }


### PR DESCRIPTION
This adds the Scholar history perk to the character.
The perk was chosen because the character starts out with spell books.

Fixes #1303 