### PR TITLE
Perception implementation

### DIFF
--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -239,6 +239,15 @@ package classes
 						"<b>You are not durable enough to gain benefit from this perk.</b>" +
 						"]",
 				"You choose the 'Parry' perk, giving you a chance to deflect blow with your weapon. (Speed-based).");
+		public static const Perception:PerkType = mk("Perception", "Perception",
+				"Raises your perception allowing you to see openings most wouldn't (+3% Crit)",
+				"You've chosen the 'Perception' perk, which raises your critical strike chance by 3%.");
+		public static const Perception2:PerkType = mk("Perception 2", "Perception 2",
+				"Raises your perception allowing you to see openings most wouldn't (+7% Crit)",
+				"You've chosen the 'Perception 2' perk, which raises your critical strike chance by 7%.");
+		public static const Perception3:PerkType = mk("Perception 3", "Perception 3",
+				"Raises your perception allowing you to see openings most wouldn't (+10% Crit)",
+				"You've chosen the 'Perception 3' perk, which raises your critical strike chance by 10%.");
 		public static const Precision:PerkType = mk("Precision", "Precision",
 				"Reduces enemy armor by 10. (Req's 25+ Intelligence)",
 				"You've chosen the 'Precision' perk.  Thanks to your intelligence, you're now more adept at finding and striking an enemy's weak points, reducing their damage resistance from armor by 10.  If your intelligence ever drops below 25 you'll no longer be smart enough to benefit from this perk.");
@@ -302,11 +311,11 @@ package classes
 				"You choose the 'Strong Back 2: Strong Harder' perk, enabling a fifth item slot.");
 		public static const Tactician:PerkType = mk("Tactician", "Tactician",
 				"[if (player.inte>=50)" +
-						"Increases critical hit chance by up to 10% (Intelligence-based)." +
+						"Increases critical hit chance by 1% per 5 points intelligence above 50." +
 						"|" +
 						"<b>You are too dumb to gain benefit from this perk.</b>" +
 						"]",
-				"You choose the 'Tactician' perk, increasing critical hit chance by up to 10% (Intelligence-based).");
+				"You choose the 'Tactician' perk, increasing critical hit chance by 1% per 5 points intelligence above 50.");
 		public static const Tank:PerkType = mk("Tank", "Tank",
 				"Raises max HP by 50.",
 				"You choose the 'Tank' perk, giving you an additional 50 HP!");
@@ -767,6 +776,13 @@ package classes
 			Survivalist2.requireLevel(12)
 						.requirePerk(Survivalist)
 						.requireHungerEnabled();
+			//Other Misc Perks
+			Perception.requireLevel(30)
+			          .requirePerk(Tactician);
+			Perception2.requireLevel(60)
+			          .requirePerk(Perception);
+			Perception3.requireLevel(90)
+			          .requirePerk(Perception2);
 		}
 		{
 			initRequirements();

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -188,6 +188,15 @@ package classes
 		public static const ImprovedSelfControl3:PerkType = mk("Improved Self-Control 3", "Improved Self-Control 3",
 				"Increases maximum lust by further 10.",
 				"You choose the 'Improved Self-Control 2' perk. Thanks to your superior mental conditioning, your maximum lust has been increased by further 10!</b>");
+		public static const ImprovedVision:PerkType = mk("Improved Vision", "Improved Vision",
+				"Improves your vision allowing you to see openings most wouldn't (+3% Crit)",
+				"You've chosen the 'Improved Vision' perk, which raises your critical strike chance by 3%.");
+		public static const ImprovedVision2:PerkType = mk("Improved Vision 2", "Improved Vision 2",
+				"Improves your vision allowing you to see openings most wouldn't (+7% Crit)",
+				"You've chosen the 'Improved Vision 2' perk, which raises your critical strike chance by 7%.");
+		public static const ImprovedVision3:PerkType = mk("Improved Vision 3", "Improved Vision 3",
+				"Improves your vision allowing you to see openings most wouldn't (+10% Crit)",
+				"You've chosen the 'Improved Vision 3' perk, which raises your critical strike chance by 10%.");
 		public static const Indefatigable:PerkType = mk("Indefatigable", "Indefatigable",
 				"Can no longer lose by lust. Can still submit manually at maximum lust via Fantasize.",
 				"You choose the 'Indefatigable' perk. Thanks to your sheer willpower, you can no longer lose when your lust reaches maximum. (Choosing Fantasize at maximum lust still allows you to submit.)")
@@ -239,15 +248,6 @@ package classes
 						"<b>You are not durable enough to gain benefit from this perk.</b>" +
 						"]",
 				"You choose the 'Parry' perk, giving you a chance to deflect blow with your weapon. (Speed-based).");
-		public static const Perception:PerkType = mk("Perception", "Perception",
-				"Raises your perception allowing you to see openings most wouldn't (+3% Crit)",
-				"You've chosen the 'Perception' perk, which raises your critical strike chance by 3%.");
-		public static const Perception2:PerkType = mk("Perception 2", "Perception 2",
-				"Raises your perception allowing you to see openings most wouldn't (+7% Crit)",
-				"You've chosen the 'Perception 2' perk, which raises your critical strike chance by 7%.");
-		public static const Perception3:PerkType = mk("Perception 3", "Perception 3",
-				"Raises your perception allowing you to see openings most wouldn't (+10% Crit)",
-				"You've chosen the 'Perception 3' perk, which raises your critical strike chance by 10%.");
 		public static const Precision:PerkType = mk("Precision", "Precision",
 				"Reduces enemy armor by 10. (Req's 25+ Intelligence)",
 				"You've chosen the 'Precision' perk.  Thanks to your intelligence, you're now more adept at finding and striking an enemy's weak points, reducing their damage resistance from armor by 10.  If your intelligence ever drops below 25 you'll no longer be smart enough to benefit from this perk.");
@@ -777,12 +777,12 @@ package classes
 						.requirePerk(Survivalist)
 						.requireHungerEnabled();
 			//Other Misc Perks
-			Perception.requireLevel(30)
+			ImprovedVision.requireLevel(30)
 			          .requirePerk(Tactician);
-			Perception2.requireLevel(60)
-			          .requirePerk(Perception);
-			Perception3.requireLevel(90)
-			          .requirePerk(Perception2);
+			ImprovedVision2.requireLevel(60)
+			          .requirePerk(ImprovedVision);
+			ImprovedVision3.requireLevel(90)
+			          .requirePerk(ImprovedVision2);
 		}
 		{
 			initRequirements();

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1898,20 +1898,18 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		}
 		else
 			player.lowerBody.legCount = saveFile.data.legCount;
-			
-		if (saveFile.data.eyeCount == undefined) {
-			if (player.eyes.type == Eyes.SPIDER) {
-				player.eyes.count = 4;
-			}
-			else if (player.eyes.type == Eyes.FOUR_SPIDER_EYES) {
-				player.eyes.type = Eyes.SPIDER;
-				player.eyes.count = 4;
-			}
-			else player.eyes.count = 2;
+
+		if (player.eyes.type === Eyes.FOUR_SPIDER_EYES) {
+			player.eyes.type = Eyes.SPIDER;
 		}
-		else
+		if (saveFile.data.eyeCount == undefined) {
+			player.eyes.count = player.eyes.type === Eyes.SPIDER ? 4 : 2;
+		} else {
 			player.eyes.count = saveFile.data.eyeCount;
-			
+		}
+		if (player.eyes.type === Eyes.SPIDER && player.eyes.count < 4) {
+			player.eyes.count = 4;
+		}
 
 		// Fix deprecated and merged underBody-types
 		switch (player.underBody.type) {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1131,17 +1131,14 @@ package classes.Scenes.Combat
 				critChance += 3;
 			}
 			// Special eyes calculations
-			if (player.hasSpiderEyes()) {
-				critChance += 4;
-			} else {
-				switch (player.eyes.type) {
-					case Eyes.DRAGON: critChance += 8; break;
-					case Eyes.CAT:    critChance += 5; break;
-					default: // The default is a lie!
-				}
-				if (player.eyes.count >= 4) {
-					critChance += 2;
-				}
+			switch (player.eyes.type) {
+				case Eyes.DRAGON: critChance += 8; break;
+				case Eyes.CAT:    critChance += 5; break;
+				case Eyes.SPIDER: critChance += 2; break;
+				default: // The default is a lie!
+			}
+			if (player.eyes.count >= 4) {
+				critChance += 2;
 			}
 			// Other calculations
 			if (player.findPerk(PerkLib.Tactician) >= 0 && player.inte >= 50) critChance += (player.inte - 50) / 5;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1122,6 +1122,28 @@ package classes.Scenes.Combat
 		
 		public function getCritChance():Number {
 			var critChance:Number = 5;
+			// Perception calculations
+			if (player.hasPerk(PerkLib.Perception3)) {
+				critChance += 10;
+			} else if (player.hasPerk(PerkLib.Perception2)) {
+				critChance += 7;
+			} else if (player.hasPerk(PerkLib.Perception)) {
+				critChance += 3;
+			}
+			// Special eyes calculations
+			if (player.hasSpiderEyes()) {
+				critChance += 4;
+			} else {
+				switch (player.eyes.type) {
+					case Eyes.DRAGON: critChance += 8; break;
+					case Eyes.CAT:    critChance += 5; break;
+					default: // The default is a lie!
+				}
+				if (player.eyes.count >= 4) {
+					critChance += 2;
+				}
+			}
+			// Other calculations
 			if (player.findPerk(PerkLib.Tactician) >= 0 && player.inte >= 50) critChance += (player.inte - 50) / 5;
 			if (player.findPerk(PerkLib.Blademaster) >= 0 && (player.weaponVerb.search("slash") >= 0 || player.weaponVerb.search("cleave") >= 0 || player.weaponVerb == "keen cut") && player.shield == ShieldLib.NOTHING) critChance += 5;
 			if (player.jewelry.effectId == JewelryLib.MODIFIER_CRITICAL) critChance += player.jewelry.effectMagnitude;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1123,11 +1123,11 @@ package classes.Scenes.Combat
 		public function getCritChance():Number {
 			var critChance:Number = 5;
 			// Perception calculations
-			if (player.hasPerk(PerkLib.Perception3)) {
+			if (player.hasPerk(PerkLib.ImprovedVision3)) {
 				critChance += 10;
-			} else if (player.hasPerk(PerkLib.Perception2)) {
+			} else if (player.hasPerk(PerkLib.ImprovedVision2)) {
 				critChance += 7;
-			} else if (player.hasPerk(PerkLib.Perception)) {
+			} else if (player.hasPerk(PerkLib.ImprovedVision)) {
 				critChance += 3;
 			}
 			// Special eyes calculations


### PR DESCRIPTION
See [CoC: Perception Perk](https://docs.google.com/document/d/1VayqFftPRnBCOBcLbLkRCUUei_UGyMgbzQLORgSGEN0/edit) or [the diff](https://github.com/Kitteh6660/Corruption-of-Champions-Mod/pull/1383/files) for the changes.

I've also updated the descriptions of the perk Tactician, since its not just up to +10% considering ascension and (in Vanilla CoC) racial stats.