### PR TITLE
Enable code completion for tests in asconfig

### DIFF
--- a/asconfig.json
+++ b/asconfig.json
@@ -6,7 +6,8 @@
             "lib/bin"
         ],
         "source-path": [
-            "classes"
+            "classes",
+            "test"
         ],
         "output": "target/Main.swf",
         "define": [

--- a/asconfig.json
+++ b/asconfig.json
@@ -3,7 +3,8 @@
     "config": "flex",
     "compilerOptions": {
         "library-path": [
-            "lib/bin"
+            "lib/bin",
+            "lib/bin/flexunit/"
         ],
         "source-path": [
             "classes",


### PR DESCRIPTION
- Include the `test/` directory as source code
- Include the `lib/bin/flexunit/` directory as a library

This allows code completion to work in tests.