### PR TITLE
Gown fixes

### DIFF
--- a/classes/classes/Items/Armors/Gown.as
+++ b/classes/classes/Items/Armors/Gown.as
@@ -11,48 +11,54 @@ package classes.Items.Armors
 	import classes.lists.BreastCup;
 	import classes.CoC;
 
-	public class Gown extends Armor implements TimeAwareInterface {
-
-		public function Gown():void {
+	public class Gown extends Armor implements TimeAwareInterface
+	{
+		public function Gown():void
+		{
 			super("FrsGown","FrsGown","forest gown","a forest gown",1,10,"This the very earthy gown commonly worn by dryads.   It is made from a mixture of plants.   The predominate fabric looks like a weave of fresh grass.   It is decorated by simple flowers that are attached to it.   Strangely, everything seems alive like it was still planted.   There must be some peculiar magic at work here.","Light");
-		
+
 			CoC.timeAwareClassAdd(this);
 		}
 
-		override public function useText():void{ //Produces any text seen when equipping the armor normally
+		override public function useText():void
+		{
+			//Produces any text seen when equipping the armor normally
 			switch (kGAMECLASS.player.gender) {
 				case Gender.FEMALE:   
-					outputText("You comfortably slide into the forest gown.   You spin around several times and giggle happily."
+					outputText("You comfortably slide into the forest gown. You spin around several times and giggle happily."
 					          +" Where did that come from?");
 					break;
 
-				case  Gender.MALE:
+				case Gender.MALE:
 					outputText("You slide forest gown over your head and down to your toes. It obviously would fit someone more female."
 					          +" You feel sad and wish you had the svelte body that would look amazing in this gown."
 					          +" Wait, did you always think that way?");
-			     break;
-			  default :  //non-binary
-				  outputText("You slide the gown over your head and slip it into place.");
+					break;
+				default:  //non-binary
+					outputText("You slide the gown over your head and slip it into place.");
 			}
 			if (kGAMECLASS.player.hasCock()) 
 				outputText("You notice the bulge from [cock] in the folds of the dress and wish it wasn't there.\n");
-
-			
 		}
+
 		public function timeChangeLarge():Boolean { return false; }
-		public function timeChange():Boolean {
+
+		public function timeChange():Boolean
+		{
 			if (kGAMECLASS.player.armor is Gown && kGAMECLASS.time.hours == 5) { //only call function once per day as time change is called every hour
 				dryadProgression(); 
 				return true;
 			}
 			return false; //stop if not wearing
 		}
-		public function dryadProgression():void {
+
+		public function dryadProgression():void
+		{
 			var verb:String; 
 			var text:String;
-			var x :int;
-			var changed :int = 0;
-			var tfChoice :Array = []; 
+			var x:int;
+			var changed:int = 0;
+			var tfChoice:Array = [];
 			var dryadDreams:Array = [
 				"In your dream you find yourself in a lush forest standing next to a tree. The tree seems like your best friend and You give it a hug before sitting down next to it. Looking around, there is grass and flowers all about. You can’t help but hum a cheery tune enjoying nature as a bright butterfly flutters nearby, holding out your hand the butterfly lands softly on your finger and smile sweetly to it.",
 				"You walk through a meadow and down towards a swift running brook, It looks like some clean water.   You sit down, pull up your gown and admire your feet. They are brown, the color of bark.   You place your feet in the cool water of the brook and soak up the water through your feet,  a cool refreshing feeling fills your body. Ah, being a Dryad is so nice.",
@@ -70,53 +76,55 @@ package classes.Items.Armors
 			];
 			//display a random dream
 			clearOutput();
-			outputText("\n\n"+dryadDreams[rand(dryadDreams.length)]+"\n\n");
+			outputText("\n\n" + dryadDreams[rand(dryadDreams.length)] + "\n\n");
 			//build a list of non ideal parts 
-			if (kGAMECLASS.player.hips.rating != 5 )
-				 tfChoice.push("hips");
-			if (kGAMECLASS.player.butt.rating != 5 )
+			if (kGAMECLASS.player.hips.rating != 5)
+				tfChoice.push("hips");
+			if (kGAMECLASS.player.butt.rating != 5)
 				tfChoice.push("butt");
-			if (kGAMECLASS.player.hasCock() != false )
+			if (kGAMECLASS.player.hasCock())
 				tfChoice.push("cock");
 			if (kGAMECLASS.player.breastRows[0].breastRating != 4 || kGAMECLASS.player.bRows() > 1)
 				tfChoice.push("breasts");
 			if (kGAMECLASS.player.femininity < 70)
 				tfChoice.push("girlyness");
 
-			//progress slowly to the ideal dryad build	
+			//progress slowly to the ideal dryad build
 			switch (randomChoice(tfChoice)) {
 				case "hips":
-						outputText("You wiggle around in your gown, pleasant feeling of flower petals rubbing against your skin washes over you.  The feeling settles on your [hips].\n");
+					outputText("You wiggle around in your gown, pleasant feeling of flower petals rubbing against your skin washes over you."
+					          +" The feeling settles on your [hips].\n");
 
-						if (kGAMECLASS.player.hips.rating < 5) {
-							verb = "enlarge";
-							kGAMECLASS.player.hips.rating++;
-						}
-						if (kGAMECLASS.player.hips.rating > 5) {
-							verb = "shrink";
-							kGAMECLASS.player.hips.rating--;
-						} 
-						if (kGAMECLASS.player.hips.rating == 5)
-							break;
-						outputText("You feel them slowly " + verb + ".<b>  You now have [hips].</b>\n"); 
-						changed = 1;
+					if (kGAMECLASS.player.hips.rating < 5) {
+						verb = "enlarge";
+						kGAMECLASS.player.hips.rating++;
+					}
+					if (kGAMECLASS.player.hips.rating > 5) {
+						verb = "shrink";
+						kGAMECLASS.player.hips.rating--;
+					}
+					if (kGAMECLASS.player.hips.rating == 5)
+						break;
+					outputText("You feel them slowly " + verb + ".<b>  You now have [hips].</b>\n");
+					changed = 1;
 					break;
 
 				case "butt":
-					outputText("You wiggle around in your gown, the pleasant feeling of flower petals rubbing against your skin washes over you.  The feeling settles on your [butt].\n");
+					outputText("You wiggle around in your gown, the pleasant feeling of flower petals rubbing against your skin washes over you."
+					          +"The feeling settles on your [butt].\n");
 				
 					if (kGAMECLASS.player.butt.rating < 5) {
 						verb = "enlarge";
 						kGAMECLASS.player.butt.rating++;
 					}
 					if (kGAMECLASS.player.butt.rating > 5) {
-						verb = "shrink";	
+						verb = "shrink";
 						kGAMECLASS.player.butt.rating--;
 					} 
 					if (kGAMECLASS.player.butt.rating == 5)
 						break;
 
-					outputText("You feel them slowly " + verb + ". <b>You now have a [butt].</b>"); 
+					outputText("You feel them slowly " + verb + ". <b>You now have a [butt].</b>");
 					changed = 1;
 					break;
 
@@ -126,100 +134,99 @@ package classes.Items.Armors
 					changed = 1;
 					break;
 
-	case "breasts":
-		outputText("You feel like a beautful flower in your gown.  Dawn approaches and you place your hands on your chest as if expecting your nipples to bloom to greet the rising sun.\n");
-		
-				if (kGAMECLASS.player.bRows() > 1)
-				{
-					x = 1;
-					outputText("Some of your breasts shrink back into your body leaving you with just two.");
-					kGAMECLASS.player.breastRows.length = 1;
-				}
-				
-				if (kGAMECLASS.player.breastRows[0].breastRating > BreastCup.D )
-					{
+				case "breasts":
+					outputText("You feel like a beautful flower in your gown. Dawn approaches and you place your hands on your chest"
+					          +" as if expecting your nipples to bloom to greet the rising sun.\n");
+
+					if (kGAMECLASS.player.bRows() > 1) {
+						x = 1;
+						outputText("Some of your breasts shrink back into your body leaving you with just two.");
+						kGAMECLASS.player.breastRows.length = 1;
+					}
+
+					if (kGAMECLASS.player.breastRows[0].breastRating > BreastCup.D) {
 						kGAMECLASS.player.breastRows[0].breastRating = BreastCup.D;
 						outputText("A chill runs against your chest and <b>your boobs become smaller. You now have [breasts]</b>\n\n");
-						changed = 1;	
+						changed = 1;
 					}
-					
-				if ( kGAMECLASS.player.smallestTitSize() < BreastCup.D )
-					{
+
+					if (kGAMECLASS.player.smallestTitSize() < BreastCup.D) {
 						kGAMECLASS.player.breastRows[0].breastRating = BreastCup.D;
 						outputText("Heat builds in chest and your boobs become bigger.\n\n<b>You now have [breasts]</b>");
 						changed = 1;
 					}
-				break;
-				
+					break;
+
 				case "girlyness":
 					text = kGAMECLASS.player.modFem(70, 2);
 					if (text == "") break;
-					outputText("You run your [hands] across the fabric of your Gown, then against your face as it feels like there is something you need to wipe off.\n");
+					outputText("You run your [hands] across the fabric of your Gown, then against your face as it feels like"
+					          +" there is something you need to wipe off.\n");
 					outputText(text);
 					changed = 1;
 					break;
-					
+
 				default:
 					outputText("\nERROR: this forest gown TF choice shouldn't ever get called.");
 			}
 			outputText("\n\n"); //spacing issues
-			if (changed !== 1) DryadProg();   //if no small changes, start big changes
+			if (changed !== 1) dryadProg(); //if no small changes, start big changes
 		}
 
-		public function DryadProg():void {
-
-		//types of changes
+		public function dryadProg():void
+		{
+			//types of changes
 			var tfChoice:String = randomChoice("skin", "ears", "face", "lowerbody", "arms", "hair");
 			outputText("\n\n");
 			switch (tfChoice) {
-			case "ears":
-				if (kGAMECLASS.player.ears.type !== Ears.ELFIN) {
-					outputText("There is a tingling on the sides of your head as your ears change to pointed elfin ears.");
-					kGAMECLASS.player.ears.type = Ears.ELFIN;
-				}
-				break;
+				case "ears":
+					if (kGAMECLASS.player.ears.type !== Ears.ELFIN) {
+						outputText("There is a tingling on the sides of your head as your ears change to pointed elfin ears.");
+						kGAMECLASS.player.ears.type = Ears.ELFIN;
+					}
+					break;
 
-			case "skin":
-				if (kGAMECLASS.player.skin.type !== Skin.PLAIN) {
-					outputText("A tingling runs up along your [skin] as it changes back to normal");
-				} else if (kGAMECLASS.player.skin.tone !== "bark" && kGAMECLASS.player.skin.type == Skin.PLAIN) {
-					outputText("Your skin hardens and becomes the consistency of tree’s bark."); 
-					kGAMECLASS.player.skin.tone = "woodly brown";
-					kGAMECLASS.player.skin.type = Skin.BARK;
-				}
-				break;
+				case "skin":
+					if (kGAMECLASS.player.skin.type !== Skin.PLAIN) {
+						outputText("A tingling runs up along your [skin] as it changes back to normal");
+					} else if (kGAMECLASS.player.skin.tone !== "bark" && kGAMECLASS.player.skin.type == Skin.PLAIN) {
+						outputText("Your skin hardens and becomes the consistency of tree’s bark.");
+						kGAMECLASS.player.skin.tone = "woodly brown";
+						kGAMECLASS.player.skin.type = Skin.BARK;
+					}
+					break;
 
-			case "lowerbody":
-				if (kGAMECLASS.player.lowerBody.type !== LowerBody.HUMAN) {
-					outputText("There is a rumbling in your lower body as it returns to a human shape.");
-					kGAMECLASS.player.lowerBody.type = LowerBody.HUMAN;
-				}
-				break;
+				case "lowerbody":
+					if (kGAMECLASS.player.lowerBody.type !== LowerBody.HUMAN) {
+						outputText("There is a rumbling in your lower body as it returns to a human shape.");
+						kGAMECLASS.player.lowerBody.type = LowerBody.HUMAN;
+					}
+					break;
 
-			case "arms":
-				if (kGAMECLASS.player.arms.type !== Arms.HUMAN || kGAMECLASS.player.arms.claws.type !== Claws.NORMAL) {
-					outputText("Your hands shake and shudder as they slowly transform back into normal human hands.");
-					kGAMECLASS.player.arms.restore();
-				}
-				break;
+				case "arms":
+					if (kGAMECLASS.player.arms.type !== Arms.HUMAN || kGAMECLASS.player.arms.claws.type !== Claws.NORMAL) {
+						outputText("Your hands shake and shudder as they slowly transform back into normal human hands.");
+						kGAMECLASS.player.arms.restore();
+					}
+					break;
 
-			case "face":
-				if (kGAMECLASS.player.face.type !== Face.HUMAN) {
-					outputText("Your face twitches a few times and slowly morphs itself back to a normal human face.");
-					kGAMECLASS.player.face.type = Face.HUMAN;
-				}
-				break;
+				case "face":
+					if (kGAMECLASS.player.face.type !== Face.HUMAN) {
+						outputText("Your face twitches a few times and slowly morphs itself back to a normal human face.");
+						kGAMECLASS.player.face.type = Face.HUMAN;
+					}
+					break;
 
-			case "hair":
-				if (kGAMECLASS.player.hair.type !== Hair.LEAF) {
-					outputText("Much to your shock, your hair begins falling out in tuffs onto the ground. "
-					          +" Moments later, your scalp sprouts vines all about that extend down and bloom into leafy hair.");
-					kGAMECLASS.player.hair.type = Hair.LEAF;
-				}
+				case "hair":
+					if (kGAMECLASS.player.hair.type !== Hair.LEAF) {
+						outputText("Much to your shock, your hair begins falling out in tuffs onto the ground. "
+						          +" Moments later, your scalp sprouts vines all about that extend down and bloom into leafy hair.");
+						kGAMECLASS.player.hair.type = Hair.LEAF;
+					}
+					break;
 
-				break;
-			default:
-				outputText("\nERROR: this forest gown TF choice shouldn't ever get called.");
+				default:
+					outputText("\nERROR: this forest gown TF choice shouldn't ever get called.");
 			}
 		}
 	}

--- a/classes/classes/Items/Armors/Gown.as
+++ b/classes/classes/Items/Armors/Gown.as
@@ -57,7 +57,7 @@ package classes.Items.Armors
 			var verb:String; 
 			var text:String;
 			var x:int;
-			var changed:int = 0;
+			var changed:Boolean = false;
 			var tfChoice:Array = [];
 			var dryadDreams:Array = [
 				"In your dream you find yourself in a lush forest standing next to a tree. The tree seems like your best friend and You give it a hug before sitting down next to it. Looking around, there is grass and flowers all about. You can’t help but hum a cheery tune enjoying nature as a bright butterfly flutters nearby, holding out your hand the butterfly lands softly on your finger and smile sweetly to it.",
@@ -106,13 +106,13 @@ package classes.Items.Armors
 					if (kGAMECLASS.player.hips.rating == 5)
 						break;
 					outputText("You feel them slowly " + verb + ".<b>  You now have [hips].</b>\n");
-					changed = 1;
+					changed = true;
 					break;
 
 				case "butt":
 					outputText("You wiggle around in your gown, the pleasant feeling of flower petals rubbing against your skin washes over you."
 					          +"The feeling settles on your [butt].\n");
-				
+
 					if (kGAMECLASS.player.butt.rating < 5) {
 						verb = "enlarge";
 						kGAMECLASS.player.butt.rating++;
@@ -125,13 +125,13 @@ package classes.Items.Armors
 						break;
 
 					outputText("You feel them slowly " + verb + ". <b>You now have a [butt].</b>");
-					changed = 1;
+					changed = true;
 					break;
 
 				case "cock":
 					outputText("Your [cock] feels strange as it brushes against the fabric of your gown.\n");
 					(new BimboProgression).shrinkCock();
-					changed = 1;
+					changed = true;
 					break;
 
 				case "breasts":
@@ -147,13 +147,13 @@ package classes.Items.Armors
 					if (kGAMECLASS.player.breastRows[0].breastRating > BreastCup.D) {
 						kGAMECLASS.player.breastRows[0].breastRating = BreastCup.D;
 						outputText("A chill runs against your chest and <b>your boobs become smaller. You now have [breasts]</b>\n\n");
-						changed = 1;
+						changed = true;
 					}
 
 					if (kGAMECLASS.player.smallestTitSize() < BreastCup.D) {
 						kGAMECLASS.player.breastRows[0].breastRating = BreastCup.D;
 						outputText("Heat builds in chest and your boobs become bigger.\n\n<b>You now have [breasts]</b>");
-						changed = 1;
+						changed = true;
 					}
 					break;
 
@@ -163,14 +163,16 @@ package classes.Items.Armors
 					outputText("You run your [hands] across the fabric of your Gown, then against your face as it feels like"
 					          +" there is something you need to wipe off.\n");
 					outputText(text);
-					changed = 1;
+					changed = true;
 					break;
 
 				default:
-					outputText("\nERROR: this forest gown TF choice shouldn't ever get called.");
+					// no error, intended
 			}
 			outputText("\n\n"); //spacing issues
-			if (changed !== 1) dryadProg(); //if no small changes, start big changes
+			if (!changed) {
+				dryadProg(); //if no small changes, start big changes
+			}
 		}
 
 		public function dryadProg():void

--- a/classes/classes/Items/Armors/Gown.as
+++ b/classes/classes/Items/Armors/Gown.as
@@ -56,7 +56,6 @@ package classes.Items.Armors
 		{
 			var verb:String; 
 			var text:String;
-			var x:int;
 			var changed:Boolean = false;
 			var tfChoice:Array = [];
 			var dryadDreams:Array = [
@@ -103,8 +102,7 @@ package classes.Items.Armors
 						verb = "shrink";
 						kGAMECLASS.player.hips.rating--;
 					}
-					if (kGAMECLASS.player.hips.rating == 5)
-						break;
+
 					outputText("You feel them slowly " + verb + ".<b>  You now have [hips].</b>\n");
 					changed = true;
 					break;
@@ -121,8 +119,6 @@ package classes.Items.Armors
 						verb = "shrink";
 						kGAMECLASS.player.butt.rating--;
 					} 
-					if (kGAMECLASS.player.butt.rating == 5)
-						break;
 
 					outputText("You feel them slowly " + verb + ". <b>You now have a [butt].</b>");
 					changed = true;
@@ -139,7 +135,6 @@ package classes.Items.Armors
 					          +" as if expecting your nipples to bloom to greet the rising sun.\n");
 
 					if (kGAMECLASS.player.bRows() > 1) {
-						x = 1;
 						outputText("Some of your breasts shrink back into your body leaving you with just two.");
 						kGAMECLASS.player.breastRows.length = 1;
 					}

--- a/classes/classes/Items/Armors/Gown.as
+++ b/classes/classes/Items/Armors/Gown.as
@@ -91,14 +91,13 @@ package classes.Items.Armors
 			//progress slowly to the ideal dryad build
 			switch (randomChoice(tfChoice)) {
 				case "hips":
-					outputText("You wiggle around in your gown, pleasant feeling of flower petals rubbing against your skin washes over you."
+					outputText("You wiggle around in your gown, the pleasant feeling of flower petals rubbing against your skin washes over you."
 					          +" The feeling settles on your [hips].\n");
 
 					if (kGAMECLASS.player.hips.rating < 5) {
 						verb = "enlarge";
 						kGAMECLASS.player.hips.rating++;
-					}
-					if (kGAMECLASS.player.hips.rating > 5) {
+					} else {
 						verb = "shrink";
 						kGAMECLASS.player.hips.rating--;
 					}
@@ -114,8 +113,7 @@ package classes.Items.Armors
 					if (kGAMECLASS.player.butt.rating < 5) {
 						verb = "enlarge";
 						kGAMECLASS.player.butt.rating++;
-					}
-					if (kGAMECLASS.player.butt.rating > 5) {
+					} else {
 						verb = "shrink";
 						kGAMECLASS.player.butt.rating--;
 					} 
@@ -139,15 +137,14 @@ package classes.Items.Armors
 						kGAMECLASS.player.breastRows.length = 1;
 					}
 
-					if (kGAMECLASS.player.breastRows[0].breastRating > BreastCup.D) {
+					if (kGAMECLASS.player.breastRows[0].breastRating !== BreastCup.D) {
+						if (kGAMECLASS.player.breastRows[0].breastRating > BreastCup.D) {
+							outputText("\nA chill runs against your chest and your boobs become smaller.");
+						} else {
+							outputText("\nHeat builds in chest and your boobs become bigger.");
+						}
+						outputText("\n<b>You now have [breasts]</b>");
 						kGAMECLASS.player.breastRows[0].breastRating = BreastCup.D;
-						outputText("A chill runs against your chest and <b>your boobs become smaller. You now have [breasts]</b>\n\n");
-						changed = true;
-					}
-
-					if (kGAMECLASS.player.smallestTitSize() < BreastCup.D) {
-						kGAMECLASS.player.breastRows[0].breastRating = BreastCup.D;
-						outputText("Heat builds in chest and your boobs become bigger.\n\n<b>You now have [breasts]</b>");
 						changed = true;
 					}
 					break;


### PR DESCRIPTION
### Fixes
- Fixed Error text being shown on intended behaviour
- Fixed `hips` and `butt`-change text unintentionally being hidden

### Other unrelated changes
The first commit is code tidying only. I wanted to keep that separate from the actual fixes.
And theres some DRY-coding, noise reduction and I've removed the unused var `x`.

### Note
I considered changing the type of `BodyParts.Butt.rating` and `BodyParts.Hips.rating` from `Number` to `int` since `Number` allows float-values and float-values are not intended for these two rating-vars.
However: Currently theres nothing broken aka both vars are never set to a float value AFAICS by grepping through the codebase.
Maybe later and if I'm in the mood of testing if loading old saves won't break.
Or in other words: No need to disarm a bomb that has yet to be armed.