### PR TITLE
Reset knot multiplier if cock does not support knot

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -456,7 +456,6 @@ package classes {
 			player.cocks[0].cockLength = 5.5;
 			player.cocks[0].cockThickness = 1;
 			player.cocks[0].cockType = CockTypesEnum.HUMAN;
-			player.cocks[0].knotMultiplier = 1;
 			player.createBreastRow(); //breasts
 			clearOutput();
 			outputText(images.showImage("event-question"));
@@ -513,7 +512,6 @@ package classes {
 			player.cocks[0].cockLength = 5.5;
 			player.cocks[0].cockThickness = 1;
 			player.cocks[0].cockType = CockTypesEnum.HUMAN;
-			player.cocks[0].knotMultiplier = 1;
 			player.createBreastRow(); //breasts
 			clearOutput();
 			outputText(images.showImage("event-question"));

--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -274,7 +274,7 @@ package classes
 		{
 			_cockType = value;
 
-			if(!supportsKnot(value)) {
+			if (!supportsKnot(value) && this.knotMultiplier !== KNOTMULTIPLIER_NO_KNOT) {
 				this.knotMultiplier = KNOTMULTIPLIER_NO_KNOT;
 				LOGGER.debug("Cock type {0} does not support knots, setting knot knotMultiplier to {1}", value, knotMultiplier);
 			}

--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -12,12 +12,15 @@ package classes
 		
 		private static const SERIALIZATION_VERSION:int = 1;
 		
+		private static const OBJECT_NOT_FOUND:int = -1;
+
 		public static const MAX_LENGTH:Number = 9999.9;
 		public static const MAX_THICKNESS:Number = 999.9;
 		
 		private var _cockLength:Number;
 		private var _cockThickness:Number;		
 		private var _cockType:CockTypesEnum;	//See CockTypesEnum.as for all cock types
+		private static const cockTypesWithKnots:Vector.<CockTypesEnum> = new <CockTypesEnum> [CockTypesEnum.DOG, CockTypesEnum.FOX, CockTypesEnum.WOLF, CockTypesEnum.DRAGON];
 		
 		//Used to determine thickness of knot relative to normal thickness
 		private var _knotMultiplier:Number;
@@ -223,7 +226,17 @@ package classes
 			}
 			LOGGER.debug("thickenCock called and thickened by: {0}", amountGrown);
 			return amountGrown;
-		}	
+		}
+
+		/**
+		 * Check if the given cockType supports a knot.
+		 * @param cockType the cockType to check
+		 * @return true if the cockType supports a knot
+		 */
+		public static function supportsKnot(cockType:CockTypesEnum):Boolean
+		{
+			return cockTypesWithKnots.indexOf(cockType) != OBJECT_NOT_FOUND;
+		}
 		
 		public function get cockLength():Number 
 		{

--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -29,7 +29,9 @@ package classes
 		 */
 		private static const cockTypesWithKnots:Vector.<CockTypesEnum> = new <CockTypesEnum> [CockTypesEnum.DOG, CockTypesEnum.FOX, CockTypesEnum.WOLF, CockTypesEnum.DRAGON];
 		
-		//Used to determine thickness of knot relative to normal thickness
+		/**
+		 * Used to determine thickness of knot relative to normal thickness
+		 */
 		private var _knotMultiplier:Number;
 		
 		//Piercing info

--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -21,6 +21,12 @@ package classes
 		private var _cockLength:Number;
 		private var _cockThickness:Number;		
 		private var _cockType:CockTypesEnum;	//See CockTypesEnum.as for all cock types
+		
+		/**
+		 * Contains cock types that support knots.
+		 * This is used for the supportsKnot method and with that to decide if a knot is reset when the cock type changes
+		 * e.g. player.cocks[0].cockType = CockTypesEnum.HORSE
+		 */
 		private static const cockTypesWithKnots:Vector.<CockTypesEnum> = new <CockTypesEnum> [CockTypesEnum.DOG, CockTypesEnum.FOX, CockTypesEnum.WOLF, CockTypesEnum.DRAGON];
 		
 		//Used to determine thickness of knot relative to normal thickness
@@ -264,6 +270,10 @@ package classes
 			return _cockType;
 		}
 		
+		/**
+		 * Sets the cock type.
+		 * If the cock type does not support a knot, the knot is reset.
+		 */
 		public function set cockType(value:CockTypesEnum):void 
 		{
 			_cockType = value;

--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -16,6 +16,7 @@ package classes
 
 		public static const MAX_LENGTH:Number = 9999.9;
 		public static const MAX_THICKNESS:Number = 999.9;
+		public static const KNOTMULTIPLIER_NO_KNOT:Number = 1;
 		
 		private var _cockLength:Number;
 		private var _cockThickness:Number;		
@@ -59,7 +60,7 @@ package classes
 			_cockThickness = i_cockThickness;
 			_cockType = i_cockType;
 			_pierced = 0;
-			_knotMultiplier = 1;
+			_knotMultiplier = KNOTMULTIPLIER_NO_KNOT;
 			_isPierced = false;
 			_pShortDesc = "";
 			_pLongDesc = "";
@@ -268,14 +269,14 @@ package classes
 			_cockType = value;
 
 			if(!supportsKnot(value)) {
-				this.knotMultiplier = 1;
+				this.knotMultiplier = KNOTMULTIPLIER_NO_KNOT;
 				LOGGER.debug("Cock type {0} does not support knots, setting knot knotMultiplier to {1}", value, knotMultiplier);
 			}
 		}
 		
 		public function hasKnot():Boolean
 		{
-			return knotMultiplier > 1;
+			return knotMultiplier > KNOTMULTIPLIER_NO_KNOT;
 		}
 		
 		public function get knotMultiplier():Number 

--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -361,8 +361,8 @@ package classes
 		{
 			this.cockThickness = relativeRootObject.cockThickness;
 			this.cockLength = relativeRootObject.cockLength;
-			this.cockType = CockTypesEnum.ParseConstantByIndex(relativeRootObject.cockType);
 			this.knotMultiplier = relativeRootObject.knotMultiplier;
+			this.cockType = CockTypesEnum.ParseConstantByIndex(relativeRootObject.cockType);
 			this.sock = relativeRootObject.sock;
 			
 			this.pierced = relativeRootObject.pierced;

--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -3,6 +3,7 @@ package classes
 	import classes.CockTypesEnum;
 	import classes.internals.Serializable;
 	import classes.internals.Utils;
+	import classes.lists.GenitalLists;
 	import mx.logging.ILogger;
 	import classes.internals.LoggerFactory;
 
@@ -21,13 +22,6 @@ package classes
 		private var _cockLength:Number;
 		private var _cockThickness:Number;		
 		private var _cockType:CockTypesEnum;	//See CockTypesEnum.as for all cock types
-		
-		/**
-		 * Contains cock types that support knots.
-		 * This is used for the supportsKnot method and with that to decide if a knot is reset when the cock type changes
-		 * e.g. player.cocks[0].cockType = CockTypesEnum.HORSE
-		 */
-		private static const cockTypesWithKnots:Vector.<CockTypesEnum> = new <CockTypesEnum> [CockTypesEnum.DOG, CockTypesEnum.FOX, CockTypesEnum.WOLF, CockTypesEnum.DRAGON];
 		
 		/**
 		 * Used to determine thickness of knot relative to normal thickness
@@ -244,7 +238,7 @@ package classes
 		 */
 		public static function supportsKnot(cockType:CockTypesEnum):Boolean
 		{
-			return cockTypesWithKnots.indexOf(cockType) != OBJECT_NOT_FOUND;
+			return GenitalLists.KNOTTED_COCKS.indexOf(cockType) != OBJECT_NOT_FOUND;
 		}
 		
 		public function get cockLength():Number 

--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -266,6 +266,11 @@ package classes
 		public function set cockType(value:CockTypesEnum):void 
 		{
 			_cockType = value;
+
+			if(!supportsKnot(value)) {
+				this.knotMultiplier = 1;
+				LOGGER.debug("Cock type {0} does not support knots, setting knot knotMultiplier to {1}", value, knotMultiplier);
+			}
 		}
 		
 		public function hasKnot():Boolean

--- a/classes/classes/Items/Consumables/KangaFruit.as
+++ b/classes/classes/Items/Consumables/KangaFruit.as
@@ -1,3 +1,4 @@
+
 package classes.Items.Consumables 
 {
 	import classes.BodyParts.*;
@@ -160,7 +161,6 @@ package classes.Items.Consumables
 					while (cockIdx < player.cockTotal()) {
 						if (player.cocks[cockIdx].cockType !== CockTypesEnum.KANGAROO) {
 							player.cocks[cockIdx].cockType = CockTypesEnum.KANGAROO;
-							player.cocks[cockIdx].knotMultiplier = 1;
 							break;
 						}
 						cockIdx++;

--- a/classes/classes/Items/Consumables/WhiskerFruit.as
+++ b/classes/classes/Items/Consumables/WhiskerFruit.as
@@ -180,7 +180,6 @@ package classes.Items.Consumables
 				}
 				else outputText("Then, it disappears back into your sheath.");
 				player.cocks[i].cockType = CockTypesEnum.CAT;
-				player.cocks[i].knotMultiplier = 1;
 				changes++;
 			}
 			//Cat penorz shrink

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -1041,7 +1041,7 @@
 				result += Pronoun3+(i>0?(" #"+(i+1)):"")+" "+cock.cockType.toString().toLowerCase()+" cock is ";
 				result += Appearance.inchesAndFeetsAndInches(cock.cockLength)+" long and "+cock.cockThickness+"\" thick";
 				if (cock.isPierced) result += ", pierced with " + cock.pLongDesc;
-				if (cock.knotMultiplier !== 1) result += ", with knot of size " + cock.knotMultiplier;
+				if (cock.knotMultiplier !== Cock.KNOTMULTIPLIER_NO_KNOT) result += ", with knot of size " + cock.knotMultiplier;
 				result+=".\n";
 			}
 			if (balls > 0 || ballSize > 0) result += Hehas + numberOfThings(balls, "ball") + " of size " + ballSize+".\n";

--- a/classes/classes/lists/GenitalLists.as
+++ b/classes/classes/lists/GenitalLists.as
@@ -1,0 +1,23 @@
+package classes.lists
+{
+	import classes.CockTypesEnum;
+	/**
+	 * Class for Genital lists
+	 * @since September 29, 2018
+	 * @author Stadler76
+	 */
+	public class GenitalLists
+	{
+		/**
+		 * Contains cock types that support knots.
+		 * This is used for the supportsKnot method and with that to decide if a knot is reset when the cock type changes
+		 * e.g. player.cocks[0].cockType = CockTypesEnum.HORSE
+		 */
+		public static const KNOTTED_COCKS:Vector.<CockTypesEnum> = new <CockTypesEnum>[
+			CockTypesEnum.DOG,
+			CockTypesEnum.FOX,
+			CockTypesEnum.WOLF,
+			CockTypesEnum.DRAGON,
+		];
+	}
+}

--- a/classes/classes/lists/GenitalLists.as
+++ b/classes/classes/lists/GenitalLists.as
@@ -18,6 +18,7 @@ package classes.lists
 			CockTypesEnum.FOX,
 			CockTypesEnum.WOLF,
 			CockTypesEnum.DRAGON,
+			CockTypesEnum.DISPLACER,
 		];
 	}
 }

--- a/test/ClassesSuit.as
+++ b/test/ClassesSuit.as
@@ -17,6 +17,7 @@ package {
 	import classes.PlayerEventsTest;
 	import classes.PlayerEventsVaginaLoosenessRecoveryTest;
 	import classes.MenusSuit;
+	import classes.CockKnotSupportTest;
 
 [Suite]
 [RunWith("org.flexunit.runners.Suite")]
@@ -40,5 +41,6 @@ package {
 		 public var internalsSuit:InternalsSuit;
 		 public var menusSuit:MenusSuit;
 		 public var appearanceTest:AppearanceTest;
+		 public var cockKnotSupportTest:CockKnotSupportTest;
 	}
 }

--- a/test/classes/CockKnotSupportTest.as
+++ b/test/classes/CockKnotSupportTest.as
@@ -21,6 +21,7 @@ package classes{
 			[CockTypesEnum.DRAGON, 		true],
 			[CockTypesEnum.FOX, 		true],
 			[CockTypesEnum.WOLF, 		true],
+			[CockTypesEnum.DISPLACER, 	true],
 
 			[CockTypesEnum.HUMAN, 		false],
 			[CockTypesEnum.HORSE, 		false],
@@ -30,7 +31,6 @@ package classes{
 			[CockTypesEnum.LIZARD, 		false],
 			[CockTypesEnum.ANEMONE, 	false],
 			[CockTypesEnum.KANGAROO, 	false],
-			[CockTypesEnum.DISPLACER, 	false],
 			[CockTypesEnum.BEE, 		false],
 			[CockTypesEnum.PIG, 		false],
 			[CockTypesEnum.AVIAN, 		false],

--- a/test/classes/CockKnotSupportTest.as
+++ b/test/classes/CockKnotSupportTest.as
@@ -1,0 +1,56 @@
+package classes{
+
+	import org.hamcrest.assertThat;
+	import org.hamcrest.object.equalTo;
+	
+	import classes.Cock;
+	import classes.CockTypesEnum;
+
+	import org.flexunit.runners.Parameterized;
+
+	[RunWith("org.flexunit.runners.Parameterized")]
+	public class CockKnotSupportTest
+	{
+
+		private var cockType:CockTypesEnum;
+		private var supportsKnot:Boolean;
+
+		[Parameters]
+		public static var testData:Array = [
+			[CockTypesEnum.DOG, 		true],
+			[CockTypesEnum.DRAGON, 		true],
+			[CockTypesEnum.FOX, 		true],
+			[CockTypesEnum.WOLF, 		true],
+
+			[CockTypesEnum.HUMAN, 		false],
+			[CockTypesEnum.HORSE, 		false],
+			[CockTypesEnum.DEMON, 		false],
+			[CockTypesEnum.TENTACLE, 	false],
+			[CockTypesEnum.CAT, 		false],
+			[CockTypesEnum.LIZARD, 		false],
+			[CockTypesEnum.ANEMONE, 	false],
+			[CockTypesEnum.KANGAROO, 	false],
+			[CockTypesEnum.DISPLACER, 	false],
+			[CockTypesEnum.BEE, 		false],
+			[CockTypesEnum.PIG, 		false],
+			[CockTypesEnum.AVIAN, 		false],
+			[CockTypesEnum.RHINO, 		false],
+			[CockTypesEnum.ECHIDNA, 	false],
+			[CockTypesEnum.RED_PANDA, 	false],
+			[CockTypesEnum.FERRET, 		false],
+			[CockTypesEnum.UNDEFINED, 	false]
+		];
+
+		public function CockKnotSupportTest(cockType:CockTypesEnum, supportsKnot:Boolean):void
+		{
+			this.cockType = cockType;
+			this.supportsKnot = supportsKnot;
+		}
+
+		[Test]
+		public function testIfCockSupportsKnot():void
+		{
+			assertThat(Cock.supportsKnot(cockType), equalTo(supportsKnot));
+		}
+	}
+}

--- a/test/classes/CockTest.as
+++ b/test/classes/CockTest.as
@@ -187,5 +187,21 @@ package classes{
 
 			assertThat(cut.knotMultiplier, equalTo(DEFAULT_KNOT_MULTIPLIER));
 		}
+		
+		[Test]
+		public function checkHasKnot():void
+		{
+			cut.knotMultiplier = KNOT_MULTIPLIER;
+
+			assertThat(cut.hasKnot(), equalTo(true));
+		}
+		
+		[Test]
+		public function checkHasNoKnot():void
+		{
+			cut.knotMultiplier = Cock.KNOTMULTIPLIER_NO_KNOT;
+
+			assertThat(cut.hasKnot(), equalTo(false));
+		}
 	}
 }

--- a/test/classes/CockTest.as
+++ b/test/classes/CockTest.as
@@ -23,6 +23,7 @@ package classes{
 
 		private static const COCK_LENGTH:Number = 12.3;
 		private static const COCK_THICKNESS:Number= 3.21;
+		private static const KNOT_MULTIPLIER:Number = 2.3;
 		
 		private var cut:Cock;
 		private var serializedClass:*;
@@ -165,6 +166,26 @@ package classes{
 			SerializationUtils.deserialize(serializedClass, cut);
 			
 			assertThat(cut.cockThickness, equalTo(COCK_THICKNESS));
+		}
+
+		[Test]
+		public function doNotResetKnotIfKnotIsSupported():void
+		{
+			cut.knotMultiplier = KNOT_MULTIPLIER;
+
+			cut.cockType = CockTypesEnum.DOG;
+
+			assertThat(cut.knotMultiplier, equalTo(KNOT_MULTIPLIER));
+		}
+
+		[Test]
+		public function resetKnotIfKnotIsNotSupported():void
+		{
+			cut.knotMultiplier = KNOT_MULTIPLIER;
+
+			cut.cockType = CockTypesEnum.HORSE;
+
+			assertThat(cut.knotMultiplier, equalTo(DEFAULT_KNOT_MULTIPLIER));
 		}
 	}
 }

--- a/test/classes/Items/Consumables/KangaFruitTest.as
+++ b/test/classes/Items/Consumables/KangaFruitTest.as
@@ -1,0 +1,65 @@
+package classes.Items.Consumables 
+{
+	import classes.CoC;
+	import classes.CockTypesEnum;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Items.Consumable;
+	import classes.Player;
+	import classes.helper.StageLocator;
+	
+	import org.hamcrest.assertThat;
+	import org.hamcrest.object.equalTo;
+
+	public class KangaFruitTest 
+	{
+		private static const DEFAULT_KNOT_MULTIPLIER:Number = 1;
+		private static const KNOT_MULTIPLIER:Number = 2.3;
+		private static const ITEM_USE_COUNT:int = 20;
+		
+		private var standard:KangaFruit;
+		private var enhanced:KangaFruit;
+		
+		private var player:Player;
+		
+		private function useItemMultipleTimes(consumable:Consumable):void
+		{
+			for (var i:int = 0; i < ITEM_USE_COUNT; i++) {
+				consumable.useItem();
+			}
+		}
+		
+		[BeforeClass]
+		public static function setUpClass():void
+		{
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+
+		[Before]
+		public function setUp():void {
+			standard = new KangaFruit(KangaFruit.STANDARD);
+			enhanced = new KangaFruit(KangaFruit.ENHANCED);
+			player = new Player();
+			
+			kGAMECLASS.player = player;
+		}
+		
+		[Test] 
+		public function cockTransformationResetsKnot():void {
+			player.createCock(5.5, 1, CockTypesEnum.DOG);
+			player.cocks[0].knotMultiplier = KNOT_MULTIPLIER;
+			
+			useItemMultipleTimes(enhanced);
+			
+			assertThat(player.cocks[0].knotMultiplier, equalTo(DEFAULT_KNOT_MULTIPLIER));
+		}
+		
+		[Test] 
+		public function standardDoesNotTransformCock():void {
+			player.createCock(5.5, 1, CockTypesEnum.DOG);
+			
+			useItemMultipleTimes(standard);
+			
+			assertThat(player.cocks[0].cockType , equalTo(CockTypesEnum.DOG));
+		}
+	}
+}

--- a/test/classes/Items/Consumables/WhiskerFruitTest.as
+++ b/test/classes/Items/Consumables/WhiskerFruitTest.as
@@ -1,0 +1,53 @@
+package classes.Items.Consumables 
+{
+	import classes.CoC;
+	import classes.CockTypesEnum;
+	import classes.GlobalFlags.kGAMECLASS;
+	import classes.Items.Consumable;
+	import classes.Player;
+	import classes.helper.StageLocator;
+	
+	import org.hamcrest.assertThat;
+	import org.hamcrest.object.equalTo;
+
+	public class WhiskerFruitTest 
+	{
+		private static const DEFAULT_KNOT_MULTIPLIER:Number = 1;
+		private static const KNOT_MULTIPLIER:Number = 2.3;
+		private static const ITEM_USE_COUNT:int = 20;
+		
+		private var cut:WhiskerFruit;
+		private var player:Player;
+		
+		private function useItemMultipleTimes(consumable:Consumable):void
+		{
+			for (var i:int = 0; i < ITEM_USE_COUNT; i++) {
+				consumable.useItem();
+			}
+		}
+		
+		[BeforeClass]
+		public static function setUpClass():void
+		{
+			kGAMECLASS = new CoC(StageLocator.stage);
+		}
+
+		[Before]
+		public function setUp():void {
+			cut = new WhiskerFruit();
+			player = new Player();
+			
+			kGAMECLASS.player = player;
+		}
+		
+		[Test] 
+		public function cockTransformationResetsKnot():void {
+			player.createCock(5.5, 1, CockTypesEnum.DOG);
+			player.cocks[0].knotMultiplier = KNOT_MULTIPLIER;
+			
+			useItemMultipleTimes(cut);
+			
+			assertThat(player.cocks[0].knotMultiplier, equalTo(DEFAULT_KNOT_MULTIPLIER));
+		}
+	}
+}

--- a/test/classes/Items/ConsumablesSuite.as
+++ b/test/classes/Items/ConsumablesSuite.as
@@ -1,10 +1,12 @@
 package classes.Items {
 	import classes.Items.Consumables.KangaFruitTest;
+	import classes.Items.Consumables.WhiskerFruitTest;
 
 	[Suite]
 	[RunWith("org.flexunit.runners.Suite")]
 	public class ConsumablesSuite
 	{
 		public var kangaFruitTest:KangaFruitTest
+		public var whiskerFruitTest:WhiskerFruitTest
 	}
 }

--- a/test/classes/Items/ConsumablesSuite.as
+++ b/test/classes/Items/ConsumablesSuite.as
@@ -1,0 +1,10 @@
+package classes.Items {
+	import classes.Items.Consumables.KangaFruitTest;
+
+	[Suite]
+	[RunWith("org.flexunit.runners.Suite")]
+	public class ConsumablesSuite
+	{
+		public var kangaFruitTest:KangaFruitTest
+	}
+}

--- a/test/classes/ItemsSuit.as
+++ b/test/classes/ItemsSuit.as
@@ -1,6 +1,7 @@
 package classes {
 	import classes.Items.ArmorsSuite;
 	import classes.Items.ConsumableTest;
+	import classes.Items.ConsumablesSuite;
 	import classes.Items.MutationsTest;
 
 [Suite]
@@ -10,5 +11,6 @@ package classes {
 		 public var mutationsTest:MutationsTest;
 		 public var consumableTest:ConsumableTest;
 		 public var armorsSuite:ArmorsSuite;
+		 public var consumablesSuite:ConsumablesSuite;
 	}
 }


### PR DESCRIPTION
- Method to check if a cock type supports a knot
- Added knot reset code to `set cockType` in `Cock`
- Removed knot reset code from items that had it

This fixes the remainder of #1335