### PR TITLE
Fix Kelt comments on PC strip

### DIFF
--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -275,7 +275,7 @@ package classes
 		// Scenes/Places/
 		public var bazaar:Bazaar = new Bazaar();
 		public var boat:Boat = new Boat();
-		public var farm:Farm = new Farm();
+		public var farm:Farm;
 		public var owca:Owca = new Owca();
 		public var telAdre:TelAdre;
 		public var ingnam:Ingnam = new Ingnam();
@@ -458,6 +458,7 @@ package classes
 			desert = new Desert(pregnancyProgression, output);
 			
 			telAdre = new TelAdre(pregnancyProgression);
+			farm = new Farm(output);
 			
 			impScene = new ImpScene(pregnancyProgression, output);
 			anemoneScene = new AnemoneScene(pregnancyProgression, output);

--- a/classes/classes/Scenes/Places/Farm.as
+++ b/classes/classes/Scenes/Places/Farm.as
@@ -15,8 +15,8 @@ package classes.Scenes.Places{
 	public var kelly:Kelly;
 	public var farmCorruption:FarmCorruption;
 
-	public function Farm(){
-		keltScene = new KeltScene();
+	public function Farm(output:GuiOutput){
+		keltScene = new KeltScene(output);
 		kelly = new Kelly();
 		farmCorruption = new FarmCorruption();
 	}

--- a/classes/classes/Scenes/Places/Farm.as
+++ b/classes/classes/Scenes/Places/Farm.as
@@ -13,13 +13,16 @@ package classes.Scenes.Places{
 	public class Farm extends BaseContent{
 	public var keltScene:KeltScene = new KeltScene();
 	public var kelly:Kelly = new Kelly();
-	private function get marbleScene():MarbleScene {
-		return kGAMECLASS.marbleScene;
-	}
+
 	public var farmCorruption:FarmCorruption = new FarmCorruption();
 
 	public function Farm(){
 
+	}
+	
+	private function get marbleScene():MarbleScene
+	{
+		return kGAMECLASS.marbleScene;
 	}
 //const FARM_DISABLED:int = 464;
 
@@ -1321,3 +1324,4 @@ private function centaurToysHoooooo():void {
 }
 }
 }
+

--- a/classes/classes/Scenes/Places/Farm.as
+++ b/classes/classes/Scenes/Places/Farm.as
@@ -11,13 +11,14 @@ package classes.Scenes.Places{
 	use namespace kGAMECLASS;
 
 	public class Farm extends BaseContent{
-	public var keltScene:KeltScene = new KeltScene();
-	public var kelly:Kelly = new Kelly();
-
-	public var farmCorruption:FarmCorruption = new FarmCorruption();
+	public var keltScene:KeltScene;
+	public var kelly:Kelly;
+	public var farmCorruption:FarmCorruption;
 
 	public function Farm(){
-
+		keltScene = new KeltScene();
+		kelly = new Kelly();
+		farmCorruption = new FarmCorruption();
 	}
 	
 	private function get marbleScene():MarbleScene

--- a/classes/classes/Scenes/Places/Farm/KeltScene.as
+++ b/classes/classes/Scenes/Places/Farm/KeltScene.as
@@ -521,7 +521,6 @@ private function keltMainEncounterAfterNakedReq():void {
 }
 //Normal Encounter 2
 private function keltMainEncounter2():void {
-	clearOutput();
 	//Used for randomization
 	var temporary:Number = 0;
 	if (player.hasKeyItem("Bow") < 0) { //No bow equipped

--- a/classes/classes/Scenes/Places/Farm/KeltScene.as
+++ b/classes/classes/Scenes/Places/Farm/KeltScene.as
@@ -59,6 +59,22 @@ STATUSES:
 "Kelt" - v1 = Archery, v2 = Submissiveness, v3 = total encounters.
 "KeltOff" - Turns off Kelt */
 
+		/**
+		 * Redirtect the output to injected output instance.
+		 * @param	output text to output
+		 */
+		override protected function outputText(output:String):void {
+			outputLocal.text(output);
+		}
+		
+		/**
+		 * Redirect the clear output call to the injected output instance.
+		 */
+		override protected function clearOutput():void
+		{
+			outputLocal.clear();
+		}
+
 private function bowSkill(diff:Number):Number {
 	player.addStatusValue(StatusEffects.Kelt,1,diff);
 	if (player.statusEffectv1(StatusEffects.Kelt) >= 100) player.changeStatusValue(StatusEffects.Kelt,1,100);

--- a/classes/classes/Scenes/Places/Farm/KeltScene.as
+++ b/classes/classes/Scenes/Places/Farm/KeltScene.as
@@ -8,8 +8,13 @@ package classes.Scenes.Places.Farm {
 	public class KeltScene extends AbstractFarmContent {
 
 		public var kelly:Kelly = new Kelly();
+		
+		private var outputLocal:GuiOutput;
 
-	public function KeltScene() {}
+		public function KeltScene(output:GuiOutput)
+		{
+			this.outputLocal = output;
+		}
 
 	/*Kelt the Centaur Archer
 A Corruption of Champions Event by Ourakun

--- a/test/classes/Scenes/Places/Farm/KeltSceneTest.as
+++ b/test/classes/Scenes/Places/Farm/KeltSceneTest.as
@@ -1,0 +1,65 @@
+package classes.Scenes.Places.Farm
+{
+	import classes.Appearance;
+	import classes.BodyParts.Butt;
+	import classes.StatusEffects;
+	import classes.helper.DummyOutput;
+	import classes.helper.FireButtonEvent;
+	import classes.internals.RandomNumberGenerator;
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	import org.hamcrest.collection.*;
+	
+	import classes.helper.StageLocator;
+	
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Player;
+	import classes.CoC;
+	import classes.GlobalFlags.kFLAGS;
+	import classes.Output;
+	
+	public class KeltSceneTest
+	{
+		private static const EVENT_ITERATIONS:int = 5;
+		
+		private var cut:KeltScene;
+		private var player:Player;
+		private var fireButtons:FireButtonEvent;
+		private var output:DummyOutput;
+		
+		[BeforeClass]
+		public static function setUpClass():void
+		{
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+		
+		[Before]
+		public function setUp():void
+		{
+			output = new DummyOutput();
+			cut = new KeltScene(output);
+			
+			player = new Player();
+			kGAMECLASS.player = player;
+			
+			player.createStatusEffect(StatusEffects.Kelt, 0, 0, 0, 0);
+			player.addStatusValue(StatusEffects.Kelt, 3, 3);
+			
+			fireButtons = new FireButtonEvent(kGAMECLASS.mainView, Output.MAX_BUTTON_INDEX);
+		}
+		
+		[Test]
+		public function keltCommentsOnPcDuringStrip():void
+		{
+			cut.keltEncounter();
+			
+			fireButtons.fireButtonClick(0);
+			
+			assertThat(output.collectedOutput, hasItem(startsWith("You are uncomfortable with the idea ")));
+		}
+	}
+}

--- a/test/classes/Scenes/Places/FarmSuite.as
+++ b/test/classes/Scenes/Places/FarmSuite.as
@@ -1,0 +1,10 @@
+package classes.Scenes.Places {
+	import classes.Scenes.Places.Farm.KeltSceneTest;
+
+	[Suite]
+	[RunWith("org.flexunit.runners.Suite")]
+	public class FarmSuite
+	{
+		public var keltSceneTest:KeltSceneTest;
+	}
+}

--- a/test/classes/Scenes/PlacesSuit.as
+++ b/test/classes/Scenes/PlacesSuit.as
@@ -1,11 +1,13 @@
 package classes.Scenes {
 
 import classes.Scenes.Places.BazaarSuit;
+import classes.Scenes.Places.FarmSuite;
 
 [Suite]
 [RunWith("org.flexunit.runners.Suite")]
 	public class PlacesSuit
 	{
 		 public var bazaarSuit:BazaarSuit;
+		 public var farmSuite:FarmSuite;
 	}
 }


### PR DESCRIPTION
This PR fixes Kelt no longer commenting when the PC strips.

The issue was that a `clearOutput()` introduced [here](https://github.com/Kitteh6660/Corruption-of-Champions-Mod/commit/33c41f4f97f0c1861f6dff846783685e8eca724f#diff-52a6fd9c06ffa372ce504c45233fd2a7R503) cleared the comments as soon as they were displayed.

- Inject output into scene for better design and testing
- Unit test, since this is the second time the regression has been introduced
- Remove `clearOutput` call that caused the issue
