### PR TITLE
Cat-face reworked

### DIFF
--- a/classes/classes/Appearance.as
+++ b/classes/classes/Appearance.as
@@ -1930,6 +1930,7 @@ package classes {
 					[Face.SHARK_TEETH, "shark"],
 					[Face.SNAKE_FANGS, "snake"],
 					[Face.CAT, "cat"],
+					[Face.CATGIRL, "cat"],
 					[Face.LIZARD, "lizard"],
 					[Face.BUNNY, "bunny"],
 					[Face.KANGAROO, "kangaroo"],
@@ -1959,6 +1960,7 @@ package classes {
 					[Tongue.DRACONIC, "draconic"],
 					[Tongue.ECHIDNA, "echidna"],
 					[Tongue.LIZARD, "lizard"],
+					[Tongue.CAT, "cat"],
 				]
 		);
 		public static const DEFAULT_EYES_NAMES:Object = createMapFromPairs(
@@ -1972,6 +1974,7 @@ package classes {
 					[Eyes.BASILISK, "basilisk"],
 					[Eyes.SPIDER, "spider"],
 					[Eyes.COCKATRICE, "cockatrice"],
+					[Eyes.CAT, "cat"],
 				]
 		);
 		public static const DEFAULT_EARS_NAMES:Object = createMapFromPairs(

--- a/classes/classes/BodyParts/Eyes.as
+++ b/classes/classes/BodyParts/Eyes.as
@@ -21,6 +21,26 @@ package classes.BodyParts
 		public var type:Number  = HUMAN;
 		public var count:Number = 2;
 
+		public function setType(eyeType:Number, eyeCount:Number = NaN):void
+		{
+			type = eyeType;
+
+			if (!isNaN(eyeCount)) {
+				count = eyeCount;
+				return;
+			}
+
+			switch (eyeType) {
+				case FOUR_SPIDER_EYES:
+				case SPIDER:
+					count = 4;
+					break;
+
+				default:
+					count = 2;
+			}
+		}
+
 		public function restore():void
 		{
 			type  = HUMAN;

--- a/classes/classes/BodyParts/Eyes.as
+++ b/classes/classes/BodyParts/Eyes.as
@@ -16,6 +16,7 @@ package classes.BodyParts
 		public static const WOLF:int                 =   6;
 		public static const SPIDER:int               =   7;
 		public static const COCKATRICE:int           =   8;
+		public static const CAT:int                  =   9;
 
 		public var type:Number  = HUMAN;
 		public var count:Number = 2;

--- a/classes/classes/BodyParts/Face.as
+++ b/classes/classes/BodyParts/Face.as
@@ -1,5 +1,6 @@
 package classes.BodyParts 
 {
+	import classes.Creature;
 	/**
 	 * Container class for the players face
 	 * @since August 08, 2017
@@ -13,7 +14,7 @@ package classes.BodyParts
 		public static const COW_MINOTAUR:int =   3;
 		public static const SHARK_TEETH:int  =   4;
 		public static const SNAKE_FANGS:int  =   5;
-		public static const CAT:int          =   6;
+		public static const CATGIRL:int      =   6;
 		public static const LIZARD:int       =   7;
 		public static const BUNNY:int        =   8;
 		public static const KANGAROO:int     =   9;
@@ -35,8 +36,39 @@ package classes.BodyParts
 		public static const COCKATRICE:int   =  25;
 		public static const BEAK:int         =  26; // This is a placeholder for the next beaked face type, so feel free to refactor (rename)
 		public static const RED_PANDA:int    =  27;
+		public static const CAT:int          =  28;
 
+		private var _creature:Creature;
 		public var type:Number = HUMAN;
+
+		public function Face(i_creature:Creature = null)
+		{
+			_creature = i_creature;
+		}
+
+		public function setType(faceType:Number, eyeType:Number = NaN):void
+		{
+			type = faceType;
+
+			if (_creature === null) {
+				return;
+			}
+
+			if (!isNaN(eyeType)) {
+				_creature.eyes.type = eyeType;
+				return;
+			}
+
+			switch(faceType) {
+				case Face.CAT:
+				case Face.CATGIRL:
+					_creature.eyes.type = Eyes.CAT;
+					break;
+
+				default:
+					// Empty default because SonarQQbe ...
+			}
+		}
 
 		public function restore():void
 		{

--- a/classes/classes/BodyParts/Face.as
+++ b/classes/classes/BodyParts/Face.as
@@ -55,14 +55,14 @@ package classes.BodyParts
 			}
 
 			if (!isNaN(eyeType)) {
-				_creature.eyes.type = eyeType;
+				_creature.eyes.setType(eyeType);
 				return;
 			}
 
-			switch(faceType) {
+			switch (faceType) {
 				case Face.CAT:
 				case Face.CATGIRL:
-					_creature.eyes.type = Eyes.CAT;
+					_creature.eyes.setType(Eyes.CAT);
 					break;
 
 				default:

--- a/classes/classes/BodyParts/Tongue.as
+++ b/classes/classes/BodyParts/Tongue.as
@@ -13,6 +13,7 @@ package classes.BodyParts
 		public static const DRACONIC:int =   3;
 		public static const ECHIDNA:int  =   4;
 		public static const LIZARD:int   =   5;
+		public static const CAT:int      =   6;
 
 		public var type:Number = HUMAN;
 

--- a/classes/classes/Character.as
+++ b/classes/classes/Character.as
@@ -308,7 +308,7 @@ package classes
 			{
 				if (int(Math.random() * 3) == 0 && face.type == Face.HORSE)
 					stringo = "long ";
-				if (int(Math.random() * 3) == 0 && face.type == Face.CAT)
+				if (int(Math.random() * 3) == 0 && hasCatFace())
 					stringo = "feline ";
 				if (int(Math.random() * 3) == 0 && face.type == Face.RHINO)
 					stringo = "rhino ";

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -382,7 +382,7 @@ package classes
 		public var butt:Butt = new Butt();
 		public var ears:Ears = new Ears();
 		public var eyes:Eyes = new Eyes();
-		public var face:Face = new Face();
+		public var face:Face; // Set in the constructor ...
 		public var gills:Gills = new Gills();
 		public var hair:Hair = new Hair();
 		public var hips:Hips = new Hips();
@@ -610,6 +610,7 @@ package classes
 			_perks = [];
 			statusEffects = [];
 			arms = new Arms(this);
+			face = new Face(this);
 			//keyItems = new Array();
 		}
 
@@ -2792,6 +2793,16 @@ package classes
 		public function hasBeak():Boolean
 		{
 			return [Face.BEAK, Face.COCKATRICE].indexOf(face.type) != -1;
+		}
+
+		public function hasCatFace():Boolean
+		{
+			return [Face.CAT, Face.CATGIRL].indexOf(face.type) != -1;
+		}
+
+		public function hasCatEyes():Boolean
+		{
+			return eyes.type === Eyes.CAT;
 		}
 
 		public function hasClaws():Boolean

--- a/classes/classes/DebugMenu.as
+++ b/classes/classes/DebugMenu.as
@@ -917,7 +917,7 @@ package classes
 			[Face.COW_MINOTAUR,"(3) COW_MINOTAUR"],
 			[Face.SHARK_TEETH,"(4) SHARK_TEETH"],
 			[Face.SNAKE_FANGS,"(5) SNAKE_FANGS"],
-			[Face.CAT,"(6) CAT"],
+			[Face.CATGIRL,"(6) CATGIRL"],
 			[Face.LIZARD,"(7) LIZARD"],
 			[Face.BUNNY,"(8) BUNNY"],
 			[Face.KANGAROO,"(9) KANGAROO"],
@@ -939,6 +939,7 @@ package classes
 			[Face.COCKATRICE,"(25) COCKATRICE"],
 			//[Face.BEAK,"(26) BEAK"], // Unused placeholder
 			[Face.RED_PANDA,"(27) RED_PANDA"],
+			[Face.CAT,"(28) CAT"],
 			/* [INTERMOD: xianxia]
 			[Face.MANTICORE,"(25) MANTICORE"],
 			[Face.SALAMANDER_FANGS,"(26) SALAMANDER_FANGS"],
@@ -965,6 +966,7 @@ package classes
 			[Tongue.DRACONIC, "(3) DRACONIC"],
 			[Tongue.ECHIDNA, "(4) ECHIDNA"],
 			[Tongue.LIZARD, "(5) LIZARD"],
+			[Tongue.CAT, "(6) CAT"],
 			/* [INTERMOD: xianxia]
 			[Tongue.CAT, "(5) CAT"],
 			*/
@@ -988,6 +990,7 @@ package classes
 			[Eyes.WOLF, "(6) WOLF"],
 			[Eyes.SPIDER, "(7) SPIDER"],
 			[Eyes.COCKATRICE, "(8) COCKATRICE"],
+			[Eyes.CAT, "(9) CAT"],
 		];
 		private static const EAR_TYPE_CONSTANTS:Array    = [
 			[Ears.HUMAN, "(0) HUMAN"],

--- a/classes/classes/Items/Consumables/WhiskerFruit.as
+++ b/classes/classes/Items/Consumables/WhiskerFruit.as
@@ -314,7 +314,7 @@ package classes.Items.Consumables
 				          +" You walk around disoriented until the luminosity fades back to normal."
 				          +" You run to a puddle of water to check your reflection and quickly notice your pupils have become cat-like.");
 				outputText("\n<b>You now have cat-eyes!</b>");
-				player.eyes.type = Eyes.CAT;
+				player.eyes.setType(Eyes.CAT);
 				changes++;
 			}
 			//CAT-FACE!  FULL ON FURRY!  RAGE AWAY NEKOZ

--- a/classes/classes/Items/Consumables/WhiskerFruit.as
+++ b/classes/classes/Items/Consumables/WhiskerFruit.as
@@ -238,6 +238,23 @@ package classes.Items.Consumables
 				mutations.updateOvipositionPerk(tfSource);
 			}
 			//Body type changes.  Teh rarest of the rare.
+			// Catgirl-face -> cat-morph-face
+			if (player.face.type === Face.CATGIRL &&
+				player.tongue.type === Tongue.CAT &&
+				player.ears.type === Ears.CAT &&
+				player.tail.type === Tail.CAT &&
+				player.lowerBody.type === LowerBody.CAT &&
+				player.arms.type === Arms.CAT &&
+				(player.hasFur() || (player.hasReptileScales() && player.dragonneScore() >= 4)) &&
+				rand(5) === 0 && changes < changeLimit
+			) {
+				outputText("\n\nMind-numbing pain courses through you as you feel your facial bones rearranging."
+				          +" You clutch at your face in agony as your skin crawls and shifts, your visage reshaping to replace your facial"
+				          +" characteristics with those of a feline along with a muzzle, a cute cat-nose and whiskers.");
+				outputText("\n<b>You now have a cat-face.</b>");
+				player.face.type = Face.CAT;
+				changes++;
+			}
 			//DA EARZ
 			if (player.ears.type !== Ears.CAT && rand(5) === 0 && changes < changeLimit) {
 				//human to cat:
@@ -291,14 +308,32 @@ package classes.Items.Consumables
 				outputText("You reach down to scratch your arm absent-mindedly and pull your fingers away to find strands of " + player.skin.furColor + " fur. Wait, fur?  What just happened?! You spend a moment examining yourself and discover that <b>you are now covered in glossy, soft fur.</b>");
 				changes++;
 			}
+			// Fix old cat faces without cat-eyes.
+			if (player.hasCatFace() && !player.hasCatEyes() && rand(3) === 0 && changes < changeLimit) {
+				outputText("\n\nFor a moment your sight shifts as the ambient light suddenly turns extremely bright, almost blinding you."
+				          +" You walk around disoriented until the luminosity fades back to normal."
+				          +" You run to a puddle of water to check your reflection and quickly notice your pupils have become cat-like.");
+				outputText("\n<b>You now have cat-eyes!</b>");
+				player.eyes.type = Eyes.CAT;
+				changes++;
+			}
 			//CAT-FACE!  FULL ON FURRY!  RAGE AWAY NEKOZ
-			if (player.tail.type === Tail.CAT && player.ears.type === Ears.CAT && rand(5) === 0 && changes < changeLimit && player.lowerBody.type === LowerBody.CAT && (player.hasFur() || (player.hasReptileScales() && player.dragonneScore() >= 4)) && player.face.type !== Face.CAT) {
+			if (player.tail.type === Tail.CAT && player.ears.type === Ears.CAT && player.lowerBody.type === LowerBody.CAT && !player.hasCatFace() && rand(5) === 0 && changes < changeLimit) {
 				//Gain cat face, replace old face
-				temp = rand(3);
-				if (temp === 0) outputText("\n\nYour face is wracked with pain. You throw back your head and scream in agony as you feel your cheekbones breaking and shifting, reforming into something... different. You find a puddle to view your reflection and discover <b>your face is now a cross between human and feline features.</b>");
-				else if (temp === 1) outputText("\n\nMind-numbing pain courses through you as you feel your facial bones rearranging.  You clutch at your face in agony as your skin crawls and shifts, your visage reshaping to replace your facial characteristics with those of a feline. <b>You now have an anthropomorphic cat-face.</b>");
-				else outputText("\n\nYour face is wracked with pain. You throw back your head and scream in agony as you feel your cheekbones breaking and shifting, reforming into something else. <b>Your facial features rearrange to take on many feline aspects.</b>");
-				player.face.type = Face.CAT;
+				outputText("\n\nYou feel your canines changing, elongating into sharp dagger-like teeth capable of causing severe injuries."
+				          +" Funnily, your face remained relatively human even after the change. You purr at the change, giving you a cute look."
+				          +"[if (hasCatEyes == false)\nFor a moment your sight shifts as the ambient light suddenly turns extremely bright,"
+				          +" almost blinding you. You walk around disoriented until the luminosity fades back to normal."
+				          +" You run to a puddle of water to check your reflection and quickly notice your pupils have become cat-like.]");
+				outputText("\n<b>You now have the face of a cat-" + player.mf("boy", "girl") + "!</b>");
+				player.face.setType(Face.CATGIRL);
+				changes++;
+			}
+			// Cat-tongue
+			if (player.hasCatFace() && player.tongue.type !== Tongue.CAT && rand(5) === 0 && changes < changeLimit) {
+				outputText("\n\nYour tongue suddenly feel weird. You try to stick it out to see whats going on and discover it changed to look"
+				          +" similar to the tongue of a cat. At least you will be able to groom yourself properly with <b>your new cat tongue</b>.");
+				player.tongue.type = Tongue.CAT;
 				changes++;
 			}
 			//Arms

--- a/classes/classes/Parser/conditionalConverters.as
+++ b/classes/classes/Parser/conditionalConverters.as
@@ -55,6 +55,8 @@
 				"hascock"			: function():* {return  kGAMECLASS.player.hasCock();},
 				"hassheath"			: function():* {return  kGAMECLASS.player.hasSheath();},
 				"hasbeak"			: function():* {return  kGAMECLASS.player.hasBeak();},
+				"hascateyes"		: function():* {return  kGAMECLASS.player.hasCatEyes();},
+				"hascatface"		: function():* {return  kGAMECLASS.player.hasCatFace();},
 				"hasclaws"			: function():* {return  kGAMECLASS.player.hasClaws();},
 				"hasdragonneck"		: function():* {return  kGAMECLASS.player.hasDragonNeck();},
 				"hastail"			: function():* {return  kGAMECLASS.player.hasTail();},

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -791,12 +791,12 @@
 			{
 				if (isTaur() && lowerBody.type == LowerBody.CAT) {
 					race = "cat-taur";
-					if (face.type == 0)
+					if (face.type === Face.HUMAN || (hasCatFace() && !isFurryOrScaley()))
 						race = "sphinx-morph"; // no way to be fully feral anyway
 				}
 				else {
 					race = "cat-morph";
-					if (face.type == 0)
+					if (face.type === Face.HUMAN || (hasCatFace() && !isFurryOrScaley()))
 						race = "cat-" + mf("boy", "girl");
 				}
 			}
@@ -1462,7 +1462,9 @@
 		public function catScore():Number
 		{
 			var catCounter:Number = 0;
-			if (face.type == Face.CAT)
+			if (hasCatFace())
+				catCounter++;
+			if (tongue.type == Tongue.CAT)
 				catCounter++;
 			if (ears.type == Ears.CAT)
 				catCounter++;
@@ -2019,7 +2021,7 @@
 		public function manticoreScore():Number
 		{
 			var catCounter:Number = 0;
-			if (face.type == Face.CAT)
+			if (hasCatFace())
 				catCounter++;
 			if (ears.type == Ears.CAT)
 				catCounter++;

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -165,21 +165,21 @@ package classes
 					outputText("  You have the facial structure of a dog, wet nose and all, but overlaid with glittering [skinFurScales].");
 			}
 			//cat-face
-			if (player.face.type == Face.CAT) 
+			if (player.hasCatFace())
 			{
-				if (player.hasPlainSkin() || player.hasGooSkin()) 
-					outputText("  You have a cat-like face, complete with a cute, moist nose and whiskers.  The [skin] that is revealed by your lack of fur looks quite unusual on so feline a face.");
-				if (player.hasFur())
-					if (player.hasDifferentUnderBody())
-						outputText("  You have a cat-like face, complete with moist nose and whiskers.  You have [skinFurScales] on your upper jaw and head, while your lower jaw is decorated by [underBody.skinFurScales], hiding your [skin.noadj] underneath.");
-					else
-						outputText("  You have a cat-like face, complete with moist nose and whiskers.  Your [skinDesc] is [furColor], hiding your [skin.noadj] underneath.");
-				if (player.hasScales()) 
-					outputText("  Your facial structure blends humanoid features with those of a cat.  A moist nose and whiskers are included, but overlaid with glittering [skinFurScales].");
-				if (player.eyes.type != Eyes.BLACK_EYES_SAND_TRAP)
+				if (player.face.type === Face.CAT && player.isFurryOrScaley())
 				{
-					outputText("  Of course, no feline face would be complete without vertically slit eyes");
-					outputText(!player.hasReptileEyes() ? "." : ", although they come with a second set of eyelids, which is somewhat unusual for a cats face.");
+					if (player.hasDifferentUnderBody())
+						outputText("  You have a cat-like face, complete with moist nose and whiskers."
+						          +" You have [skinFurScales] on your upper jaw and head, while your lower jaw is decorated"
+						          +" by [underBody.skinFurScales][if (isFurry), hiding your [skin.noadj] underneath].");
+					else
+						outputText("  You have a cat-like face, complete with moist nose and whiskers."
+						          +" It has [skinFurScales][if (isFurry), hiding your [skin.noadj] underneath].");
+				}
+				else
+				{
+					outputText("  Your face is human in appearance. You have a set of sharp cat-like teeth in your mouth.");
 				}
 			}
 			//Minotaaaauuuur-face
@@ -290,7 +290,9 @@ package classes
 			else if (player.eyes.type == Eyes.COCKATRICE)
 				outputText("  You have electric blue eyes spiderwebbed with lightning like streaks that signal their power and slit reptilian pupils."
 				          +" When excited your pupils dilate into wide circles.");
-			else if (player.face.type != Face.CAT && player.hasReptileEyes())
+			else if (player.eyes.type == Eyes.CAT)
+				outputText("  Your eyes are similar to those of a cat, with slit pupils.");
+			else if (player.hasReptileEyes())
 			{
 				outputText("  Your eyes are");
 				switch (player.eyes.type)
@@ -413,18 +415,36 @@ package classes
 			}
 			
 			//Tongue
-			if (player.tongue.type == Tongue.SNAKE) 
-				outputText("  A snake-like tongue occasionally flits between your lips, tasting the air.");
-			else if (player.tongue.type == Tongue.DEMONIC) 
-				outputText("  A slowly undulating tongue occasionally slips from between your lips.  It hangs nearly two feet long when you let the whole thing slide out, though you can retract it to appear normal.");
-			else if (player.tongue.type == Tongue.DRACONIC) 
-				outputText("  Your mouth contains a thick, fleshy tongue that, if you so desire, can telescope to a distance of about four feet.  It has sufficient manual dexterity that you can use it almost like a third arm.");
-			else if (player.tongue.type == Tongue.ECHIDNA)
-				outputText("  A thin echidna tongue, at least a foot long, occasionally flits out from between your lips.");
-			else if (player.tongue.type == Tongue.LIZARD)
-				outputText("  Your mouth contains a thick, fleshy lizard tongue, bringing to mind the tongue of large predatory reptiles."
-				          +" It can reach up to one foot, its forked tips tasting the air as they flick at the end of each movement.");
-			//Horns
+			switch (player.tongue.type) {
+				case Tongue.SNAKE:
+					outputText("  A snake-like tongue occasionally flits between your lips, tasting the air.");
+					break;
+
+				case Tongue.DEMONIC:
+					outputText("  A slowly undulating tongue occasionally slips from between your lips."
+					          +" It hangs nearly two feet long when you let the whole thing slide out, though you can retract it to appear normal.");
+					break;
+
+				case Tongue.DRACONIC:
+					outputText("  Your mouth contains a thick, fleshy tongue that, if you so desire, can telescope to a distance of about four feet."
+					          +" It has sufficient manual dexterity that you can use it almost like a third arm.");
+					break;
+
+				case Tongue.ECHIDNA:
+					outputText("  A thin echidna tongue, at least a foot long, occasionally flits out from between your lips.");
+					break;
+
+				case Tongue.LIZARD:
+					outputText("  Your mouth contains a thick, fleshy lizard tongue, bringing to mind the tongue of large predatory reptiles."
+					          +" It can reach up to one foot, its forked tips tasting the air as they flick at the end of each movement.");
+					break;
+
+				case Tongue.CAT:
+					outputText("  Your tongue is rough like that of a cat. You sometimes groom yourself with it.");
+					break;
+
+				default:
+			}
 			if (player.horns.type == Horns.IMP) {
 				outputText(" A set of pointed imp horns rest atop your head.");
 			}

--- a/classes/classes/Scenes/Places/Farm.as
+++ b/classes/classes/Scenes/Places/Farm.as
@@ -441,7 +441,7 @@ public function workFarm():void {
 		outputText("  The first thing that hits you is the smell, a mingling of sweat, milk, droppings, and rotting hay. There are also probably some cows in Whitney's herd ready for breeding.\n\n");
 		outputText("Opening the door to one of the empty stalls, Whitney says, \"<i>I don't get to them as often as I should. Anything you can do would help.</i>\"\n\n");
 		outputText("You steel yourself, ignore your ");
-		if (InCollection(player.face.type, Face.DOG, Face.FOX, Face.CAT)) outputText("sensitive ");
+		if (InCollection(player.face.type, Face.DOG, Face.FOX, Face.CAT, Face.CATGIRL)) outputText("sensitive ");
 		outputText("nose, and set to work.");
 		//[Lust increase based on libido, degree of cow/mino features] 
 		if (player.cowScore() + player.minoScore() > 0) dynStats("lus", player.cowScore() + player.minoScore());

--- a/includes/debug.as
+++ b/includes/debug.as
@@ -174,7 +174,7 @@ public function doThatTestingThang():void
 * 17 \[if (hasCock) HERP|DERP\]
 * 17 [if (hasCock) HERP|DERP]
 * 18 \[if (hasVagina) HERP|DERP\]
-* 18 [if (hasVagina) HERP|DERP]
+* 18 [if (hasVagina) HERP | DERP]
 
 ** Member Accessors**
 
@@ -206,6 +206,8 @@ public function doThatTestingThang():void
 * 31 you feel your [if (tallness >= 120)frame|[if (tallness >= 80)smaller frame|much smaller frame]] surrounded 
 * 32 \[if (bakeryTalkedRoot)talked about root|didn't talk about root\]
 * 32 [if (bakeryTalkedRoot)talked about root|didn't talk about root]
+* 33 \[if (hasCatEyes == false) HERP|DERP\]
+* 33 [if (hasCatEyes == false) HERP|DERP]
 
 
 

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -444,7 +444,8 @@ package classes
 			var catPlayer:Player = new Player();
 			createBreastRows(3, catPlayer);
 			createCock(CockTypesEnum.CAT, catPlayer);
-			catPlayer.face.type = Face.CAT;
+			catPlayer.face.setType(Face.CAT);
+			catPlayer.tongue.type = Tongue.CAT;
 			catPlayer.ears.type = Ears.CAT;
 			catPlayer.tail.type = Tail.CAT;
 			catPlayer.lowerBody.type = LowerBody.CAT;


### PR DESCRIPTION
Revamped the cat-face:
- `Face.CAT` is split up into `Face.CAT` (with muzzle, if furry or scaley) and `Face.CATGIRL` aka Nekomimi (Always skinny, no muzzle, nose and whiskers).
- `Tongue.CAT` added.
- `Eyes.CAT` (linked to cat face) added.
- Updated and cleaned up the appearance-tab accordingly

Thanks to Liadri for her help with the blurbs.