### PR TITLE
Paws 'n' claws

### DIFF
--- a/classes/classes/Appearance.as
+++ b/classes/classes/Appearance.as
@@ -1905,7 +1905,7 @@ package classes {
 						case Claws.SALAMANDER:
 						case Claws.CAT:
 						case Claws.DOG:
-						case Claws.RAPTOR:
+						case Claws.FOX:
 						case Claws.IMP:
 						case Claws.RED_PANDA:
 						default:

--- a/classes/classes/BodyParts/Arms.as
+++ b/classes/classes/BodyParts/Arms.as
@@ -19,6 +19,9 @@ package classes.BodyParts
 		public static const COCKATRICE:int =   7;
 		public static const RED_PANDA:int  =   8;
 		public static const FERRET:int     =   9;
+		public static const CAT:int        =  10;
+		public static const DOG:int        =  11;
+		public static const FOX:int        =  12;
 
 		private var _creature:Creature;
 		public var type:Number = HUMAN;
@@ -39,6 +42,9 @@ package classes.BodyParts
 				case COCKATRICE: updateClaws(Claws.COCKATRICE); break;
 				case RED_PANDA:  updateClaws(Claws.RED_PANDA);  break;
 				case FERRET:     updateClaws(Claws.FERRET);     break;
+				case CAT:        updateClaws(Claws.CAT);        break;
+				case DOG:        updateClaws(Claws.DOG);        break;
+				case FOX:        updateClaws(Claws.FOX);        break;
 
 				case HUMAN:
 				case HARPY:

--- a/classes/classes/BodyParts/Claws.as
+++ b/classes/classes/BodyParts/Claws.as
@@ -11,9 +11,9 @@ package classes.BodyParts
 		public static const LIZARD:int     =   1;
 		public static const DRAGON:int     =   2;
 		public static const SALAMANDER:int =   3;
-		public static const CAT:int        =   4; // NYI! Placeholder for now!!
-		public static const DOG:int        =   5; // NYI! Placeholder for now!!
-		public static const RAPTOR:int     =   6; // NYI! Placeholder for now!!
+		public static const CAT:int        =   4;
+		public static const DOG:int        =   5;
+		public static const FOX:int        =   6;
 		public static const MANTIS:int     =   7; // NYI! Placeholder for Xianxia mod
 		public static const IMP:int        =   8;
 		public static const COCKATRICE:int =   9;

--- a/classes/classes/CharSpecial.as
+++ b/classes/classes/CharSpecial.as
@@ -1634,7 +1634,7 @@ package classes
 			
 			player.face.type = Face.FOX;
 			player.ears.type = Ears.FOX;
-			player.arms.claws.type = Claws.DOG;
+			player.arms.setType(Arms.FOX);
 			player.arms.claws.tone = "ivory";
 			player.eyes.type = Eyes.DRAGON;
 			player.lowerBody.type = LowerBody.FOX;
@@ -1644,6 +1644,8 @@ package classes
 			player.horns.type = Horns.DRACONIC_X2; // draconic horns adds to your exotic look, counts towards dragon score and keeps your tentacle hair out of your face! and your partners can use them as handles on occasions, letting your delicate ears uncrumpled!
 			player.horns.value = 8;
 			player.wings.type = Wings.DRACONIC_LARGE; // wings! to fly!
+			player.wings.color = "snow white";
+			player.wings.color2 = "snow white";
 			
 			player.str += -10; // strength? not a kitsune way, besides, you are small and really neglected physical training
 			player.tou += 0; // still, your dragon blood makes you surprisingly tough for your size and condition

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -2940,9 +2940,12 @@ package classes
 
 			switch (arms.claws.type) {
 				case Claws.NORMAL: return "fingernails";
-				case Claws.LIZARD: return "short curved" + toneText + "claws";
 				case Claws.DRAGON: return "powerful, thick curved" + toneText + "claws";
 				case Claws.IMP:    return "long" + toneText + "claws";
+				case Claws.CAT:    return "long, thin curved" + toneText + "claws";
+				case Claws.LIZARD:
+				case Claws.DOG:
+				case Claws.FOX:    return "short curved" + toneText + "claws";
 				default: // Since mander and cockatrice arms are hardcoded and the others are NYI, we're done here for now
 			}
 			return "fingernails";

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -2738,6 +2738,11 @@ package classes
 			return [Face.BEAK, Face.COCKATRICE].indexOf(face.type) != -1;
 		}
 
+		public function hasClaws():Boolean
+		{
+			return arms.claws.type !== Claws.NORMAL;
+		}
+
 		public function hasGills():Boolean
 		{
 			return gills.type != Gills.NONE;

--- a/classes/classes/DebugMenu.as
+++ b/classes/classes/DebugMenu.as
@@ -1200,7 +1200,7 @@ package classes
 			[Claws.SALAMANDER,"(3) SALAMANDER"],
 			[Claws.CAT,"(4) CAT"],
 			[Claws.DOG,"(5) DOG"],
-			[Claws.RAPTOR,"(6) RAPTOR"],
+			[Claws.FOX,"(6) FOX"],
 			[Claws.MANTIS,"(7) MANTIS"],
 		];
 		private static const TAIL_TYPE_CONSTANTS:Array  = [

--- a/classes/classes/Items/Consumables/CaninePepper.as
+++ b/classes/classes/Items/Consumables/CaninePepper.as
@@ -156,8 +156,6 @@ package classes.Items.Consumables
 			if (player.hasNonSharkRearBody() && changes < changeLimit && rand(5) === 0) mutations.restoreRearBody(tfSource);
 			//Ovi perk loss
 			if (rand(5) === 0) mutations.updateOvipositionPerk(tfSource);
-			//Restore arms to become human arms again
-			if (rand(4) === 0) mutations.restoreArms(tfSource);
 			//Remove feathery hair
 			mutations.removeFeatheryHair();
 			//if (type !== 2 && type !== 4 && type !== 5) outputText("\n");
@@ -723,6 +721,20 @@ package classes.Items.Consumables
 				changes++;
 				player.tail.type = Tail.DOG;
 				outputText("<b>You now have a dog-tail.</b>");
+			}
+			//Arms
+			if (player.arms.type !== Arms.DOG && player.isFurry() && player.tail.type === Tail.DOG && player.lowerBody.type === LowerBody.DOG && rand(4) === 0 && changes < changeLimit)
+			{
+				outputText("\n\nWeakness overcomes your arms, and no matter what you do, you can’t muster the strength to raise or move them."
+				          +" Did the pepper have some drug-like effects? Sitting on the ground, you wait for the limpness to end."
+				          +" As you do so, you realize that the bones at your hands are changing, as well as the muscles on your arms."
+				          +" They’re soon covered, from the shoulders to the tip of your digits, on a layer of soft,"
+				          +" fluffy [if (hasFurryUnderBody)[underBody.furColor]|[furColor]] fur."
+				          +" Your hands gain pink, padded paws where your palms were once, and your nails become short claws,"
+				          +" not sharp enough to tear flesh, but nimble enough to make climbing and exploring easier."
+				          +" <b>Your arms have become like those of a dog!</b>");
+				player.arms.setType(Arms.DOG);
+				changes++;
 			}
 			// Remove gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) mutations.updateGills();

--- a/classes/classes/Items/Consumables/FoxBerry.as
+++ b/classes/classes/Items/Consumables/FoxBerry.as
@@ -377,6 +377,20 @@ package classes.Items.Consumables
 				changes++;
 				player.face.type = Face.FOX;
 			}
+			//Arms
+			if (player.arms.type !== Arms.FOX && player.isFurry() && player.tail.type === Tail.FOX && player.lowerBody.type === LowerBody.FOX && rand(4) === 0 && changes < changeLimit)
+			{
+				outputText("\n\nWeakness overcomes your arms, and no matter what you do, you can’t muster the strength to raise or move them."
+				          +" Did the berry have some drug-like effects? Sitting on the ground, you wait for the limpness to end."
+				          +" As you do so, you realize that the bones at your hands are changing, as well as the muscles on your arms."
+				          +" They’re soon covered, from the shoulders to the tip of your digits, on a layer of soft,"
+				          +" fluffy [if (hasFurryUnderBody)[underBody.furColor]|[furColor]] fur. Your hands gain pink,"
+				          +" padded paws where your palms were once, and your nails become short claws, not sharp enough to tear flesh,"
+				          +" but nimble enough to make climbing and exploring easier."
+				          +" <b>Your arms have become like those of a fox!</b>");
+				player.arms.setType(Arms.FOX);
+				changes++;
+			}
 			if (player.tone > 40 && changes < changeLimit && rand(2) === 0) {
 				outputText("\n\nMoving brings with it a little more jiggle than you're used to.  You don't seem to have gained weight, but your muscles seem less visible, and various parts of you are pleasantly softer.");
 				player.tone -= 4;

--- a/classes/classes/Items/Consumables/WhiskerFruit.as
+++ b/classes/classes/Items/Consumables/WhiskerFruit.as
@@ -302,6 +302,20 @@ package classes.Items.Consumables
 				player.face.type = Face.CAT;
 				changes++;
 			}
+			//Arms
+			if (player.arms.type !== Arms.CAT && player.isFurry() && player.tail.type === Tail.CAT && player.lowerBody.type === LowerBody.CAT && rand(4) === 0 && changes < changeLimit)
+			{
+				outputText("\n\nWeakness overcomes your arms, and no matter what you do, you can’t muster the strength to raise or move them."
+				          +" Did the fruit have some drug-like effects? Sitting on the ground, you wait for the limpness to end."
+				          +" As you do so, you realize that the bones at your hands are changing, as well as the muscles on your arms."
+				          +" They’re soon covered, from the shoulders to the tip of your digits, on a layer of soft,"
+				          +" fluffy [if (hasFurryUnderBody)[underBody.furColor]|[furColor]] fur. Your hands gain pink,"
+				          +" padded paws where your palms were once, and your nails become long, thin, curved claws,"
+				          +" sharp enough to tear flesh and nimble enough to make climbing and exploring easier."
+				          +" <b>Your arms have become like those of a cat!</b>");
+				player.arms.setType(Arms.CAT);
+				changes++;
+			}
 			// Remove gills
 			if (rand(4) === 0 && player.hasGills() && changes < changeLimit) {
 				mutations.updateGills();

--- a/classes/classes/Parser/Parser.as
+++ b/classes/classes/Parser/Parser.as
@@ -1065,7 +1065,7 @@ package classes.Parser
 
 			var ret:String = "";
 			// Run through the parser
-			contents = contents.replace(/\\n/g, "\n")
+			contents = contents.replace(/\r\n?|\\n/g, "\n")
 			ret = recParser(contents, 0);
 			if (printIntermediateParseStateDebug) LOGGER.warn("WARNING: Parser intermediate contents = ", ret)
 			// Currently, not parsing text as markdown by default because it's fucking with the line-endings.

--- a/classes/classes/Parser/conditionalConverters.as
+++ b/classes/classes/Parser/conditionalConverters.as
@@ -55,6 +55,7 @@
 				"hascock"			: function():* {return  kGAMECLASS.player.hasCock();},
 				"hassheath"			: function():* {return  kGAMECLASS.player.hasSheath();},
 				"hasbeak"			: function():* {return  kGAMECLASS.player.hasBeak();},
+				"hasclaws"			: function():* {return  kGAMECLASS.player.hasClaws();},
 				"hasdragonneck"		: function():* {return  kGAMECLASS.player.hasDragonNeck();},
 				"hastail"			: function():* {return  kGAMECLASS.player.hasTail();},
 				"neckpos"			: function():* {return  kGAMECLASS.player.neck.pos;},

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1361,6 +1361,8 @@
 				dogCounter++;
 			if (lowerBody.type == LowerBody.DOG)
 				dogCounter++;
+			if (arms.type == Arms.DOG)
+				dogCounter++;
 			if (dogCocks() > 0)
 				dogCounter++;
 			//Fur only counts if some canine features are present
@@ -1433,6 +1435,8 @@
 				foxCounter++;
 			if (lowerBody.type == LowerBody.FOX)
 				foxCounter++;
+			if (arms.type == Arms.FOX)
+				foxCounter++;
 			if (dogCocks() > 0 && foxCounter > 0)
 				foxCounter++;
 			if (breastRows.length > 1 && foxCounter > 0)
@@ -1458,6 +1462,8 @@
 			if (tail.type == Tail.CAT)
 				catCounter++;
 			if (lowerBody.type == LowerBody.CAT)
+				catCounter++;
+			if (arms.type == Arms.CAT)
 				catCounter++;
 			if (countCocksOfType(CockTypesEnum.CAT) > 0)
 				catCounter++;

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -630,6 +630,18 @@ package classes
 					          +" [if (hasFurryUnderBody)[underBody.furColor]|brown-black] fur from elbows to paws."
 					          +" The latter have cute, pink paw pads and short claws.");
 					break;
+
+				case Arms.DOG:
+					outputText("  Soft, [hairOrFurColor] fluff covers your arms. Your paw-like hands have cute, pink paw pads and short claws."
+					          +" They should assist you walking on all [if (isTaur)sixs|fours]"
+					          +" just like the hellhounds you saw lurking in the mountains.");
+					break;
+
+				case Arms.CAT:
+				case Arms.FOX:
+					outputText("  Soft, [hairOrFurColor] fluff covers your arms. Your paw-like hands have cute, pink paw pads and [claws].");
+					break;
+
 				default:
 					//Nothing here, move along!
 			}

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -159,6 +159,7 @@ package classes
 			dogPlayer.face.type = Face.DOG;
 			dogPlayer.ears.type = Ears.DOG;
 			dogPlayer.tail.type = Tail.DOG;
+			dogPlayer.arms.setType(Arms.DOG);
 			dogPlayer.lowerBody.type = LowerBody.DOG;
 			dogPlayer.skin.type = Skin.FUR;
 
@@ -430,6 +431,7 @@ package classes
 			foxPlayer.ears.type = Ears.FOX;
 			foxPlayer.tail.type = Tail.FOX;
 			foxPlayer.lowerBody.type = LowerBody.FOX;
+			foxPlayer.arms.setType(Arms.FOX);
 			foxPlayer.skin.type = Skin.FUR;
 
 			assertThat(foxPlayer.foxScore(), greaterThan(0));
@@ -446,6 +448,7 @@ package classes
 			catPlayer.ears.type = Ears.CAT;
 			catPlayer.tail.type = Tail.CAT;
 			catPlayer.lowerBody.type = LowerBody.CAT;
+			catPlayer.arms.setType(Arms.CAT);
 			catPlayer.skin.type = Skin.FUR;
 
 			assertThat(catPlayer.catScore(), greaterThan(0));


### PR DESCRIPTION
### Gameplay changes
Made the furries (dogs, cats and foxes) even furrier by giving them paws aka paw-like hands with claws.
All three new arm types now add one extra point to the corresponding race score.
See the GDoc [CoC: Paws 'n' Claws](https://docs.google.com/document/d/1WL0rmjWSlLiVv4q91yWLBMJBYAhaRYGgjkDDs3mmdgY/edit#) for the TF and appearance blurbs.

### Internal changes
- Updated the unit test `PlayerTest.as` to include the arm type in the tests for `dogScore`, `catScore` and `foxScore`.
- Replaced the NYI clawType `Claws.RAPTOR` with `Claws.FOX`.

### Notes
@Netys: I guessed, that the intention for your OC (Custom character Etis) was to give him fox arms with fox claws. See the diff below:

```diff  
diff --git a/classes/classes/CharSpecial.as b/classes/classes/CharSpecial.as
index 21153b48e..6cd8e765d 100644
--- a/classes/classes/CharSpecial.as
+++ b/classes/classes/CharSpecial.as
@@ -1634,7 +1634,7 @@ package classes
 			
 			player.face.type = Face.FOX;
 			player.ears.type = Ears.FOX;
-			player.arms.claws.type = Claws.DOG;
+			player.arms.setType(Arms.FOX);
 			player.arms.claws.tone = "ivory";
 			player.eyes.type = Eyes.DRAGON;
 			player.lowerBody.type = LowerBody.FOX;
```

The appearance blurb for the arms of your OC is now:
> Soft, snow white fluff covers your arms. Your paw-like hands have cute, pink paw pads and short curved, ivory claws.

Since dragon wings are now colorable I've set the two wing colors to 'snow white'.
The appearance blurb for the wings of your OC is now:
> Magnificent wings sprout from your shoulders. When unfurled they stretch further than your arm span, and a single beat of them is all you need to set out toward the sky. They look a bit like bat wings, but the membranes are covered in fine, delicate snow white scales supported by snow white bones. A wicked talon juts from the end of each bone.

If you have any objections or suggestions, just tell me and I'll fix that ASAP.