### PR TITLE
Fix truncated report dump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,9 @@ after_success:
   - sonar-scanner
 
 # If the build fails, pack up the unit test reports - if any - and dump them to the console
+# The sleep is required for Travis to flush the log, otherwise the encoded dump will be cut off
 after_failure:
-  - devTools/ci/dump-report.sh
+  - devTools/ci/dump-report.sh && sleep 10
 
 env:
   global:


### PR DESCRIPTION
Give Travis CI time to flush the dump to the log.

Otherwise the instance seems to terminate before the full report dump can be written to the log, making it useless.

This issue was introduced by using  `travis_wait` for the build, which in turn is needed because the unit test only prints the results after it is done, or if there are test failures  or errors.

Due to this, the build can go for over 10 minutes without log output, causing Travis to flag the build as *stalled*, terminating the instance and failing the build.