### PR TITLE
Fixed the remaining custom chars

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -850,22 +850,20 @@ package classes {
 			var totalStartingPerks:int = 0;
 			var button:int = 0;
 			//Attribute Perks
-			var buttonTexts:Array = ["Strong", "Tough", "Fast", "Smarts", "Libido", "Touch", "Perversion"];
-			var buttonPerks:Array = [PerkLib.Strong, PerkLib.Tough, PerkLib.Fast, PerkLib.Smart, PerkLib.Lusty, PerkLib.Sensitive, PerkLib.Pervert];
+			var endowmentPerks:Array = PerkLists.ENDOWMENT_ATTRIBUTE;
 			//Endowment Perks
 			if (player.hasCock()) {
-				buttonTexts.push("Big Cock", "Lots of Jizz");
-				buttonPerks.push(PerkLib.BigCock, PerkLib.MessyOrgasms);
+				endowmentPerks = endowmentPerks.concat(PerkLists.ENDOWMENT_COCK);
 			}
 			if (player.hasVagina()) {
-				buttonTexts.push("Big Breasts", "Big Clit", "Fertile", "Wet Vagina");
-				buttonPerks.push(PerkLib.BigTits, PerkLib.BigClit, PerkLib.Fertile, PerkLib.WetPussy);
+				endowmentPerks = endowmentPerks.concat(PerkLists.ENDOWMENT_VAGINA);
 			}
 			//Add buttons
-			for (var i:int = 0; i < buttonTexts.length; i++) {
-				if (player.findPerk(buttonPerks[i]) < 0) addButton(button++, buttonTexts[i], confirmEndowment, buttonPerks[i]);
-				else {
-					addButtonDisabled(button++, buttonTexts[i], "You already have this starting perk.");
+			for each (var p:Object in endowmentPerks) {
+				if (!player.hasPerk(p.perk)) {
+					addButton(button++, p.text, confirmEndowment, p.perk);
+				} else {
+					addButtonDisabled(button++, p.text, "You already have this starting perk.");
 					totalStartingPerks++;
 				}
 			}
@@ -985,13 +983,11 @@ package classes {
 			var totalHistoryPerks:int = 0;
 			var button:int = 0;
 			//Attribute Perks
-			var buttonTexts:Array = ["Alchemy", "Fighting", "Fortune", "Healing", "Religion", "Schooling", "Slacking", "Slutting", "Smithing", "Whoring"];
-			var buttonPerks:Array = [PerkLib.HistoryAlchemist, PerkLib.HistoryFighter, PerkLib.HistoryFortune, PerkLib.HistoryHealer, PerkLib.HistoryReligious, PerkLib.HistoryScholar, PerkLib.HistorySlacker, PerkLib.HistorySlut, PerkLib.HistorySmith, PerkLib.HistoryWhore];
-			for (var i:int = 0; i < buttonTexts.length; i++) {
-				if (player.findPerk(buttonPerks[i]) < 0)
-					addButton(button++, buttonTexts[i], confirmHistory, buttonPerks[i]);
+			for each (var p:Object in PerkLists.HISTORY) {
+				if (!player.hasPerk(p.perk))
+					addButton(button++, p.text, confirmHistory, p.perk);
 				else {
-					addButtonDisabled(button++, buttonTexts[i], "You already have this history perk.");
+					addButtonDisabled(button++, p.text, "You already have this history perk.");
 					totalHistoryPerks++;
 				}
 			}

--- a/classes/classes/CharSpecial.as
+++ b/classes/classes/CharSpecial.as
@@ -369,6 +369,8 @@ package classes
 			player.ballSize = 8;
 			//A virility boost would be nice too if possible.
 			player.cumMultiplier = 50;
+			player.createPerk(PerkLib.HistoryFighter, 0, 0, 0, 0);
+			player.createPerk(PerkLib.HistoryWhore, 0, 0, 0, 0);
 		}
 		
 		private function customCody():void {
@@ -1108,6 +1110,7 @@ package classes
 			//She has a demonic tail and small demonic wings thanks to some encounters early on with succubus milk (that stuff is delicious!) but is otherwise still human.
 			player.wings.type = Wings.BAT_LIKE_LARGE;
 			player.tail.type = Tail.DEMONIC;
+			flags[kFLAGS.HISTORY_PERK_SELECTED] = 0;
 			//I feel really weird talking about all this, so if there's anything you need to change or can't do, or if I totally misinterpreted this, just shoot me an email! jordie.wierenga@gmail.com . Thanks in advance... I'm a big fan. "	Prismere
 		}
 		
@@ -1128,6 +1131,7 @@ package classes
 			player.thickness = 25;
 			player.tone = 65;
 			player.tallness = 65;
+			player.createPerk(PerkLib.HistorySlacker, 0, 0, 0, 0);
 		}
 		
 		private function customRope():void {

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -939,6 +939,16 @@ package classes
 		}
 		return perk(counter).value4;
 	}
+
+	public function hasHistoryPerk():Boolean
+	{
+		for each (var p:Object in PerkLists.HISTORY) {
+			if (hasPerk(p.perk)) {
+				return true;
+			}
+		}
+		return false;
+	}
 		
 		/*
 		

--- a/classes/classes/lists/PerkLists.as
+++ b/classes/classes/lists/PerkLists.as
@@ -43,5 +43,40 @@ package classes.lists
 			PerkLib.FutaForm,
 			PerkLib.FutaFaculties,
 		];
+
+		public static const HISTORY:Array = [
+			{ text: "Alchemy",   perk: PerkLib.HistoryAlchemist },
+			{ text: "Fighting",  perk: PerkLib.HistoryFighter },
+			{ text: "Fortune",   perk: PerkLib.HistoryFortune },
+			{ text: "Healing",   perk: PerkLib.HistoryHealer },
+			{ text: "Religion",  perk: PerkLib.HistoryReligious },
+			{ text: "Schooling", perk: PerkLib.HistoryScholar },
+			{ text: "Slacking",  perk: PerkLib.HistorySlacker },
+			{ text: "Slutting",  perk: PerkLib.HistorySlut },
+			{ text: "Smithing",  perk: PerkLib.HistorySmith },
+			{ text: "Whoring",   perk: PerkLib.HistoryWhore },
+		];
+
+		public static const ENDOWMENT_ATTRIBUTE:Array = [
+			{ text: "Strong",     perk: PerkLib.Strong },
+			{ text: "Tough",      perk: PerkLib.Tough },
+			{ text: "Fast",       perk: PerkLib.Fast },
+			{ text: "Smarts",     perk: PerkLib.Smart },
+			{ text: "Libido",     perk: PerkLib.Lusty },
+			{ text: "Touch",      perk: PerkLib.Sensitive },
+			{ text: "Perversion", perk: PerkLib.Pervert },
+		];
+
+		public static const ENDOWMENT_COCK:Array = [
+			{ text: "Big Cock",     perk: PerkLib.BigCock },
+			{ text: "Lots of Jizz", perk: PerkLib.MessyOrgasms },
+		];
+
+		public static const ENDOWMENT_VAGINA:Array = [
+			{ text: "Big Breasts", perk: PerkLib.BigTits },
+			{ text: "Big Clit",    perk: PerkLib.BigClit },
+			{ text: "Fertile",     perk: PerkLib.Fertile },
+			{ text: "Wet Vagina",  perk: PerkLib.WetPussy },
+		];
 	}
 }


### PR DESCRIPTION
There were a few custom chars remaining that either had no history perk
or didn't get to choose one during char creation or in the camp menu.

I've also changed `CharSpecialTest.as` to check all custom chars for a
missing history perk, so adding more customs won't be trial&error.