### PR TITLE
Various Jojo fixes

### DIFF
--- a/classes/classes/DebugMenu.as
+++ b/classes/classes/DebugMenu.as
@@ -1525,7 +1525,7 @@ package classes
 			outputText("Which NPC would you like to reset?");
 			menu();
 			if (flags[kFLAGS.URTA_COMFORTABLE_WITH_OWN_BODY] < 0 || flags[kFLAGS.URTA_QUEST_STATUS] == -1) addButton(0, "Urta", resetUrta);
-			if (flags[kFLAGS.JOJO_STATUS] >= 5 || flags[kFLAGS.JOJO_DEAD_OR_GONE] > 0) addButton(1, "Jojo", resetJojo);
+			if (getGame().jojoScene.isJojoCorrupted() || flags[kFLAGS.JOJO_DEAD_OR_GONE] > 0) addButton(1, "Jojo", resetJojo);
 			if (flags[kFLAGS.EGG_BROKEN] > 0) addButton(2, "Ember", resetEmber);
 			if (flags[kFLAGS.SHEILA_DISABLED] > 0 || flags[kFLAGS.SHEILA_DEMON] > 0 || flags[kFLAGS.SHEILA_CITE] < 0 || flags[kFLAGS.SHEILA_CITE] >= 6) addButton(6, "Sheila", resetSheila);
 			

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -5,6 +5,7 @@
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Items.*;
+	import classes.Scenes.NPCs.Jojo;
 	import classes.internals.LoggerFactory;
 	import classes.internals.SerializationUtils;
 	import classes.lists.BreastCup;
@@ -965,6 +966,8 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.cocks = SerializationUtils.serializeVector(player.cocks as Vector.<*>);
 		saveFile.data.vaginas = SerializationUtils.serializeVector(player.vaginas as Vector.<*>);
 		
+		saveNPCs(saveFile);
+		
 		//NIPPLES
 		saveFile.data.nippleLength = player.nippleLength;
 		//Set Breast Array
@@ -1259,6 +1262,20 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		addButton(9, "Restore", restore, slot);
 	}
 	
+}
+
+/**
+ * Save NPCs to the save file. The NPC data is placed in the 'npcs' object (saveFile.data.npcs).
+ * This method is protected instead of private to allow for testing.
+ * @param	saveFile the file to save the NPC data to.
+ */
+protected function saveNPCs(saveFile:*): void {
+	saveFile.data.npcs = [];
+	var npcs:* = saveFile.data.npcs;
+	
+	npcs.jojo = [];
+	
+	SerializationUtils.serialize(npcs.jojo, new Jojo());
 }
 
 public function restore(slotName:String):void
@@ -1910,6 +1927,8 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		player.vaginas = new Vector.<VaginaClass>();
 		SerializationUtils.deserializeVector(player.vaginas as Vector.<*>, saveFile.data.vaginas, VaginaClass);
 		
+		loadNPCs(saveFile);
+		
 		if (player.hasVagina() && player.vaginaType() != 5 && player.vaginaType() != 0)
 			player.vaginaType(0);
 		
@@ -2317,6 +2336,27 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		}
 		doNext(playerMenu);
 	}
+}
+
+/**
+ * Load NPCs from the save file. The NPC data is loaded from the 'npcs' object (saveFile.data.npcs).
+ * Creates empty dummy structure if the NPC data is missing, to avoid errors on loading.
+ * This method is protected instead of private to allow for testing.
+ * @param	saveFile the file to save the NPC data to.
+ */
+protected function loadNPCs(saveFile:*):void 
+{
+	var npcs:* = saveFile.data.npcs;
+	//TODO change safeFile structure with versioning of the saveFile itself.
+	if (npcs === undefined) {
+		npcs = [];
+	}
+	
+	if (npcs.jojo === undefined) {
+		npcs.jojo = [];
+	}
+	
+	SerializationUtils.deserialize(npcs.jojo, new Jojo());
 }
 
 public function unFuckSave():void

--- a/classes/classes/Scenes/Dungeons/DesertCave.as
+++ b/classes/classes/Scenes/Dungeons/DesertCave.as
@@ -2392,7 +2392,7 @@ package classes.Scenes.Dungeons
 			outputText("\n\nSuddenly, the Queen jerks up, looking you in the eye with her strange, white-irised gaze.");
 			//(No new PG.  Corrupt version)
 			if (!player.isPureEnough(100 - player.inte100)
-				|| flags[kFLAGS.JOJO_STATUS] >= 5
+				|| getGame().jojoScene.isJojoCorrupted()
 				|| player.hasStatusEffect(StatusEffects.Exgartuan)
 				|| kGAMECLASS.amilyScene.amilyCorrupt()
 				|| flags[kFLAGS.SOPHIE_DISABLED_FOREVER] > 0

--- a/classes/classes/Scenes/Masturbation.as
+++ b/classes/classes/Scenes/Masturbation.as
@@ -2032,7 +2032,7 @@ package classes.Scenes {
 					//(+sensitivity by 3 & intellect -2 & libido +1	)
 				}
 				//Option Jojo veyeurism?
-				if (flags[kFLAGS.JOJO_STATUS] >= 5 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) {
+				if (getGame().jojoScene.isJojoCorrupted() && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) {
 					outputText("\n\nAs you stand and try to clean up you manage to spot Jojo off in the woods, ");
 					if (player.hasStatusEffect(StatusEffects.TentacleJojo))
 						outputText("his tentacles splattering mouse-jizz everywhere as he gets off from your show.");

--- a/classes/classes/Scenes/NPCs/AmilyScene.as
+++ b/classes/classes/Scenes/NPCs/AmilyScene.as
@@ -4660,7 +4660,7 @@ package classes.Scenes.NPCs
 
 			outputText("\"<i>Torturing myself you say? I think you're right. Maybe I should see if ");
 			//[(if Jojo's corrupt)
-			if (flags[kFLAGS.JOJO_STATUS] >= 5 && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) outputText("Jojo wants to play,");
+			if (getGame().jojoScene.isJojoCorrupted() && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) outputText("Jojo wants to play,");
 			//(else)
 			else outputText("I can't find someone else to play with,");
 			outputText("</i>\" you say, nonchalantly attempting to pull away from her. \"<i>No!</i>\" Amily screams; her legs tighten about your waist with such force that she actually lifts herself off of the ground in her eagerness to plant herself firmly against your crotch, rubbing her slavering pussy against you. \"<i>Mine! My fuck! Mine!</i>\" she squeaks indignantly. You laugh at how far you've pushed your little mouse slave.  Sliding your " + player.cockDescript(0) + " against her pussy, you bend down and grope her breasts roughly, drawing a desperate moan from her; slowly you get closer to her ears, then whisper, \"<i>Go ahead,</i>\" while humping against her to further excite her.\n\n");

--- a/classes/classes/Scenes/NPCs/CeraphScene.as
+++ b/classes/classes/Scenes/NPCs/CeraphScene.as
@@ -93,7 +93,7 @@ package classes.Scenes.NPCs
 			spriteSelect(SpriteDb.s_ceraph);
 			clearOutput();
 			//UBER-Fullbodypenetration
-			if (!player.isTaur() && player.biggestCockArea() > 500 && (player.statusEffectv1(StatusEffects.Exgartuan) == 1 || flags[kFLAGS.JOJO_STATUS] >= 5)) {
+			if (!player.isTaur() && player.biggestCockArea() > 500 && (player.statusEffectv1(StatusEffects.Exgartuan) == 1 || getGame().jojoScene.isJojoCorrupted())) {
 				hugeCorruptionForceFuckCeraph();
 				return;
 			}

--- a/classes/classes/Scenes/NPCs/Exgartuan.as
+++ b/classes/classes/Scenes/NPCs/Exgartuan.as
@@ -941,7 +941,7 @@ private function exgartuanSleepSurprise():void {
 		outputText("  Liquid-hot pressure slides over the underside of your " + player.cockDescript(0) + ", licking wetly at the pulsating, need-filled demon-prick.  Your rogue tongue's attentions have the desired effect, and the cries of your pleasure are muffled by your own thick flesh and its rapidly distending urethra.\n\n");
 		
 		outputText("If someone were watching");
-		if (flags[kFLAGS.JOJO_STATUS] >= 5 && !player.hasStatusEffect(StatusEffects.NoJojo) && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) outputText(", and judging by Jojo's high pitched whines, he certainly is,");
+		if (jojoScene.campCorruptJojo()) outputText(", and judging by Jojo's high pitched whines, he certainly is,");
 		outputText(" they'd see dick-flesh bulging with a heavy load as it's pumped into your lips.  The fully-inflated cum-tube distends your mouth, stretching your jaw painfully, and dumps its creamy cargo into its willing receptacle.  Your belly burbles as it adjusts to the ");
 		temp = player.cumQ();
 		if (temp < 50) outputText("surprisingly light");
@@ -964,7 +964,7 @@ private function exgartuanSleepSurprise():void {
 		}
 		outputText("\n\n");
 		
-		if (flags[kFLAGS.JOJO_STATUS] >= 5 && !player.hasStatusEffect(StatusEffects.NoJojo) && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) {
+		if (jojoScene.campCorruptJojo()) {
 			outputText("The splatter of mouse-cum erupting in the wood reaches your ears, bringing a wistful smile to your face.  That slutty mouse is such a peeping tom!  ");
 		}
 		outputText("Your eyes slowly roll back down while Exgartuan deflates, leaving a trail of pleased, white submission ");

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -4,10 +4,16 @@
 	import classes.BodyParts.*;
 	import classes.BodyParts.Butt;
 	import classes.GlobalFlags.*;
+	import classes.internals.LoggerFactory;
+	import classes.internals.Serializable;
+	import mx.logging.ILogger;
 
-	public class Jojo extends Monster
+	public class Jojo extends Monster implements Serializable
 	{
+		private static const LOGGER:ILogger = LoggerFactory.getLogger(Jojo);
 
+		private static const SERIALIZATION_VERSION:int = 1;
+		
 		override public function defeated(hpVictory:Boolean):void
 		{
 			game.jojoScene.defeatedJojo(hpVictory);
@@ -122,6 +128,34 @@ if (lust >= maxLust()) {
 			}
 			this.drop = NO_DROP;
 			checkMonster();
+		}
+		
+		public function serialize(relativeRootObject:*):void 
+		{
+			
+		}
+		
+		public function deserialize(relativeRootObject:*):void 
+		{
+			
+		}
+		
+		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
+		{
+			switch(serializedDataVersion) {
+				case 0:
+					LOGGER.debug("Converting jojo from legacy save");
+					
+					if (flags[kFLAGS.JOJO_STATUS] === 5) {
+						LOGGER.info("Correcting jojo status (slave status is now 6)");
+						flags[kFLAGS.JOJO_STATUS] = 6;
+					}
+			}
+		}
+		
+		public function currentSerializationVerison():int 
+		{
+			return SERIALIZATION_VERSION;
 		}
 
 	}

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -97,7 +97,7 @@ if (lust >= maxLust()) {
 			this.hair.color = "white";
 			this.hair.length = 2;
 			initStrTouSpeInte(35, 40, 65, 55);
-			initLibSensCor(15, 40, flags[kFLAGS.JOJO_STATUS] * 15);
+
 			this.weaponName = "paw";
 			this.weaponVerb="punch";
 			this.armorName = "robes";
@@ -107,20 +107,41 @@ if (lust >= maxLust()) {
 			this.level = 4;
 			this.gems = rand(5) + 2;
 			this.special1 = selfCorruption;
-			//Create jojo sex attributes
-			//Variations based on jojo's corruption.
+
+			corruptionBasedStats();
+			
+			this.drop = NO_DROP;
+			checkMonster();
+		}
+		
+		/**
+		 * Modifies Jojo's attributes based on how corrupted he is.
+		 */
+		private function corruptionBasedStats(): void {
+			//FIXME Anal looseness is based on the PC at construction - not when the PC raped jojo
+			
+			initLibSensCor(15, 40, flags[kFLAGS.JOJO_STATUS] * 15);
+			
 			if (flags[kFLAGS.JOJO_STATUS] == 3) {
 				this.lust += 30;
 				this.cocks[0].cockThickness += .2;
 				this.cocks[0].cockLength += 1.5;
-				if (player.gender == 1 || player.gender == 3) this.ass.analLooseness = 2;
+				
+				if (player.gender == 1 || player.gender == 3) {
+					this.ass.analLooseness = 2;
+				}
 			}
+			
 			if (flags[kFLAGS.JOJO_STATUS] == 4) {
 				this.lust += 40;
 				this.cocks[0].cockThickness += .5;
 				this.cocks[0].cockLength += 3.5;
-				if (player.gender == 1 || player.gender == 3) this.ass.analLooseness = 3;
+				
+				if (player.gender == 1 || player.gender == 3) {
+					this.ass.analLooseness = 3;
+				}
 			}
+			
 			if (flags[kFLAGS.JOJO_STATUS] >= 5) {
 				this.lust += 50;
 				this.cocks[0].cockThickness += 1;
@@ -129,11 +150,13 @@ if (lust >= maxLust()) {
 				this.tou += 30;
 				this.cor += 10;
 				this.HP += 60;
-				if (player.gender == 1 || player.gender == 3) this.ass.analLooseness = 4;
+				
+				if (player.gender == 1 || player.gender == 3) {
+					this.ass.analLooseness = 4;
+				}
+				
 				this.long = "Jojo is an anthropomorphic mouse with immaculate white fur.  Though he stands only four feet tall, he is covered in lean muscle and moves with incredible speed.  He's naked, with a large tainted throbbing member bouncing at attention.  A fuzzy sack with painfully large looking balls dangles between his legs.";
 			}
-			this.drop = NO_DROP;
-			checkMonster();
 		}
 		
 		public function serialize(relativeRootObject:*):void 

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -115,7 +115,7 @@ if (lust >= maxLust()) {
 				this.cocks[0].cockLength += 3.5;
 				if (player.gender == 1 || player.gender == 3) this.ass.analLooseness = 3;
 			}
-			if (flags[kFLAGS.JOJO_STATUS] == 5) {
+			if (flags[kFLAGS.JOJO_STATUS] >= 5) {
 				this.lust += 50;
 				this.cocks[0].cockThickness += 1;
 				this.cocks[0].cockLength += 5.5;

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -64,15 +64,21 @@ if (lust >= maxLust()) {
 			doNext(game.playerMenu);
 		}
 		
-		public function Jojo()
+		public function Jojo() {
+			this.init();
+		}
+		
+		/**
+		 * This function initializes the class.
+		 * This is done to keep the constructor as light weight as possible, as it is interpreted each time, instead of compiled.
+		 */
+		public function init(): void 
 		{
-			//trace("Jojo Constructor!");
 			this.a = "";
 			this.short = "Jojo";
 			this.imageName = "jojo";
 			this.long = "Jojo is an anthropomorphic mouse with immaculate white fur.  Though he stands only four feet tall, he is covered in lean muscle and moves with incredible speed.  He wears loose white clothes wrapped in prayer beads and tattered prayer papers.";
 			this.race = "Mouse-Morph";
-			// this.plural = false;
 			this.createCock(7.5, 1.8);
 			this.cocks[0].cockType = CockTypesEnum.HUMAN;
 			this.balls = 2;

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -179,6 +179,12 @@ if (lust >= maxLust()) {
 						LOGGER.info("Correcting jojo status (slave status is now 6)");
 						flags[kFLAGS.JOJO_STATUS] = 6;
 					}
+					
+				default:
+					/*
+					 * The default block is left empty intentionally,
+					 * this switch case operates by using fall through behavior.
+					 */
 			}
 		}
 		

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -67,7 +67,8 @@ if (lust >= maxLust()) {
 			this.long = "Jojo is an anthropomorphic mouse with immaculate white fur.  Though he stands only four feet tall, he is covered in lean muscle and moves with incredible speed.  He wears loose white clothes wrapped in prayer beads and tattered prayer papers.";
 			this.race = "Mouse-Morph";
 			// this.plural = false;
-			this.createCock(7.5,1.8);
+			this.createCock(7.5, 1.8);
+			this.cocks[0].cockType = CockTypesEnum.HUMAN;
 			this.balls = 2;
 			this.ballSize = 1;
 			this.cumMultiplier = 1;

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -45,7 +45,7 @@
 					lust += 10;
 					break;
 				default:
-					outputText("Jojo frantically jerks his " + player.cockDescriptShort(0) + ", stroking the " + player.cockDescriptShort(0) + " as it leaks pre-cum at the sight of you.  ");
+					outputText("Jojo frantically jerks his " + this.cockDescriptShort(0) + ", stroking the " + this.cockDescriptShort(0) + " as it leaks pre-cum at the sight of you.  ");
 					lust += 15;
 			}
 

--- a/classes/classes/Scenes/NPCs/JojoScene.as
+++ b/classes/classes/Scenes/NPCs/JojoScene.as
@@ -10,7 +10,11 @@
 	import classes.internals.*;
 
 	public class JojoScene extends NPCAwareContent implements TimeAwareInterface {
-
+		/**
+		 * If jojo's status reaches this, he is now the PCs slave.
+		 */
+		public static const JOJO_FULL_CORRUPTION_STATUS:int = 6;
+		
 		public var pregnancy:PregnancyStore;
 
 		public function JojoScene(pregnancyProgression:PregnancyProgression, output:GuiOutput)
@@ -130,7 +134,16 @@ public function tentacleJojo():Boolean {
 
 }
 override public function campCorruptJojo():Boolean {
-	return flags[kFLAGS.JOJO_STATUS] >= 6 && !player.hasStatusEffect(StatusEffects.NoJojo) && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0;
+	return isJojoCorrupted() && !player.hasStatusEffect(StatusEffects.NoJojo) && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0;
+}
+
+/**
+ * Has the PC completly corrupted jojo (jojo as slave)?
+ * <b>Note:</b> Based soley on NPC status, other flags and status effects are not checked. Used for legacy code.
+ * @return true if jojo is corrupted
+ */
+public function isJojoCorrupted(): Boolean {
+	return flags[kFLAGS.JOJO_STATUS] >= JOJO_FULL_CORRUPTION_STATUS;
 }
 
 private function jojoMutationOffer():void {

--- a/classes/classes/Scenes/NPCs/JojoScene.as
+++ b/classes/classes/Scenes/NPCs/JojoScene.as
@@ -130,7 +130,7 @@ public function tentacleJojo():Boolean {
 
 }
 override public function campCorruptJojo():Boolean {
-	return flags[kFLAGS.JOJO_STATUS] >= 5 && !player.hasStatusEffect(StatusEffects.NoJojo) && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0;
+	return flags[kFLAGS.JOJO_STATUS] >= 6 && !player.hasStatusEffect(StatusEffects.NoJojo) && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0;
 }
 
 private function jojoMutationOffer():void {
@@ -1596,6 +1596,8 @@ public function jojoFollowerMeditate():void {
 				outputText("When you're done you feel more clear-headed, but Jojo looks hornier than ever.");
 				dynStats("lib", -4);
 			}
+			
+			flags[kFLAGS.JOJO_STATUS] += 1;
 		}
 		
 		public function loseToJojo():void {

--- a/classes/classes/Scenes/NPCs/JojoScene.as
+++ b/classes/classes/Scenes/NPCs/JojoScene.as
@@ -1630,7 +1630,7 @@ public function jojoFollowerMeditate():void {
 						if (player.cockTotal() > 1) outputText("Your " + player.cockDescript(0) + " splatters the ground with cum repeatedly, until both your genders are raw and sore.  ");
 						else outputText("Your " + player.vaginaDescript(0) + " cums on him many more times it until it is sore and tender, dripping with spunk.  ");
 						outputText("You black out as Jojo cums AGAIN, forcing a river of spunk from your already over-filled uterus.");
-						player.cuntChange(monster.cocks[0].cockThickness, true);
+						player.cuntChange(monster.cockArea(0), true);
 						//Preggers chance!
 						player.knockUp(PregnancyStore.PREGNANCY_MOUSE, PregnancyStore.INCUBATION_MOUSE + 82, 101); //Jojo's kids take longer for some reason
 					}

--- a/classes/classes/Scenes/NPCs/KihaFollower.as
+++ b/classes/classes/Scenes/NPCs/KihaFollower.as
@@ -1418,7 +1418,7 @@ private function kihaPlaysWithBigassCocksFemDomAhoy():void {
 		else outputText("  You wonder what would happen if she got jumped by your tiger-shark children.");
 	}
 	outputText("[pg]Wiping up as best you can, you don your [armor] and walk back");
-	if (flags[kFLAGS.JOJO_STATUS] >= 5 && !player.hasStatusEffect(StatusEffects.NoJojo) && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0) {
+	if (jojoScene.campCorruptJojo()) {
 		if (!jojoScene.tentacleJojo()) outputText(", ignoring the sounds of Jojo feverishly masturbating in the woods");
 		else outputText(", ignoring the sound of Jojo vigorously fucking himself with all his tentacles in the trees");
 	}

--- a/classes/classes/Scenes/NPCs/SophieBimbo.as
+++ b/classes/classes/Scenes/NPCs/SophieBimbo.as
@@ -163,7 +163,7 @@ private function acceptBimboSophie():void {
 		if (flags[kFLAGS.AMILY_FOLLOWER] == 1) outputText("flushes hotly and denies the bimbo's request with a terse 'no'.");
 		else outputText("flushes hotly and wiggles her hips Sophie's way.  The slutty, corrupted mouse and Sophie will clearly be helping to sate each other's needs in your absence.");
 	}
-	else if (flags[kFLAGS.JOJO_STATUS] >= 5 && !player.hasStatusEffect(StatusEffects.NoJojo) && flags[kFLAGS.JOJO_DEAD_OR_GONE] == 0)
+	else if (jojoScene.campCorruptJojo())
 	{
 		outputText("  Afterwards, she offers to suck Jojo's cock.  The corrupted slut-mouse nods and stiffens in delight, though he keeps glancing back your way.  Those two will probably spend a lot of time together...");
 	}

--- a/classes/classes/Scenes/Places/TelAdre.as
+++ b/classes/classes/Scenes/Places/TelAdre.as
@@ -111,7 +111,7 @@ private function telAdreCrystal():void {
 		return;
 	}
 	//-50+ corruption or corrupted Jojo
-	else if (!player.isPureEnough(50) || flags[kFLAGS.JOJO_STATUS] >= 5) {
+	else if (!player.isPureEnough(50) || getGame().jojoScene.isJojoCorrupted()) {
 		outputText("The crystal pendant shimmers, vibrating in place and glowing a purple hue.  Edryn steps back, watching you warily, \"<i>You've been deeply touched by corruption.  You balance on a razor's edge between falling completely and returning to sanity.  You may enter, but we will watch you closely.</i>\"\n\n");
 	}
 	//-25+ corruption or corrupted Marae

--- a/classes/classes/Scenes/Places/TelAdre/Rubi.as
+++ b/classes/classes/Scenes/Places/TelAdre/Rubi.as
@@ -3656,7 +3656,11 @@ public function hypnoBimboficationForRubiSloots():void
 	outputText("\n\nRubi is watching you in open mouthed fascination. His lips move, stammering, trying to talk, but he just can't get the words out. It's no wonder, really - you've got your big, hard tool");
 	if (player.cockTotal() > 1) outputText("s");
 	outputText(" whipped out and swaying with your sinuous movements, and all he has is his comparatively undersized little pecker. You rock your whole body with the snake-like grace given to you by your naga body, swaying rhythmically as you meet his eyes. Knowing full well just what kinds of depravity you'd like to force him into, you feel a ");
-	if (flags[kFLAGS.JOJO_STATUS] >= 5) outputText("familiar ");
+	
+	if (getGame().jojoScene.isJojoCorrupted()) {
+		outputText("familiar ");
+	}
+	
 	else outputText("strange ");
 	outputText("dark power welling up within you.");
 	outputText("\n\nRubi is powerless to resist your hypnotic gaze. Your very eyes seem alight with wisps of dark, almost-demonic power, beginning to entrance the vulnerable ");

--- a/classes/classes/Scenes/Seasonal/XmasElf.as
+++ b/classes/classes/Scenes/Seasonal/XmasElf.as
@@ -48,7 +48,7 @@ package classes.Scenes.Seasonal {
 			addDisabledButton(1, "Unwrap Elf");
 			addButton(4, "Decline", declineXmasPresent);
 			
-			if (!player.isPureEnough(90) || flags[kFLAGS.JOJO_STATUS] >= 5 || player.hasStatusEffect(StatusEffects.Exgartuan) || getGame().amilyScene.amilyCorrupt() || flags[kFLAGS.SOPHIE_DISABLED_FOREVER] > 0 || flags[kFLAGS.SOPHIE_BIMBO] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0)
+			if (!player.isPureEnough(90) || getGame().jojoScene.isJojoCorrupted() || player.hasStatusEffect(StatusEffects.Exgartuan) || getGame().amilyScene.amilyCorrupt() || flags[kFLAGS.SOPHIE_DISABLED_FOREVER] > 0 || flags[kFLAGS.SOPHIE_BIMBO] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0)
 			{
 				outputText("She nods, bouncing up and down in excitement and flushing slightly, \"<i>Yup, just tear the lid off and get your gift!</i>\"\n\n");
 				if (flags[kFLAGS.PC_ENCOUNTERED_CHRISTMAS_ELF_BEFORE] > 0) outputText("Here we go again...\n\n");
@@ -83,7 +83,7 @@ package classes.Scenes.Seasonal {
 			spriteSelect(SpriteDb.s_christmas_elf);
 			clearOutput();
 			outputText("You easily rip through the ribbons holding the box together and pull off the top.   You gasp in ");
-			if (!player.isPureEnough(90) || flags[kFLAGS.JOJO_STATUS] >= 5 || player.hasStatusEffect(StatusEffects.Exgartuan) || getGame().amilyScene.amilyCorrupt() || flags[kFLAGS.SOPHIE_DISABLED_FOREVER] > 0 || flags[kFLAGS.SOPHIE_BIMBO] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0) {
+			if (!player.isPureEnough(90) || getGame().jojoScene.isJojoCorrupted() || player.hasStatusEffect(StatusEffects.Exgartuan) || getGame().amilyScene.amilyCorrupt() || flags[kFLAGS.SOPHIE_DISABLED_FOREVER] > 0 || flags[kFLAGS.SOPHIE_BIMBO] > 0 || flags[kFLAGS.NIAMH_STATUS] > 0) {
 				//[Bad Present]
 				outputText("shock at the box's contents – a nine inch cock with damn near a dozen buzzing, elliptical devices taped to it.  A pair of coal lumps rattles around underneath it, positioned as if they were the dick's testicles.\n\n");
 				

--- a/classes/classes/VaginaClass.as
+++ b/classes/classes/VaginaClass.as
@@ -131,6 +131,7 @@
 		 */
 		public function stretch(cArea:Number, bonusCapacity:Number = 0, hasFeraMilkingTwat:Boolean = false):Boolean {
 			var stretched:Boolean = false;
+			LOGGER.debug("Vaginal stretch check, cock area {0} vs vagina capacity {1}", cArea, capacity(bonusCapacity));
 			if (!hasFeraMilkingTwat || vaginalLooseness <= VaginaClass.LOOSENESS_NORMAL) {
 				//cArea > capacity = autostreeeeetch.
 				if (cArea >= capacity(bonusCapacity)) {

--- a/test/classes/Scenes/NPCs/JojoSceneTest.as
+++ b/test/classes/Scenes/NPCs/JojoSceneTest.as
@@ -68,6 +68,18 @@ package classes.Scenes.NPCs{
 			
 			assertThat(player.vaginas[0].vaginalLooseness, equalTo(3));
 		}
+		
+		[Test]
+		public function jojoNotFullyCorrupted(): void {
+			assertThat(cut.isJojoCorrupted(), equalTo(false));
+		}
+		
+		[Test]
+		public function jojoFullyCorrupted(): void {
+			kGAMECLASS.flags[kFLAGS.JOJO_STATUS] = 6;
+			
+			assertThat(cut.isJojoCorrupted(), equalTo(true));
+		}
 	}
 }
 

--- a/test/classes/Scenes/NPCs/JojoSceneTest.as
+++ b/test/classes/Scenes/NPCs/JojoSceneTest.as
@@ -33,6 +33,7 @@ package classes.Scenes.NPCs{
 			cut = new JojoSceneForTest(new PregnancyProgression(), new DummyOutput());
 			player = new Player();
 			kGAMECLASS.player = player;
+			kGAMECLASS.flags[kFLAGS.JOJO_STATUS] = 1;
         }
 		
 		[Test] 

--- a/test/classes/Scenes/NPCs/JojoSceneTest.as
+++ b/test/classes/Scenes/NPCs/JojoSceneTest.as
@@ -1,4 +1,5 @@
 package classes.Scenes.NPCs{
+	import classes.GlobalFlags.kFLAGS;
 	import classes.Scenes.PregnancyProgression;
 	import classes.helper.DummyOutput;
     import org.flexunit.asserts.*;
@@ -53,8 +54,21 @@ package classes.Scenes.NPCs{
 			
 			assertThat(cut.collectedOutput, hasItem(startsWith(ALWAYS_EXPECTED_TEXT)));
 			assertThat(cut.collectedOutput, hasItem(startsWith(WET_ONLY_EXPECTED_TEXT)));
-		} 
-    }
+		}
+		
+		[Test]
+		public function jojoCorruptFemalePCrapeUsesCockArea(): void {
+			kGAMECLASS.flags[kFLAGS.JOJO_STATUS] = 5;
+			kGAMECLASS.monster = new Jojo();
+			
+			player.createVagina(false, 1, 2);
+			player.lust = player.maxLust();
+			
+			cut.loseToJojo();
+			
+			assertThat(player.vaginas[0].vaginalLooseness, equalTo(3));
+		}
+	}
 }
 
 import classes.Scenes.NPCs.JojoScene;

--- a/test/classes/Scenes/NPCs/JojoTest.as
+++ b/test/classes/Scenes/NPCs/JojoTest.as
@@ -1,0 +1,72 @@
+package classes.Scenes.NPCs{
+	import classes.GlobalFlags.kFLAGS;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.number.greaterThan;
+	import org.hamcrest.object.equalTo;
+
+	import classes.helper.StageLocator;
+	
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.CoC;
+	import classes.CockTypesEnum;
+
+	public class JojoTest {
+		private static const JOJO_LUST:int = 45;
+		private static const JOJO_FULL_CORRUPTION_COCK_LENGTH:Number = 13;
+		
+		private var cut:JojoForTest;
+		
+		[BeforeClass]
+		public static function setUpClass():void {
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+
+		[Before]
+		public function setUp():void {  
+			createCut(3);
+		}
+		
+		private function createCut(jojoStatus:int): void {
+			kGAMECLASS.flags[kFLAGS.JOJO_STATUS] = jojoStatus;
+			
+			cut = new JojoForTest();
+		}
+		
+		[Test]
+		public function jojoStatus3Lust(): void {
+			assertThat(cut.lust, equalTo(JOJO_LUST));
+		}
+		
+		[Test]
+		public function jojoSelfCorruptionDuringCombat(): void {
+			for (var i:int = 0; i < 10; i++) {
+				cut.combatActionTest();
+			}
+			
+			assertThat(cut.lust, greaterThan(JOJO_LUST));
+		}
+
+		[Test]
+		public function jojoCockType(): void {
+			assertThat(cut.cocks[0].cockType, equalTo(CockTypesEnum.HUMAN));
+		}
+		
+		[Test]
+		public function jojoCorruptCockLength(): void {
+			createCut(5);
+			
+			assertThat(cut.cocks[0].cockLength, equalTo(JOJO_FULL_CORRUPTION_COCK_LENGTH));
+		}
+	}
+}
+
+import classes.Scenes.NPCs.Jojo;
+
+class JojoForTest extends Jojo {
+	public var collectedOutput:Vector.<String> = new Vector.<String>();
+	
+	public function combatActionTest(): void {
+		performCombatAction();
+	}
+}

--- a/test/classes/Scenes/NPCs/JojoTest.as
+++ b/test/classes/Scenes/NPCs/JojoTest.as
@@ -58,6 +58,13 @@ package classes.Scenes.NPCs{
 			
 			assertThat(cut.cocks[0].cockLength, equalTo(JOJO_FULL_CORRUPTION_COCK_LENGTH));
 		}
+		
+		[Test]
+		public function jojoSlaveCockLength(): void {
+			createCut(6);
+			
+			assertThat(cut.cocks[0].cockLength, equalTo(JOJO_FULL_CORRUPTION_COCK_LENGTH));
+		}
 	}
 }
 

--- a/test/classes/Scenes/NPCsSuit.as
+++ b/test/classes/Scenes/NPCsSuit.as
@@ -3,6 +3,7 @@ package classes.Scenes {
 import classes.Scenes.NPCs.IsabellaSceneTest;
 import classes.Scenes.NPCs.JojoSceneTest;
 import classes.Scenes.NPCs.IsabellaFollowerSceneTest;
+import classes.Scenes.NPCs.JojoTest;
 
 [Suite]
 [RunWith("org.flexunit.runners.Suite")]
@@ -11,5 +12,6 @@ import classes.Scenes.NPCs.IsabellaFollowerSceneTest;
 		 public var jojoSceneTest:JojoSceneTest;
 		 public var isabellaSceneTest : IsabellaSceneTest;
 		 public var isabellaFollowerSceneTest:IsabellaFollowerSceneTest;
+		 public var jojoTest:JojoTest
 	}
 }


### PR DESCRIPTION
Noticed an issue when fighting corrupt Jojo, found and fixed the issue and in turn discovered even more issues.

## Changes
- Stretching on loss did not always use the correct size
- Jojo did not have a cock
- Instead, the players cock was used for descriptions (which made the parser freak out if the PC was female)
- In order to enslave Jojo, the player has to defeat Jojo in his final stage (before win or loss worked)
- Refactored corruption check
- Extracted constructor for Jojo

## TODO
- Better handling of loading / saving of NPCs
- Fix Jojo attributes, they are based on the PC's state when Jojo's constructor is called