### PR TITLE
Fix forest gown

### DIFF
--- a/classes/classes/Items/Armors/Gown.as
+++ b/classes/classes/Items/Armors/Gown.as
@@ -78,7 +78,7 @@ package classes.Items.Armors
 				tfChoice.push("butt");
 			if (kGAMECLASS.player.hasCock() != false )
 				tfChoice.push("cock");
-			if (kGAMECLASS.player.breastRows[0].breastRating != 4)
+			if (kGAMECLASS.player.breastRows[0].breastRating != 4 || kGAMECLASS.player.bRows() > 1)
 				tfChoice.push("breasts");
 			if (kGAMECLASS.player.femininity < 70)
 				tfChoice.push("girlyness");
@@ -129,13 +129,13 @@ package classes.Items.Armors
 	case "breasts":
 		outputText("You feel like a beautful flower in your gown.  Dawn approaches and you place your hands on your chest as if expecting your nipples to bloom to greet the rising sun.\n");
 		
-				if (kGAMECLASS.player.bRows() > 1) {
+				if (kGAMECLASS.player.bRows() > 1)
+				{
 					x = 1;
 					outputText("Some of your breasts shrink back into your body leaving you with just two.");
-					while (x < kGAMECLASS.player.bRows()) {
-						if (kGAMECLASS.player.breastRows[x].breastRating < 1) kGAMECLASS.player.breastRows[x].breastRating = 1;
-						x++;
-					}
+					kGAMECLASS.player.breastRows.length = 1;
+				}
+				
 				if (kGAMECLASS.player.breastRows[0].breastRating > BreastCup.D )
 					{
 						kGAMECLASS.player.breastRows[0].breastRating = BreastCup.D;
@@ -149,7 +149,6 @@ package classes.Items.Armors
 						outputText("Heat builds in chest and your boobs become bigger.\n\n<b>You now have [breasts]</b>");
 						changed = 1;
 					}
-				}
 
 				case "girlyness":
 					text = kGAMECLASS.player.modFem(70, 2);

--- a/classes/classes/Items/Armors/Gown.as
+++ b/classes/classes/Items/Armors/Gown.as
@@ -149,7 +149,8 @@ package classes.Items.Armors
 						outputText("Heat builds in chest and your boobs become bigger.\n\n<b>You now have [breasts]</b>");
 						changed = 1;
 					}
-
+				break;
+				
 				case "girlyness":
 					text = kGAMECLASS.player.modFem(70, 2);
 					if (text == "") break;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -981,7 +981,7 @@
 			{
 				race = "satyr";
 			}
-			if (DryadScore() >= 3)
+			if (dryadScore() >= 3)
 			{
 				race = "dryad";
 			}
@@ -1871,7 +1871,7 @@
 		//------------
 		
 	    //dryad score
-		public function DryadScore():Number
+		public function dryadScore():Number
 		{
 			var dryad:Number = 0;
 			if (hasCock())

--- a/test/classes/Items/Armors/GownTest.as
+++ b/test/classes/Items/Armors/GownTest.as
@@ -11,6 +11,8 @@ package classes.Items.Armors
 	
 	public class GownTest 
 	{
+		private static const PLAYER_FEMININITY:Number = 100;
+		
 		private var cut:Gown;
 		private var player:Player;
 		
@@ -31,7 +33,7 @@ package classes.Items.Armors
 			player.hips.rating = 5;
 			player.butt.rating = 5;
 			player.createBreastRow(BreastCup.D);
-			player.femininity = 100;
+			player.femininity = PLAYER_FEMININITY;
 		}
 		
 		[Test]
@@ -53,6 +55,16 @@ package classes.Items.Armors
 			cut.dryadProgression();
 			
 			assertThat(player.bRows(), equalTo(1));
+		}
+		
+		[Test]
+		public function dryadProgressionBreastRatingIncreaseDoesNotChangeFemininity(): void
+		{
+			player.breastRows[0].breastRating = BreastCup.B;
+			
+			cut.dryadProgression();
+			
+			assertThat(player.femininity, equalTo(PLAYER_FEMININITY));
 		}
 	}
 }

--- a/test/classes/Items/Armors/GownTest.as
+++ b/test/classes/Items/Armors/GownTest.as
@@ -1,0 +1,58 @@
+package classes.Items.Armors 
+{
+	import classes.CoC;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.helper.StageLocator;
+	import classes.lists.BreastCup;
+	
+	import org.hamcrest.assertThat;
+	import org.hamcrest.object.equalTo;
+	
+	public class GownTest 
+	{
+		private var cut:Gown;
+		private var player:Player;
+		
+		[BeforeClass]
+		public static function setUpClass():void
+		{
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+		
+		[Before]
+		public function setUp(): void
+		{
+			cut = new Gown();
+			
+			kGAMECLASS.player = new Player();
+			player = kGAMECLASS.player;
+			
+			player.hips.rating = 5;
+			player.butt.rating = 5;
+			player.createBreastRow(BreastCup.D);
+			player.femininity = 100;
+		}
+		
+		[Test]
+		public function dryadProgressionBreastRatingIncrease(): void
+		{
+			player.breastRows[0].breastRating = BreastCup.B;
+			
+			cut.dryadProgression();
+			
+			assertThat(player.breastRows[0].breastRating, equalTo(BreastCup.D));
+		}
+		
+		[Test]
+		public function dryadProgressionRemoveBreasts(): void
+		{
+			player.createBreastRow(5);
+			player.createBreastRow(4);
+			
+			cut.dryadProgression();
+			
+			assertThat(player.bRows(), equalTo(1));
+		}
+	}
+}

--- a/test/classes/Items/ArmorsSuite.as
+++ b/test/classes/Items/ArmorsSuite.as
@@ -1,8 +1,10 @@
 package classes.Items {
+	import classes.Items.Armors.GownTest;
 
-[Suite]
-[RunWith("org.flexunit.runners.Suite")]
+	[Suite]
+	[RunWith("org.flexunit.runners.Suite")]
 	public class ArmorsSuite
 	{
+		public var gownTest:GownTest
 	}
 }

--- a/test/classes/Items/ArmorsSuite.as
+++ b/test/classes/Items/ArmorsSuite.as
@@ -1,0 +1,8 @@
+package classes.Items {
+
+[Suite]
+[RunWith("org.flexunit.runners.Suite")]
+	public class ArmorsSuite
+	{
+	}
+}

--- a/test/classes/ItemsSuit.as
+++ b/test/classes/ItemsSuit.as
@@ -1,4 +1,5 @@
 package classes {
+	import classes.Items.ArmorsSuite;
 	import classes.Items.ConsumableTest;
 	import classes.Items.MutationsTest;
 
@@ -8,5 +9,6 @@ package classes {
 	{
 		 public var mutationsTest:MutationsTest;
 		 public var consumableTest:ConsumableTest;
+		 public var armorsSuite:ArmorsSuite;
 	}
 }


### PR DESCRIPTION
@melch-i Please review this PR to check if the new behavior is as you intended 

Fixing issue flagged by Sonar, found and fixed other bugs.

- tfChange option for breasts was not added if PC had multiple breast but the first row was the correct size
- Breast changes were only applied if the PC had multiple breast rows
- It was unclear what the breast row removal code was supposed to accomplish (rewritten to remove all but the first row)
- Breast TF case had no `break`, so the `girlyness` case was also executed
- Renamed `DryadScore` to adhere to naming convention 