### PR TITLE
Serialize player attributes

### DIFF
--- a/classes/classes/Ass.as
+++ b/classes/classes/Ass.as
@@ -1,4 +1,4 @@
-﻿package classes
+package classes
 {
 	import classes.internals.Serializable;
 	import classes.internals.Utils;

--- a/classes/classes/Ass.as
+++ b/classes/classes/Ass.as
@@ -17,11 +17,6 @@
 		public static const LOOSENESS_LOOSE:int        =   3;
 		public static const LOOSENESS_STRETCHED:int    =   4;
 		public static const LOOSENESS_GAPING:int       =   5;
-
-		//constructor
-		public function Ass()
-		{
-		}
 		
 		//data
 		//butt wetness

--- a/classes/classes/Ass.as
+++ b/classes/classes/Ass.as
@@ -1,9 +1,12 @@
 ﻿package classes
 {
+	import classes.internals.Serializable;
 	import classes.internals.Utils;
 
-	public class Ass
+	public class Ass implements Serializable
 	{
+		private static const SERIALIZATION_VERSION:int = 1;
+		
 		public static const WETNESS_DRY:int            =   0;
 		public static const WETNESS_NORMAL:int         =   1;
 		public static const WETNESS_MOIST:int          =   2;
@@ -40,6 +43,30 @@
 					"analWetness", "analLooseness", "fullness"
 			]);
 			return error;
+		}
+		
+		public function serialize(relativeRootObject:*):void 
+		{
+			relativeRootObject.analLooseness = this.analLooseness;
+			relativeRootObject.analWetness = this.analWetness;
+			relativeRootObject.fullness = this.fullness;
+		}
+		
+		public function deserialize(relativeRootObject:*):void 
+		{
+			this.analLooseness = relativeRootObject.analLooseness;
+			this.analWetness = relativeRootObject.analWetness;
+			this.fullness = relativeRootObject.fullness;
+		}
+		
+		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
+		{
+			// nothing to upgrade yet
+		}
+		
+		public function currentSerializationVerison():int 
+		{
+			return SERIALIZATION_VERSION;
 		}
 	}
 }

--- a/classes/classes/BreastRow.as
+++ b/classes/classes/BreastRow.as
@@ -1,4 +1,4 @@
-﻿package classes
+package classes
 {
 	import classes.internals.LoggerFactory;
 	import classes.internals.Serializable;

--- a/classes/classes/BreastRow.as
+++ b/classes/classes/BreastRow.as
@@ -1,11 +1,15 @@
 ﻿package classes
 {
+	import classes.internals.LoggerFactory;
 	import classes.internals.Serializable;
 	import classes.internals.Utils;
 	import classes.lists.BreastCup;
+	import mx.logging.ILogger;
 
 	public class BreastRow implements Serializable
 	{
+		private static const LOGGER:ILogger = LoggerFactory.getLogger(BreastRow);
+		
 		private static const SERIALIZATION_VERSION:int = 1;
 		
 		public var breasts:Number = 2;
@@ -85,7 +89,34 @@
 		
 		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
 		{
-			
+			switch (serializedDataVersion) {
+				case 0:
+					LOGGER.debug("Upgrading legacy breast row")
+					
+					// fix breasts without nipples
+					if (relativeRootObject.nipplesPerBreast === 0) {
+						LOGGER.warn("Breasts did not have any nipples, fixing...");
+						relativeRootObject.nipplesPerBreast = 1;
+					}
+					
+					// fix negative lactation muliplier
+					if (relativeRootObject.lactationMultiplier < 0) {
+						LOGGER.warn("Lactation multiplier was {0}, resetting to 0", relativeRootObject.lactationMultiplier);
+						relativeRootObject.lactationMultiplier = 0;
+					}
+					
+					// fix negative breast rating
+					if (relativeRootObject.breastRating < 0) {
+						LOGGER.warn("Breast rating was {0}, resetting to {1}", relativeRootObject.breastRating, BreastCup.FLAT);
+						relativeRootObject.breastRating = BreastCup.FLAT;
+					}
+					
+				default:
+					/*
+					 * The default block is left empty intentionally,
+					 * this switch case operates by using fall through behavior.
+					 */
+			}
 		}
 		
 		public function currentSerializationVerison():int 

--- a/classes/classes/BreastRow.as
+++ b/classes/classes/BreastRow.as
@@ -1,10 +1,13 @@
 ﻿package classes
 {
+	import classes.internals.Serializable;
 	import classes.internals.Utils;
 	import classes.lists.BreastCup;
 
-	public class BreastRow
+	public class BreastRow implements Serializable
 	{
+		private static const SERIALIZATION_VERSION:int = 1;
+		
 		public var breasts:Number = 2;
 		public var nipplesPerBreast:Number = 1;
 		public var breastRating:Number = BreastCup.FLAT;
@@ -54,6 +57,40 @@
 		{
 			restore();
 			setProps(p);
+		}
+		
+		public function serialize(relativeRootObject:*):void 
+		{
+			relativeRootObject.breasts = this.breasts;
+			relativeRootObject.breastRating = this.breastRating;
+			relativeRootObject.nipplesPerBreast = this.nipplesPerBreast;
+			relativeRootObject.lactationMultiplier = this.lactationMultiplier;
+			relativeRootObject.milkFullness = this.milkFullness;
+			relativeRootObject.fuckable = this.fuckable;
+			relativeRootObject.fullness = this.fullness;
+			relativeRootObject.nippleCocks = this.nippleCocks;
+		}
+		
+		public function deserialize(relativeRootObject:*):void 
+		{
+			this.breasts = relativeRootObject.breasts;
+			this.breastRating = relativeRootObject.breastRating;
+			this.nipplesPerBreast = relativeRootObject.nipplesPerBreast;
+			this.lactationMultiplier = relativeRootObject.lactationMultiplier;
+			this.milkFullness = relativeRootObject.milkFullness;
+			this.fuckable = relativeRootObject.fuckable;
+			this.fullness = relativeRootObject.fullness;
+			this.nippleCocks = relativeRootObject.nippleCocks;
+		}
+		
+		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
+		{
+			
+		}
+		
+		public function currentSerializationVerison():int 
+		{
+			return SERIALIZATION_VERSION;
 		}
 	}
 }

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -4276,6 +4276,16 @@ package classes
 			relativeRootObject.sens = this.sens;
 			relativeRootObject.cor = this.cor;
 			relativeRootObject.fatigue = this.fatigue;
+			
+			relativeRootObject.XP = this.XP;
+			relativeRootObject.level = this.level;
+			relativeRootObject.gems = this.gems;
+			
+			relativeRootObject.HP = this.HP;
+			relativeRootObject.lust = this.lust;
+			
+			relativeRootObject.femininity = this.femininity;
+			relativeRootObject.tallness = this.tallness
 		}
 		
 		public function deserialize(relativeRootObject:*):void 
@@ -4300,6 +4310,36 @@ package classes
 			this.sens = relativeRootObject.sens;
 			this.cor = relativeRootObject.cor;
 			this.fatigue = relativeRootObject.fatigue;
+			
+			this.XP = relativeRootObject.XP
+			this.level = relativeRootObject.level;
+			this.gems = relativeRootObject.gems;
+			
+			fixInvalidGems();
+			
+			this.HP = relativeRootObject.HP
+			this.lust = relativeRootObject.lust;
+
+			this.femininity = relativeRootObject.femininity;
+			this.tallness = relativeRootObject.tallness;
+			
+			fixMissingFemininity();
+		}
+		
+		private function fixInvalidGems():void
+		{
+			// TODO move this to upgrade code
+			if (isNaN(this.gems) || this.gems < 0) {
+				this.gems = 0;
+			}
+		}
+		
+		private function fixMissingFemininity(): void
+		{
+			// TODO move this to upgrade code
+			if (isNaN(this.femininity)) {
+				this.femininity = 50;
+			}
 		}
 		
 		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -4253,6 +4253,9 @@ package classes
 		
 		public function serialize(relativeRootObject:*):void 
 		{
+			relativeRootObject.short = this.short;
+			relativeRootObject.a = this.a;
+	
 			relativeRootObject.cocks = SerializationUtils.serializeVector(this.cocks as Vector.<*>);
 			relativeRootObject.vaginas = SerializationUtils.serializeVector(this.vaginas as Vector.<*>);
 			relativeRootObject.breastRows = SerializationUtils.serializeVector(this.breastRows as Vector.<*>);
@@ -4260,6 +4263,9 @@ package classes
 		
 		public function deserialize(relativeRootObject:*):void 
 		{
+			this.short = relativeRootObject.short;
+			this.a = relativeRootObject.a;
+			
 			SerializationUtils.deserializeVector(this.cocks as Vector.<*>, relativeRootObject.cocks, Cock);
 			SerializationUtils.deserializeVector(this.vaginas as Vector.<*>, relativeRootObject.vaginas, Vagina);
 			SerializationUtils.deserializeVector(this.breastRows as Vector.<*>, relativeRootObject.breastRows, BreastRow);

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1,4 +1,4 @@
-﻿//CoC Creature.as
+//CoC Creature.as
 package classes
 {
 	import classes.BodyParts.Antennae;

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -34,6 +34,7 @@ package classes
 	import classes.internals.RandomNumberGenerator;
 	import classes.internals.LoggerFactory;
 	import classes.internals.Serializable;
+	import classes.internals.SerializationUtils;
 	import classes.internals.Utils;
 	import classes.internals.profiling.Begin;
 	import classes.internals.profiling.End;
@@ -4252,12 +4253,14 @@ package classes
 		
 		public function serialize(relativeRootObject:*):void 
 		{
-			
+			relativeRootObject.cocks = SerializationUtils.serializeVector(this.cocks as Vector.<*>);
+			relativeRootObject.vaginas = SerializationUtils.serializeVector(this.vaginas as Vector.<*>);
 		}
 		
 		public function deserialize(relativeRootObject:*):void 
 		{
-			
+			SerializationUtils.deserializeVector(this.cocks as Vector.<*>, relativeRootObject.cocks, Cock);
+			SerializationUtils.deserializeVector(this.vaginas as Vector.<*>, relativeRootObject.vaginas, Vagina);
 		}
 		
 		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -4259,6 +4259,9 @@ package classes
 			relativeRootObject.cocks = SerializationUtils.serializeVector(this.cocks as Vector.<*>);
 			relativeRootObject.vaginas = SerializationUtils.serializeVector(this.vaginas as Vector.<*>);
 			relativeRootObject.breastRows = SerializationUtils.serializeVector(this.breastRows as Vector.<*>);
+			
+			relativeRootObject.ass = [];
+			SerializationUtils.serialize(relativeRootObject.ass, this.ass);
 		}
 		
 		public function deserialize(relativeRootObject:*):void 
@@ -4269,6 +4272,7 @@ package classes
 			SerializationUtils.deserializeVector(this.cocks as Vector.<*>, relativeRootObject.cocks, Cock);
 			SerializationUtils.deserializeVector(this.vaginas as Vector.<*>, relativeRootObject.vaginas, Vagina);
 			SerializationUtils.deserializeVector(this.breastRows as Vector.<*>, relativeRootObject.breastRows, BreastRow);
+			SerializationUtils.deserialize(relativeRootObject.ass, this.ass);
 		}
 		
 		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -4390,4 +4390,3 @@ package classes
 		}
 	}
 }
-

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -33,6 +33,7 @@ package classes
 	import classes.Vagina;
 	import classes.internals.RandomNumberGenerator;
 	import classes.internals.LoggerFactory;
+	import classes.internals.Serializable;
 	import classes.internals.Utils;
 	import classes.internals.profiling.Begin;
 	import classes.internals.profiling.End;
@@ -44,10 +45,12 @@ package classes
 	import mx.logging.ILogger;
 
 
-	public class Creature extends Utils
+	public class Creature extends Utils implements Serializable
 	{
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(Creature);
 
+		private static const SERIALIZATION_VERSION:int = 1;
+		
 		public function get game():CoC {
 			return kGAMECLASS;
 		}
@@ -4245,6 +4248,29 @@ package classes
 				scale   : argDefs.scale[0],
 				max     : argDefs.max[0]
 			};
+		}
+		
+		public function serialize(relativeRootObject:*):void 
+		{
+			
+		}
+		
+		public function deserialize(relativeRootObject:*):void 
+		{
+			
+		}
+		
+		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
+		{
+			/**
+			 * be aware that sub-classes might override this function and may not call the super-class version.
+			 * e.g. no super.upgradeSerializationVersion(relativeRootObject, serializedDataVersion)
+			 */
+		}
+		
+		public function currentSerializationVerison():int 
+		{
+			return SERIALIZATION_VERSION;
 		}
 	}
 }

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -4262,6 +4262,20 @@ package classes
 			
 			relativeRootObject.ass = [];
 			SerializationUtils.serialize(relativeRootObject.ass, this.ass);
+			
+			serializeStats(relativeRootObject);
+		}
+		
+		private function serializeStats(relativeRootObject:*):void
+		{
+			relativeRootObject.str = this.str;
+			relativeRootObject.tou = this.tou;
+			relativeRootObject.spe = this.spe;
+			relativeRootObject.inte = this.inte;
+			relativeRootObject.lib = this.lib;
+			relativeRootObject.sens = this.sens;
+			relativeRootObject.cor = this.cor;
+			relativeRootObject.fatigue = this.fatigue;
 		}
 		
 		public function deserialize(relativeRootObject:*):void 
@@ -4273,6 +4287,19 @@ package classes
 			SerializationUtils.deserializeVector(this.vaginas as Vector.<*>, relativeRootObject.vaginas, Vagina);
 			SerializationUtils.deserializeVector(this.breastRows as Vector.<*>, relativeRootObject.breastRows, BreastRow);
 			SerializationUtils.deserialize(relativeRootObject.ass, this.ass);
+			deserializeStats(relativeRootObject);
+		}
+		
+		private function deserializeStats(relativeRootObject:*):void
+		{
+			this.str = relativeRootObject.str;
+			this.tou = relativeRootObject.tou;
+			this.spe = relativeRootObject.spe;
+			this.inte = relativeRootObject.inte;
+			this.lib = relativeRootObject.lib;
+			this.sens = relativeRootObject.sens;
+			this.cor = relativeRootObject.cor;
+			this.fatigue = relativeRootObject.fatigue;
 		}
 		
 		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -4264,6 +4264,7 @@ package classes
 			SerializationUtils.serialize(relativeRootObject.ass, this.ass);
 			
 			serializeStats(relativeRootObject);
+			serializeSexualStats(relativeRootObject);
 		}
 		
 		private function serializeStats(relativeRootObject:*):void
@@ -4288,6 +4289,17 @@ package classes
 			relativeRootObject.tallness = this.tallness
 		}
 		
+		private function serializeSexualStats(relativeRootObject:*):void
+		{
+			relativeRootObject.balls = this.balls;
+			relativeRootObject.cumMultiplier = this.cumMultiplier;
+			relativeRootObject.ballSize = this.ballSize;
+			relativeRootObject.hoursSinceCum = this.hoursSinceCum;
+			relativeRootObject.ballSize = this.ballSize;
+			relativeRootObject.fertility = this.fertility;
+			relativeRootObject.nippleLength = this.nippleLength;
+		}
+		
 		public function deserialize(relativeRootObject:*):void 
 		{
 			this.short = relativeRootObject.short;
@@ -4298,6 +4310,7 @@ package classes
 			SerializationUtils.deserializeVector(this.breastRows as Vector.<*>, relativeRootObject.breastRows, BreastRow);
 			SerializationUtils.deserialize(relativeRootObject.ass, this.ass);
 			deserializeStats(relativeRootObject);
+			deserializeSexualStats(relativeRootObject);
 		}
 		
 		private function deserializeStats(relativeRootObject:*):void
@@ -4326,6 +4339,19 @@ package classes
 			fixMissingFemininity();
 		}
 		
+		private function deserializeSexualStats(relativeRootObject:*):void
+		{
+			this.balls = relativeRootObject.balls;
+			this.cumMultiplier = relativeRootObject.cumMultiplier;
+			this.ballSize = relativeRootObject.ballSize;
+			this.hoursSinceCum = relativeRootObject.hoursSinceCum;
+			this.ballSize = relativeRootObject.ballSize;
+			this.fertility = relativeRootObject.fertility;
+			this.nippleLength = relativeRootObject.nippleLength;
+			
+			fixMissingNippleLength();
+		}
+		
 		private function fixInvalidGems():void
 		{
 			// TODO move this to upgrade code
@@ -4339,6 +4365,14 @@ package classes
 			// TODO move this to upgrade code
 			if (isNaN(this.femininity)) {
 				this.femininity = 50;
+			}
+		}
+		
+		private function fixMissingNippleLength():void
+		{
+			// TODO move this to upgrade code
+			if (isNaN(this.nippleLength)) {
+				this.nippleLength = 0.25;
 			}
 		}
 		
@@ -4356,3 +4390,4 @@ package classes
 		}
 	}
 }
+

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -4255,12 +4255,14 @@ package classes
 		{
 			relativeRootObject.cocks = SerializationUtils.serializeVector(this.cocks as Vector.<*>);
 			relativeRootObject.vaginas = SerializationUtils.serializeVector(this.vaginas as Vector.<*>);
+			relativeRootObject.breastRows = SerializationUtils.serializeVector(this.breastRows as Vector.<*>);
 		}
 		
 		public function deserialize(relativeRootObject:*):void 
 		{
 			SerializationUtils.deserializeVector(this.cocks as Vector.<*>, relativeRootObject.cocks, Cock);
 			SerializationUtils.deserializeVector(this.vaginas as Vector.<*>, relativeRootObject.vaginas, Vagina);
+			SerializationUtils.deserializeVector(this.breastRows as Vector.<*>, relativeRootObject.breastRows, BreastRow);
 		}
 		
 		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1,4 +1,4 @@
-﻿package classes
+package classes
 {
 	import classes.BodyParts.*;
 	import classes.GlobalFlags.kACHIEVEMENTS;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -3688,6 +3688,12 @@
 				LOGGER.warn("Player vagina type is {0}, resetting to human {1}.", vaginaType(), Vagina.HUMAN);
 				vaginaType(Vagina.HUMAN);
 			}
+			
+			// Force the creation of the default breast row onto the player if it's no longer present
+			if (breastRows.length === 0) {
+				LOGGER.warn("Player has no breast row, this is an invalid state. Creating breast row...");
+				createBreastRow();
+			}
 		}
 		
 		override public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -3672,12 +3672,12 @@
 		
 		override public function serialize(relativeRootObject:*):void 
 		{
-			
+			super.serialize(relativeRootObject);
 		}
 		
 		override public function deserialize(relativeRootObject:*):void 
 		{
-			
+			super.deserialize(relativeRootObject);
 		}
 		
 		override public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -16,9 +16,11 @@
 	import classes.Items.WeaponLib;
 	import classes.Scenes.Areas.Forest.KitsuneScene;
 	import classes.Scenes.Places.TelAdre.UmasShop;
+	import classes.internals.LoggerFactory;
 	import classes.internals.Serializable;
 	import classes.lists.BreastCup;
 	import classes.lists.ColorLists;
+	import mx.logging.ILogger;
 
 	use namespace kGAMECLASS;
 
@@ -27,6 +29,8 @@
 	 * @author Yoffy
 	 */
 	public class Player extends PlayerHelper implements Serializable {
+		private static const LOGGER:ILogger = LoggerFactory.getLogger(Player);
+		
 		private static const SERIALIZATION_VERSION:int = 1;
 		
 		public function Player() {
@@ -3678,6 +3682,12 @@
 		override public function deserialize(relativeRootObject:*):void 
 		{
 			super.deserialize(relativeRootObject);
+			
+			// reset vagina to human if it is an unsupported type
+			if (hasVagina() && vaginaType() !== Vagina.BLACK_SAND_TRAP && vaginaType() !== Vagina.HUMAN) {
+				LOGGER.warn("Player vagina type is {0}, resetting to human {1}.", vaginaType(), Vagina.HUMAN);
+				vaginaType(Vagina.HUMAN);
+			}
 		}
 		
 		override public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -3670,22 +3670,22 @@
 			}
 		}
 		
-		public function serialize(relativeRootObject:*):void 
+		override public function serialize(relativeRootObject:*):void 
 		{
 			
 		}
 		
-		public function deserialize(relativeRootObject:*):void 
+		override public function deserialize(relativeRootObject:*):void 
 		{
 			
 		}
 		
-		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
+		override public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
 		{
-			
+		
 		}
 		
-		public function currentSerializationVerison():int 
+		override public function currentSerializationVerison():int 
 		{
 			return SERIALIZATION_VERSION;
 		}

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -16,6 +16,7 @@
 	import classes.Items.WeaponLib;
 	import classes.Scenes.Areas.Forest.KitsuneScene;
 	import classes.Scenes.Places.TelAdre.UmasShop;
+	import classes.internals.Serializable;
 	import classes.lists.BreastCup;
 	import classes.lists.ColorLists;
 
@@ -25,7 +26,8 @@
 	 * ...
 	 * @author Yoffy
 	 */
-	public class Player extends PlayerHelper {
+	public class Player extends PlayerHelper implements Serializable {
+		private static const SERIALIZATION_VERSION:int = 1;
 		
 		public function Player() {
 			//Item things
@@ -3666,6 +3668,26 @@
 					outputText("You take <b><font color=\"#800000\">" + int(changeNum*-1) + "</font></b> damage.\n");
 				}
 			}
+		}
+		
+		public function serialize(relativeRootObject:*):void 
+		{
+			
+		}
+		
+		public function deserialize(relativeRootObject:*):void 
+		{
+			
+		}
+		
+		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
+		{
+			
+		}
+		
+		public function currentSerializationVerison():int 
+		{
+			return SERIALIZATION_VERSION;
 		}
 	}
 }

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -798,13 +798,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 	saveFile.data.version = ver;
 	flags[kFLAGS.SAVE_FILE_INTEGER_FORMAT_VERSION] = SAVE_FILE_CURRENT_INTEGER_FORMAT_VERSION;
 
-	//CLEAR OLD ARRAYS
-	
-	//Save sum dataz
-	//trace("SAVE DATAZ");
-	saveFile.data.short = player.short;
-	saveFile.data.a = player.a;
-	
 	//Notes
 	if (mainView.nameBox.text != "")
 	{
@@ -1433,8 +1426,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		
 		inventory.clearStorage();
 		inventory.clearGearStorage();
-		player.short = saveFile.data.short;
-		player.a = saveFile.data.a;
 		notes = saveFile.data.notes;
 		
 		//flags

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -866,16 +866,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.nosePierced = player.nosePierced;
 		saveFile.data.nosePShort = player.nosePShort;
 		saveFile.data.nosePLong = player.nosePLong;
-		
-		//MAIN STATS
-		saveFile.data.str = player.str;
-		saveFile.data.tou = player.tou;
-		saveFile.data.spe = player.spe;
-		saveFile.data.inte = player.inte;
-		saveFile.data.lib = player.lib;
-		saveFile.data.sens = player.sens;
-		saveFile.data.cor = player.cor;
-		saveFile.data.fatigue = player.fatigue;
+
 		//Combat STATS
 		saveFile.data.HP = player.HP;
 		saveFile.data.lust = player.lust;
@@ -1456,16 +1447,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		player.nosePierced = saveFile.data.nosePierced;
 		player.nosePShort = saveFile.data.nosePShort;
 		player.nosePLong = saveFile.data.nosePLong;
-		
-		//MAIN STATS
-		player.str = saveFile.data.str;
-		player.tou = saveFile.data.tou;
-		player.spe = saveFile.data.spe;
-		player.inte = saveFile.data.inte;
-		player.lib = saveFile.data.lib;
-		player.sens = saveFile.data.sens;
-		player.cor = saveFile.data.cor;
-		player.fatigue = saveFile.data.fatigue;
 
 		//CLOTHING/ARMOR
 		var found:Boolean = false;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -794,7 +794,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 	
 	saveFile.data.exists = true;
 	
-	saveWithSerializer(saveFile);
+	SerializationUtils.serialize(saveFile.data, this);
 	saveFile.data.version = ver;
 	flags[kFLAGS.SAVE_FILE_INTEGER_FORMAT_VERSION] = SAVE_FILE_CURRENT_INTEGER_FORMAT_VERSION;
 
@@ -977,8 +977,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.keyItems = [];
 		saveFile.data.itemStorage = [];
 		saveFile.data.gearStorage = [];
-		
-		saveWithSerializer(saveFile);
 		
 		//NIPPLES
 		saveFile.data.nippleLength = player.nippleLength;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1923,30 +1923,8 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			player.nippleLength = .25;
 		else
 			player.nippleLength = saveFile.data.nippleLength;
-		//Set Breast Array
-		for (i = 0; i < saveFile.data.breastRows.length; i++)
-		{
-			player.createBreastRow();
-				//trace("LoadOne BreastROw i(" + i + ")");
-		}
-		//Populate Breast Array
-		for (i = 0; i < saveFile.data.breastRows.length; i++)
-		{
-			player.breastRows[i].breasts = saveFile.data.breastRows[i].breasts;
-			player.breastRows[i].nipplesPerBreast = saveFile.data.breastRows[i].nipplesPerBreast;
-			//Fix nipplesless breasts bug
-			if (player.breastRows[i].nipplesPerBreast == 0)
-				player.breastRows[i].nipplesPerBreast = 1;
-			player.breastRows[i].breastRating = saveFile.data.breastRows[i].breastRating;
-			player.breastRows[i].lactationMultiplier = saveFile.data.breastRows[i].lactationMultiplier;
-			if (player.breastRows[i].lactationMultiplier < 0)
-				player.breastRows[i].lactationMultiplier = 0;
-			player.breastRows[i].milkFullness = saveFile.data.breastRows[i].milkFullness;
-			player.breastRows[i].fuckable = saveFile.data.breastRows[i].fuckable;
-			player.breastRows[i].fullness = saveFile.data.breastRows[i].fullness;
-			if (player.breastRows[i].breastRating < 0)
-				player.breastRows[i].breastRating = 0;
-		}
+
+		SerializationUtils.deserializeVector(player.breastRows as Vector.<*>, saveFile.data.breastRows, BreastRow);
 		
 		// Force the creation of the default breast row onto the player if it's no longer present
 		if (player.breastRows.length == 0) player.createBreastRow();

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -982,6 +982,8 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.cocks = SerializationUtils.serializeVector(player.cocks as Vector.<*>);
 		saveFile.data.vaginas = SerializationUtils.serializeVector(player.vaginas as Vector.<*>);
 		
+		saveWithSerializer(saveFile);
+		
 		//NIPPLES
 		saveFile.data.nippleLength = player.nippleLength;
 		//Set Breast Array
@@ -1283,7 +1285,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
  * This method is protected instead of private to allow for testing.
  * @param	saveFile the file to save the NPC data to.
  */
-protected function saveNPCs(saveFile:*): void {
+private function saveNPCs(saveFile:*): void {
 	saveFile.npcs = [];
 	var npcs:* = saveFile.npcs;
 	
@@ -2361,12 +2363,21 @@ protected function loadWithSerializer(saveFile:*):void
 }
 
 /**
+ * Save the game by using serialization
+ * @param	saveFile the file that the game should be saved to
+ */
+protected function saveWithSerializer(saveFile:*):void
+{
+	SerializationUtils.serialize(saveFile.data, this);
+}
+
+/**
  * Load NPCs from the save file. The NPC data is loaded from the 'npcs' object (saveFile.data.npcs).
  * Creates empty dummy structure if the NPC data is missing, to avoid errors on loading.
  * This method is protected instead of private to allow for testing.
  * @param	saveFile the file to save the NPC data to.
  */
-protected function loadNPCs(saveFile:*):void 
+private function loadNPCs(saveFile:*):void 
 {
 	var npcs:* = saveFile.npcs;
 	

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -966,7 +966,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		
 		saveFile.data.perks = [];
 		saveFile.data.statusAffects = [];
-		saveFile.data.ass = [];
 		saveFile.data.keyItems = [];
 		saveFile.data.itemStorage = [];
 		saveFile.data.gearStorage = [];
@@ -1055,10 +1054,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 			saveFile.data.gearStorage[i].unlocked = gearStorageGet()[i].unlocked;
 			saveFile.data.gearStorage[i].damage = gearStorageGet()[i].damage;
 		}
-		saveFile.data.ass.push([]);
-		saveFile.data.ass.analWetness = player.ass.analWetness;
-		saveFile.data.ass.analLooseness = player.ass.analLooseness;
-		saveFile.data.ass.fullness = player.ass.fullness;
 
 		saveFile.data.gameState = gameStateGet(); // Saving game state?
 		
@@ -2139,10 +2134,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 				storage.unlocked = saveFile.data.gearStorage[i].unlocked;
 			}
 		}
-		
-		player.ass.analLooseness = saveFile.data.ass.analLooseness;
-		player.ass.analWetness = saveFile.data.ass.analWetness;
-		player.ass.fullness = saveFile.data.ass.fullness;
 		
 		gameStateSet(saveFile.data.gameState);  // Loading game state
 		

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -794,7 +794,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 	
 	saveFile.data.exists = true;
 	
-	SerializationUtils.serialize(saveFile.data, this);
+	saveWithSerializer(saveFile);
 	saveFile.data.version = ver;
 	flags[kFLAGS.SAVE_FILE_INTEGER_FORMAT_VERSION] = SAVE_FILE_CURRENT_INTEGER_FORMAT_VERSION;
 
@@ -978,9 +978,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.keyItems = [];
 		saveFile.data.itemStorage = [];
 		saveFile.data.gearStorage = [];
-		
-		saveFile.data.cocks = SerializationUtils.serializeVector(player.cocks as Vector.<*>);
-		saveFile.data.vaginas = SerializationUtils.serializeVector(player.vaginas as Vector.<*>);
 		
 		saveWithSerializer(saveFile);
 		
@@ -1936,14 +1933,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		player.knockUpForce(saveFile.data.pregnancyType, saveFile.data.pregnancyIncubation);
 		player.buttKnockUpForce(saveFile.data.buttPregnancyType, saveFile.data.buttPregnancyIncubation);
 		
-		player.cocks = new Vector.<Cock>();
-		SerializationUtils.deserializeVector(player.cocks as Vector.<*>, saveFile.data.cocks, Cock);
-
-		player.vaginas = new Vector.<Vagina>();
-		SerializationUtils.deserializeVector(player.vaginas as Vector.<*>, saveFile.data.vaginas, Vagina);
-		
-		loadWithSerializer(saveFile);
-		
 		if (player.hasVagina() && player.vaginaType() != 5 && player.vaginaType() != 0)
 			player.vaginaType(0);
 		
@@ -2773,11 +2762,13 @@ public function loadText(saveText:String):void
 
 public function serialize(relativeRootObject:*):void 
 {
+	SerializationUtils.serialize(relativeRootObject, player);
 	saveNPCs(relativeRootObject);
 }
 
 public function deserialize(relativeRootObject:*):void 
 {
+	SerializationUtils.deserialize(relativeRootObject, player);
 	loadNPCs(relativeRootObject);
 }
 

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -971,7 +971,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 
 		
 		
-		saveFile.data.breastRows = [];
 		saveFile.data.perks = [];
 		saveFile.data.statusAffects = [];
 		saveFile.data.ass = [];
@@ -983,24 +982,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		
 		//NIPPLES
 		saveFile.data.nippleLength = player.nippleLength;
-		//Set Breast Array
-		for (i = 0; i < player.breastRows.length; i++)
-		{
-			saveFile.data.breastRows.push([]);
-				//trace("Saveone breastRow");
-		}
-		//Populate Breast Array
-		for (i = 0; i < player.breastRows.length; i++)
-		{
-			//trace("Populate One BRow");
-			saveFile.data.breastRows[i].breasts = player.breastRows[i].breasts;
-			saveFile.data.breastRows[i].breastRating = player.breastRows[i].breastRating;
-			saveFile.data.breastRows[i].nipplesPerBreast = player.breastRows[i].nipplesPerBreast;
-			saveFile.data.breastRows[i].lactationMultiplier = player.breastRows[i].lactationMultiplier;
-			saveFile.data.breastRows[i].milkFullness = player.breastRows[i].milkFullness;
-			saveFile.data.breastRows[i].fuckable = player.breastRows[i].fuckable;
-			saveFile.data.breastRows[i].fullness = player.breastRows[i].fullness;
-		}
+		saveFile.data.breastRows = SerializationUtils.serializeVector(player.breastRows as Vector.<*>);
 		//Set Perk Array
 		//Populate Perk Array
 		for (i = 0; i < player.perks.length; i++)

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1913,9 +1913,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		player.knockUpForce(saveFile.data.pregnancyType, saveFile.data.pregnancyIncubation);
 		player.buttKnockUpForce(saveFile.data.buttPregnancyType, saveFile.data.buttPregnancyIncubation);
 		
-		if (player.hasVagina() && player.vaginaType() != 5 && player.vaginaType() != 0)
-			player.vaginaType(0);
-		
 		//NIPPLES
 		if (saveFile.data.nippleLength == undefined)
 			player.nippleLength = .25;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -7,6 +7,7 @@ package classes
 	import classes.Items.*;
 	import classes.Scenes.NPCs.Jojo;
 	import classes.internals.LoggerFactory;
+	import classes.internals.Serializable;
 	import classes.internals.SerializationUtils;
 	import classes.lists.BreastCup;
 	import flash.events.Event;
@@ -28,7 +29,7 @@ package classes
 	
 
 
-public class Saves extends BaseContent {
+public class Saves extends BaseContent implements Serializable {
 	private static const LOGGER:ILogger = LoggerFactory.getLogger(Saves);
 
 	private static const SAVE_FILE_CURRENT_INTEGER_FORMAT_VERSION:int		= 816;
@@ -2754,6 +2755,26 @@ public function loadText(saveText:String):void
 	
 	//Load the object
 	loadGameObject(obj);
+}
+
+public function serialize(relativeRootObject:*):void 
+{
+	
+}
+
+public function deserialize(relativeRootObject:*):void 
+{
+	
+}
+
+public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
+{
+	
+}
+
+public function currentSerializationVerison():int 
+{
+	
 }
 
 //*******

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -980,7 +980,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		
 		//NIPPLES
 		saveFile.data.nippleLength = player.nippleLength;
-		saveFile.data.breastRows = SerializationUtils.serializeVector(player.breastRows as Vector.<*>);
+		
 		//Set Perk Array
 		//Populate Perk Array
 		for (i = 0; i < player.perks.length; i++)
@@ -1921,8 +1921,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			player.nippleLength = .25;
 		else
 			player.nippleLength = saveFile.data.nippleLength;
-
-		SerializationUtils.deserializeVector(player.breastRows as Vector.<*>, saveFile.data.breastRows, BreastRow);
 		
 		// Force the creation of the default breast row onto the player if it's no longer present
 		if (player.breastRows.length == 0) player.createBreastRow();

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1919,9 +1919,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		else
 			player.nippleLength = saveFile.data.nippleLength;
 		
-		// Force the creation of the default breast row onto the player if it's no longer present
-		if (player.breastRows.length == 0) player.createBreastRow();
-		
 		var hasHistoryPerk:Boolean = false;
 		var hasLustyRegenPerk:Boolean = false;
 		var addedSensualLover:Boolean = false;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -868,8 +868,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.nosePLong = player.nosePLong;
 
 		//Combat STATS
-		saveFile.data.HP = player.HP;
-		saveFile.data.lust = player.lust;
 		saveFile.data.teaseLevel = player.teaseLevel;
 		saveFile.data.teaseXP = player.teaseXP;
 		//Prison STATS
@@ -883,18 +881,13 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		//saveFile.data.prisonArmor = prison.prisonItemSlotArmor;
 		//saveFile.data.prisonWeapon = prison.prisonItemSlotWeapon;
 		//LEVEL STATS
-		saveFile.data.XP = player.XP;
-		saveFile.data.level = player.level;
-		saveFile.data.gems = player.gems;
 		saveFile.data.perkPoints = player.perkPoints;
 		saveFile.data.statPoints = player.statPoints;
 		saveFile.data.ascensionPerkPoints = player.ascensionPerkPoints;
 		//Appearance
 		saveFile.data.startingRace = player.startingRace;
-		saveFile.data.femininity = player.femininity;
 		saveFile.data.thickness = player.thickness;
 		saveFile.data.tone = player.tone;
-		saveFile.data.tallness = player.tallness;
 		saveFile.data.furColor = player.skin.furColor;
 		saveFile.data.hairColor = player.hair.color;
 		saveFile.data.hairType = player.hair.type;
@@ -1545,8 +1538,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		}
 
 		//Combat STATS
-		player.HP = saveFile.data.HP;
-		player.lust = saveFile.data.lust;
 		if (saveFile.data.teaseXP == undefined)
 			player.teaseXP = 0;
 		else
@@ -1612,10 +1603,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 				prison.prisonItemSlotWeapon = saveFile.data.prisonWeapon;
 			}
 		}*/
-		//LEVEL STATS
-		player.XP = saveFile.data.XP;
-		player.level = saveFile.data.level;
-		player.gems = saveFile.data.gems || 0;
+		
 		if (saveFile.data.perkPoints == undefined)
 			player.perkPoints = 0;
 		else
@@ -1634,10 +1622,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		//Appearance
 		if (saveFile.data.startingRace != undefined)
 			player.startingRace = saveFile.data.startingRace;
-		if (saveFile.data.femininity == undefined)
-			player.femininity = 50;
-		else
-			player.femininity = saveFile.data.femininity;
 		//EYES
 		if (saveFile.data.eyeType == undefined)
 			player.eyes.type = Eyes.HUMAN;
@@ -1662,7 +1646,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		else
 			player.thickness = saveFile.data.thickness;
 		
-		player.tallness = saveFile.data.tallness;
 		if (saveFile.data.furColor == undefined || saveFile.data.furColor == "no")
 			player.skin.furColor = saveFile.data.hairColor;
 		else
@@ -2300,8 +2283,6 @@ public function unFuckSave():void
 	if (isNaN(getGame().time.minutes)) getGame().time.minutes = 0;
 	if (isNaN(getGame().time.hours)) getGame().time.hours = 0;
 	if (isNaN(getGame().time.days)) getGame().time.days = 0;
-
-	if (player.gems < 0) player.gems = 0; //Force fix gems
 	
 	if (player.hasStatusEffect(StatusEffects.SlimeCraving) && player.statusEffectv4(StatusEffects.SlimeCraving) == 1) {
 		player.changeStatusValue(StatusEffects.SlimeCraving, 3, player.statusEffectv2(StatusEffects.SlimeCraving)); //Duplicate old combined strength/speed value

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -927,12 +927,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.hipRating = player.hips.rating;
 		saveFile.data.buttRating = player.butt.rating;
 		saveFile.data.udder = player.udder.toObject();
-		//Sexual Stuff
-		saveFile.data.balls = player.balls;
-		saveFile.data.cumMultiplier = player.cumMultiplier;
-		saveFile.data.ballSize = player.ballSize;
-		saveFile.data.hoursSinceCum = player.hoursSinceCum;
-		saveFile.data.fertility = player.fertility;
 		
 		//Preggo stuff
 		saveFile.data.pregnancyIncubation = player.pregnancyIncubation;
@@ -946,16 +940,11 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		   myLocalData.data.girlEffectArray.push(new Array());
 		 }*/
 
-		
-		
 		saveFile.data.perks = [];
 		saveFile.data.statusAffects = [];
 		saveFile.data.keyItems = [];
 		saveFile.data.itemStorage = [];
 		saveFile.data.gearStorage = [];
-		
-		//NIPPLES
-		saveFile.data.nippleLength = player.nippleLength;
 		
 		//Set Perk Array
 		//Populate Perk Array
@@ -1852,22 +1841,9 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
         if (isObject(saveFile.data.udder))
 			player.udder.setAllProps(saveFile.data.udder);
 
-		//Sexual Stuff
-		player.balls = saveFile.data.balls;
-		player.cumMultiplier = saveFile.data.cumMultiplier;
-		player.ballSize = saveFile.data.ballSize;
-		player.hoursSinceCum = saveFile.data.hoursSinceCum;
-		player.fertility = saveFile.data.fertility;
-		
 		//Preggo stuff
 		player.knockUpForce(saveFile.data.pregnancyType, saveFile.data.pregnancyIncubation);
 		player.buttKnockUpForce(saveFile.data.buttPregnancyType, saveFile.data.buttPregnancyIncubation);
-		
-		//NIPPLES
-		if (saveFile.data.nippleLength == undefined)
-			player.nippleLength = .25;
-		else
-			player.nippleLength = saveFile.data.nippleLength;
 		
 		var hasHistoryPerk:Boolean = false;
 		var hasLustyRegenPerk:Boolean = false;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -2293,24 +2293,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 }
 
 /**
- * Load save game by using serialization. 
- * @param	saveFile the file that contains the serialized savegame.
- */
-protected function loadWithSerializer(saveFile:*):void
-{
-	SerializationUtils.deserialize(saveFile.data, this);
-}
-
-/**
- * Save the game by using serialization
- * @param	saveFile the file that the game should be saved to
- */
-protected function saveWithSerializer(saveFile:*):void
-{
-	SerializationUtils.serialize(saveFile.data, this);
-}
-
-/**
  * Load NPCs from the save file. The NPC data is loaded from the 'npcs' object (saveFile.data.npcs).
  * Creates empty dummy structure if the NPC data is missing, to avoid errors on loading.
  * This method is protected instead of private to allow for testing.

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -159,17 +159,17 @@ if (lust >= maxLust()) {
 			}
 		}
 		
-		public function serialize(relativeRootObject:*):void 
+		override public function serialize(relativeRootObject:*):void 
 		{
 			
 		}
 		
-		public function deserialize(relativeRootObject:*):void 
+		override public function deserialize(relativeRootObject:*):void 
 		{
 			
 		}
 		
-		public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
+		override public function upgradeSerializationVersion(relativeRootObject:*, serializedDataVersion:int):void 
 		{
 			if (serializedDataVersion == 0) { //Changed to eliminate blocker code smell.
 				LOGGER.debug("Converting jojo from legacy save");
@@ -180,7 +180,7 @@ if (lust >= maxLust()) {
 			}
 		}
 		
-		public function currentSerializationVerison():int 
+		override public function currentSerializationVerison():int 
 		{
 			return SERIALIZATION_VERSION;
 		}

--- a/classes/classes/Scenes/NPCs/Jojo.as
+++ b/classes/classes/Scenes/NPCs/Jojo.as
@@ -1,4 +1,4 @@
-﻿package classes.Scenes.NPCs
+package classes.Scenes.NPCs
 {
 	import classes.*;
 	import classes.BodyParts.*;

--- a/test/ClassesSuite.as
+++ b/test/ClassesSuite.as
@@ -1,5 +1,6 @@
 package {
 	import classes.AppearanceTest;
+	import classes.AssTest;
 	import classes.BreastRowTest;
 	import classes.HelperSuite;
 	import classes.InternalsSuite;
@@ -37,6 +38,7 @@ package {
 		 public var vaginaClass:VaginaTest;
 		 public var cockTest:CockTest;
 		 public var breastRowTest:BreastRowTest;
+		 public var assTest:AssTest;
 		 public var savesTest:SavesTest;
 		 public var playerEventsTest:PlayerEventsTest;
 		 public var playerEventsVaginaLoosenessRecoveryTest:PlayerEventsVaginaLoosenessRecoveryTest;

--- a/test/ClassesSuite.as
+++ b/test/ClassesSuite.as
@@ -1,5 +1,6 @@
 package {
 	import classes.AppearanceTest;
+	import classes.BreastRowTest;
 	import classes.HelperSuite;
 	import classes.InternalsSuite;
 	import classes.PlayerTest;
@@ -35,6 +36,7 @@ package {
 		 public var playerTest:PlayerTest;
 		 public var vaginaClass:VaginaTest;
 		 public var cockTest:CockTest;
+		 public var breastRowTest:BreastRowTest;
 		 public var savesTest:SavesTest;
 		 public var playerEventsTest:PlayerEventsTest;
 		 public var playerEventsVaginaLoosenessRecoveryTest:PlayerEventsVaginaLoosenessRecoveryTest;

--- a/test/classes/AssTest.as
+++ b/test/classes/AssTest.as
@@ -1,0 +1,75 @@
+package classes{
+	import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	
+	
+	import classes.Ass;
+	import classes.internals.SerializationUtils;
+	
+	public class AssTest {
+		private static const TEST_WETTNESS:int = 1;
+		private static const TEST_LOOSENESS:int = 2;
+		private static const TEST_FULLNESS:int = 3;
+
+		
+		private var cut:Ass;
+		private var deserialized:Ass;
+		
+		private var serializedClass:*;
+		
+		[Before]
+		public function runBeforeEveryTest():void {
+			cut = new Ass();
+			cut.analWetness = TEST_WETTNESS;
+			cut.analLooseness = TEST_LOOSENESS;
+			cut.fullness = TEST_FULLNESS;
+			
+			deserialized = new Ass();
+			
+			serializedClass = [];
+			
+			SerializationUtils.serialize(serializedClass, cut);
+			SerializationUtils.deserialize(serializedClass, deserialized);
+		}
+		
+		[Test]
+		public function serializeWetness():void
+		{
+			assertThat(serializedClass, hasProperty("analWetness", TEST_WETTNESS));
+		}
+		
+		[Test]
+		public function serializeLooseness():void
+		{
+			assertThat(serializedClass, hasProperty("analLooseness", TEST_LOOSENESS));
+		}
+		
+		[Test]
+		public function serializeFullness():void
+		{
+			assertThat(serializedClass, hasProperty("fullness", TEST_FULLNESS));
+		}
+		
+		[Test]
+		public function deserializeWetness():void
+		{
+			assertThat(deserialized.analWetness, equalTo(TEST_WETTNESS));
+		}
+		
+		[Test]
+		public function deserializeLooseness():void
+		{
+			assertThat(deserialized.analLooseness, equalTo(TEST_LOOSENESS));
+		}
+		
+		[Test]
+		public function deserializeFullness():void
+		{
+			assertThat(deserialized.fullness, equalTo(TEST_FULLNESS));
+		}
+	}
+}

--- a/test/classes/BreastRowTest.as
+++ b/test/classes/BreastRowTest.as
@@ -214,5 +214,38 @@ package classes{
 		{
 			assertThat(deserialized.nippleCocks, equalTo(DESERIALIZE_NIPPLE_COCKS));
 		}
+		
+		[Test]
+		public function breastRowFixNoNipples():void
+		{
+			serializedClass.serializationVersion = 0;
+			serializedClass.nipplesPerBreast = 0;
+			
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(deserialized.nipplesPerBreast, equalTo(1));
+		}
+		
+		[Test]
+		public function breastRowFixNegativeLactationMultiplier():void
+		{
+			serializedClass.serializationVersion = 0;
+			serializedClass.lactationMultiplier = -42;
+			
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(deserialized.lactationMultiplier, equalTo(0));
+		}
+		
+		[Test]
+		public function breastRowFixNegativeBreastRating():void
+		{
+			serializedClass.serializationVersion = 0;
+			serializedClass.breastRating = -42;
+			
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(deserialized.breastRating, equalTo(BreastCup.FLAT));
+		}
 	}
 }

--- a/test/classes/BreastRowTest.as
+++ b/test/classes/BreastRowTest.as
@@ -1,0 +1,218 @@
+package classes{
+    import org.flexunit.asserts.*;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.core.*;
+	import org.hamcrest.number.*;
+	import org.hamcrest.object.*;
+	import org.hamcrest.text.*;
+	
+	import classes.BreastRow;
+	import classes.lists.BreastCup;
+	import classes.internals.SerializationUtils;
+	
+	public class BreastRowTest {
+		private static const DEFAULT_NUMBER_OF_BREASTS:Number = 2;
+		private static const DEFAULT_NIPPLES_PER_BREAST:Number = 1;
+		private static const DEFAULT_BREAST_RATING:Number = BreastCup.FLAT;
+		private static const DEFAULT_LACTATION_MULTIPLIER:Number = 0;
+		private static const DEFAULT_MILK_FULLNESS:Number = 0;
+		private static const DEFAULT_FULLNESS:Number = 0;
+		private static const DEFAULT_FUCKABLE:Boolean = false;
+		private static const DEFAULT_NIPPLE_COCKS:Boolean = false;
+		
+		private static const DESERIALIZE_NUMBER_OF_BREASTS:Number = 3;
+		private static const DESERIALIZE_NIPPLES_PER_BREAST:Number = 4;
+		private static const DESERIALIZE_BREAST_RATING:Number = BreastCup.C;
+		private static const DESERIALIZE_LACTATION_MULTIPLIER:Number = 2;
+		private static const DESERIALIZE_MILK_FULLNESS:Number = 3;
+		private static const DESERIALIZE_FULLNESS:Number = 4;
+		private static const DESERIALIZE_FUCKABLE:Boolean = true;
+		private static const DESERIALIZE_NIPPLE_COCKS:Boolean = true;
+		
+		private var cut:BreastRow;
+		private var toSerialize:BreastRow;
+		private var deserialized:BreastRow;
+
+		
+		private var serializedClass:*;
+
+
+		[Before]
+		public function setUp():void {
+			cut = new BreastRow();
+			toSerialize = new BreastRow();
+			deserialized = new BreastRow();
+			
+			serializedClass = [];
+
+			buildSerializedclass();
+			
+			SerializationUtils.serialize(serializedClass, toSerialize);
+			SerializationUtils.deserialize(serializedClass, deserialized);
+		}
+		
+		private function buildSerializedclass():void
+		{
+			toSerialize.breasts = DESERIALIZE_NUMBER_OF_BREASTS;
+			toSerialize.nipplesPerBreast = DESERIALIZE_NIPPLES_PER_BREAST;
+			toSerialize.breastRating = DESERIALIZE_BREAST_RATING;
+			toSerialize.lactationMultiplier = DESERIALIZE_LACTATION_MULTIPLIER;
+			toSerialize.milkFullness = DESERIALIZE_MILK_FULLNESS;
+			toSerialize.fullness = DESERIALIZE_FULLNESS;
+			toSerialize.fuckable = DESERIALIZE_FUCKABLE;
+			toSerialize.nippleCocks = DESERIALIZE_NIPPLE_COCKS;
+		}
+		
+		[Test]
+		public function defaultNumberOfBreasts():void
+		{
+			assertThat(cut.breasts, equalTo(DEFAULT_NUMBER_OF_BREASTS));
+		}
+		
+		[Test]
+		public function defaultNumberOfNipples():void
+		{
+			assertThat(cut.nipplesPerBreast, equalTo(DEFAULT_NIPPLES_PER_BREAST));
+		}
+		
+		[Test]
+		public function defaultBreastRating():void
+		{
+			assertThat(cut.breastRating, equalTo(DEFAULT_BREAST_RATING));
+		}
+		
+		[Test]
+		public function defaultLactationMultiplier():void
+		{
+			assertThat(cut.lactationMultiplier, equalTo(DEFAULT_LACTATION_MULTIPLIER));
+		}
+		
+		[Test]
+		public function defaultMilkFullness():void
+		{
+			assertThat(cut.milkFullness, equalTo(DEFAULT_MILK_FULLNESS));
+		}
+		
+		[Test]
+		public function defaultFullness():void
+		{
+			assertThat(cut.fullness, equalTo(DEFAULT_FULLNESS));
+		}
+		
+		[Test]
+		public function defaultFuckableBreasts():void
+		{
+			assertThat(cut.fuckable, equalTo(DEFAULT_FUCKABLE));
+		}
+		
+		[Test]
+		public function defaultNippleCocks():void
+		{
+			assertThat(cut.nippleCocks, equalTo(DEFAULT_NIPPLE_COCKS));
+		}
+		
+		/**
+		 * Serialization Tests
+		 */
+		
+		[Test]
+		public function serializeNumberOfBreasts():void
+		{
+			assertThat(serializedClass, hasProperty('breasts', DESERIALIZE_NUMBER_OF_BREASTS));
+		}
+		
+		[Test]
+		public function serializeNumberOfNipples():void
+		{
+			assertThat(serializedClass, hasProperty('nipplesPerBreast', DESERIALIZE_NIPPLES_PER_BREAST));
+		}
+		
+		[Test]
+		public function serializeBreastRating():void
+		{
+			assertThat(serializedClass, hasProperty('breastRating', DESERIALIZE_BREAST_RATING));
+		}
+		
+		[Test]
+		public function serializeLactationMultiplier():void
+		{
+			assertThat(serializedClass, hasProperty('lactationMultiplier', DESERIALIZE_LACTATION_MULTIPLIER));
+		}
+		
+		[Test]
+		public function serializeMilkFullness():void
+		{
+			assertThat(serializedClass, hasProperty('milkFullness', DESERIALIZE_MILK_FULLNESS));
+		}
+		
+		[Test]
+		public function serializeFullness():void
+		{
+			assertThat(serializedClass, hasProperty('fullness', DESERIALIZE_FULLNESS));
+		}
+		
+		[Test]
+		public function serializeFuckableBreasts():void
+		{
+			assertThat(serializedClass, hasProperty('fuckable', DESERIALIZE_FUCKABLE));
+		}
+		
+		[Test]
+		public function serializeNippleCocks():void
+		{
+			assertThat(serializedClass, hasProperty('nippleCocks', DESERIALIZE_NIPPLE_COCKS));
+		}
+		
+		/**
+		 * Deserialization Tests
+		 */
+		
+		[Test]
+		public function deserializeNumberOfBreasts():void
+		{
+			assertThat(deserialized.breasts, equalTo(DESERIALIZE_NUMBER_OF_BREASTS));
+		}
+		
+		[Test]
+		public function deserializeNumberOfNipples():void
+		{
+			assertThat(deserialized.nipplesPerBreast, equalTo(DESERIALIZE_NIPPLES_PER_BREAST));
+		}
+		
+		[Test]
+		public function deserializeBreastRating():void
+		{
+			assertThat(deserialized.breastRating, equalTo(DESERIALIZE_BREAST_RATING));
+		}
+		
+		[Test]
+		public function deserializeLactationMultiplier():void
+		{
+			assertThat(deserialized.lactationMultiplier, equalTo(DESERIALIZE_LACTATION_MULTIPLIER));
+		}
+		
+		[Test]
+		public function deserializeMilkFullness():void
+		{
+			assertThat(deserialized.milkFullness, equalTo(DESERIALIZE_MILK_FULLNESS));
+		}
+		
+		[Test]
+		public function deserializeFullness():void
+		{
+			assertThat(deserialized.fullness, equalTo(DESERIALIZE_FULLNESS));
+		}
+		
+		[Test]
+		public function deserializeFuckableBreasts():void
+		{
+			assertThat(deserialized.fuckable, equalTo(DESERIALIZE_FUCKABLE));
+		}
+		
+		[Test]
+		public function deserializeNippleCocks():void
+		{
+			assertThat(deserialized.nippleCocks, equalTo(DESERIALIZE_NIPPLE_COCKS));
+		}
+	}
+}

--- a/test/classes/CreatureTest.as
+++ b/test/classes/CreatureTest.as
@@ -41,6 +41,13 @@ package classes{
 		
 		private static const FEMININITY:int = 11;
 		private static const TALLNESS:int = 12;
+		
+		private static const BALLS:int = 13;
+		private static const CUMMULTIPLIER:int = 14;
+		private static const BALLSIZE:int = 15;
+		private static const HOURSSINCECUM:int = 16;
+		private static const FERTILITY:int = 17;
+		private static const NIPPLE_LENGTH:int = 18;
 			
 		private var cut:Creature;
 		private var noVagina:Creature;
@@ -101,6 +108,13 @@ package classes{
 			cut.lust = LUST;
 			cut.femininity = FEMININITY;
 			cut.tallness = TALLNESS;
+			
+			cut.balls = BALLS;
+			cut.cumMultiplier = CUMMULTIPLIER;
+			cut.ballSize = BALLSIZE;
+			cut.hoursSinceCum = HOURSSINCECUM;
+			cut.fertility = FERTILITY;
+			cut.nippleLength = NIPPLE_LENGTH;
 			
 			deserialized = new Creature();
 			serializedClass = [];
@@ -911,6 +925,89 @@ package classes{
 		public function deserializeTallness():void
 		{
 			assertThat(deserialized.tallness, equalTo(TALLNESS));
+		}
+		
+		[Test]
+		public function serializeBalls():void
+		{
+			assertThat(serializedClass, hasProperty("balls", BALLS));
+		}
+
+		[Test]
+		public function serializeCummultiplier():void
+		{
+			assertThat(serializedClass, hasProperty("cumMultiplier", CUMMULTIPLIER));
+		}
+
+		[Test]
+		public function serializeBallsize():void
+		{
+			assertThat(serializedClass, hasProperty("ballSize", BALLSIZE));
+		}
+
+		[Test]
+		public function serializeHourssincecum():void
+		{
+			assertThat(serializedClass, hasProperty("hoursSinceCum", HOURSSINCECUM));
+		}
+
+		[Test]
+		public function serializeFertility():void
+		{
+			assertThat(serializedClass, hasProperty("fertility", FERTILITY));
+		}
+
+		[Test]
+		public function deserializeBalls():void
+		{
+			assertThat(deserialized.balls, equalTo(BALLS));
+		}
+
+		[Test]
+		public function deserializeCummultiplier():void
+		{
+			assertThat(deserialized.cumMultiplier, equalTo(CUMMULTIPLIER));
+		}
+
+		[Test]
+		public function deserializeBallsize():void
+		{
+			assertThat(deserialized.ballSize, equalTo(BALLSIZE));
+		}
+
+		[Test]
+		public function deserializeHourssincecum():void
+		{
+			assertThat(deserialized.hoursSinceCum, equalTo(HOURSSINCECUM));
+		}
+
+		[Test]
+		public function deserializeFertility():void
+		{
+			assertThat(deserialized.fertility, equalTo(FERTILITY));
+		}
+		
+		[Test]
+		public function serializeNippleLength():void
+		{
+			assertThat(serializedClass, hasProperty("nippleLength", NIPPLE_LENGTH));
+		}
+		
+		[Test]
+		public function deserializeNippleLength():void
+		{
+			assertThat(deserialized.nippleLength, equalTo(NIPPLE_LENGTH));
+		}
+		
+		[Test]
+		public function deserializeNippleLengthUndefined():void
+		{
+			delete(serializedClass.nippleLength);
+			deserialized = new Creature();
+			
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(deserialized.nippleLength, equalTo(0.25));
 		}
 	}
 }

--- a/test/classes/CreatureTest.as
+++ b/test/classes/CreatureTest.as
@@ -7,6 +7,7 @@ package classes{
 	import classes.helper.StageLocator;
 	import classes.internals.RandomNumberGenerator;
 	import classes.internals.ActionScriptRNG;
+	import classes.internals.SerializationUtils;
 	import classes.lists.Gender;
 	import classes.lists.BreastCup;
 	import org.flexunit.asserts.*;
@@ -31,12 +32,25 @@ package classes{
 		private const ANAL_LOOSENESS:Number = 1;
 		private const ANAL_CAPACITY:Number = 6;
 		
-        	private var cut:Creature;
+		private static const MAX_HP:Number = 370;
+		
+		private static const XP:int = 7;
+		private static const LEVEL:int = 8;
+		private static const GEMS:int = 9;
+		private static const LUST:int = 10;
+		
+		private static const FEMININITY:int = 11;
+		private static const TALLNESS:int = 12;
+			
+		private var cut:Creature;
 		private var noVagina:Creature;
 		private var oneVagina:Creature;
 		private var maxVagina:Creature;
 		private var fullEquip:Creature;
 		private var alwaysZero:RandomNumberGenerator;
+		
+		private var deserialized: Creature;
+		private var serializedClass: *;
 		
 		private function createVaginas(numberOfVaginas:Number, instance:Creature):void {
 			var i:Number;
@@ -81,6 +95,18 @@ package classes{
 			cut.ass.analLooseness = ANAL_LOOSENESS;
 						cut.tou = 100;
 			cut.HP = 1;
+			cut.XP = XP;
+			cut.level = LEVEL;
+			cut.gems = GEMS;
+			cut.lust = LUST;
+			cut.femininity = FEMININITY;
+			cut.tallness = TALLNESS;
+			
+			deserialized = new Creature();
+			serializedClass = [];
+
+			SerializationUtils.serialize(serializedClass, cut);
+			SerializationUtils.deserialize(serializedClass, deserialized);
 			
 			noVagina = new Creature();
 			
@@ -664,7 +690,7 @@ package classes{
 		public function healToMaxHP():void {
 			cut.restoreHP();
 
-			assertThat(cut.HP, equalTo(250));
+			assertThat(cut.HP, equalTo(MAX_HP));
 		}
 
 		[Test]
@@ -680,7 +706,7 @@ package classes{
 			
 			cut.restoreHP();
 
-			assertThat(cut.HP, equalTo(250));
+			assertThat(cut.HP, equalTo(MAX_HP));
 		}
 		
 		[Test(expected="RangeError")]
@@ -802,6 +828,89 @@ package classes{
 			createCocks(CockTypesEnum.HUMAN, 2, cut);
 			
 			assertThat(cut.findFirstCockType(CockTypesEnum.HORSE), equalTo(-1));
+		}
+
+		[Test]
+		public function serializeLevel():void
+		{
+			assertThat(serializedClass, hasProperty("level", LEVEL));
+		}
+
+		[Test]
+		public function serializeGems():void
+		{
+			assertThat(serializedClass, hasProperty("gems", GEMS));
+		}
+
+		[Test]
+		public function deserializeXp():void
+		{
+			assertThat(deserialized.XP, equalTo(XP));
+		}
+
+		[Test]
+		public function deserializeLevel():void
+		{
+			assertThat(deserialized.level, equalTo(LEVEL));
+		}
+
+		[Test]
+		public function deserializeGems():void
+		{
+			assertThat(deserialized.gems, equalTo(GEMS));
+		}
+
+		[Test]
+		public function serializeXp():void
+		{
+			assertThat(serializedClass, hasProperty("XP", XP));
+		}
+
+		[Test]
+		public function serializeLust():void
+		{
+			assertThat(serializedClass, hasProperty("lust", LUST));
+		}
+
+		[Test]
+		public function deserializeLust():void
+		{
+			assertThat(deserialized.lust, equalTo(LUST));
+		}
+		
+		[Test]
+		public function serializeFemininity():void
+		{
+			assertThat(serializedClass, hasProperty("femininity", FEMININITY));
+		}
+
+		[Test]
+		public function serializeTallness():void
+		{
+			assertThat(serializedClass, hasProperty("tallness", TALLNESS));
+		}
+
+		[Test]
+		public function deserializeFemininity():void
+		{
+			assertThat(deserialized.femininity, equalTo(FEMININITY));
+		}
+		
+		[Test]
+		public function deserializeFemininityUndefined():void
+		{
+			delete(serializedClass.femininity);
+			deserialized = new Creature();
+			
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(deserialized.femininity, equalTo(50));
+		}
+
+		[Test]
+		public function deserializeTallness():void
+		{
+			assertThat(deserialized.tallness, equalTo(TALLNESS));
 		}
 	}
 }

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -287,6 +287,7 @@ package classes{
 }
 
 import classes.Saves
+import classes.internals.SerializationUtils;
 
 class SavesForTest extends Saves {
 	public function SavesForTest(gameStateDirectGet:Function, gameStateDirectSet:Function) {
@@ -294,10 +295,10 @@ class SavesForTest extends Saves {
 	}
 
 	public function saveNPCstest(saveFile:*):void {
-		this.saveWithSerializer(saveFile);
+		SerializationUtils.serialize(saveFile.data, this);
 	}
 
 	public function loadNPCstest(saveFile:*):void {
-		this.loadWithSerializer(saveFile);
+		SerializationUtils.deserialize(saveFile.data, this);
 	}
 }

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -462,6 +462,17 @@ package classes{
 			
 			assertThat(kGAMECLASS.player.gems, equalTo(0));
 		}
+		
+		[Test]
+		public function loadPlayerNipplelengthUndefined():void
+		{
+			kGAMECLASS.player.nippleLength = undefined;
+			
+			cut.saveGame(TEST_SAVE_GAME);
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.nippleLength, equalTo(0.25));
+		}
 	}
 }
 

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -94,6 +94,7 @@ package classes{
 			saveFile.data.npcs.jojo = [];
 			saveFile.data.cocks = [];
 			saveFile.data.vaginas = [];
+			saveFile.data.breastRows = [];
 		}
 		
 		[Test]

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -206,6 +206,6 @@ class SavesForTest extends Saves {
 	}
 
 	public function loadNPCstest(saveFile:*):void {
-		this.loadNPCs(saveFile);
+		this.loadWithSerializer(saveFile);
 	}
 }

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -272,6 +272,17 @@ package classes{
 
 			assertThat(kGAMECLASS.player.vaginas[0].type, equalTo(Vagina.BLACK_SAND_TRAP));
 		}
+		
+		[Test]
+		public function playerForceOneBreastRow():void {
+			player.breastRows.length = 0;
+			assertThat(player.breastRows.length, equalTo(0));
+			
+			cut.saveGame(TEST_SAVE_GAME);
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.breastRows.length, equalTo(1));
+		}
 	}
 }
 

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -1,4 +1,5 @@
 package classes{
+	import classes.lists.BreastCup;
 	import org.flexunit.asserts.*;
 	import org.hamcrest.assertThat;
 	import org.hamcrest.core.*;
@@ -26,6 +27,8 @@ package classes{
 		private static const TEST_SOCK:String = "testSock";
 		private static const VIRIDIAN_SOCK:String = "viridian";
 		
+		private static const NUMBER_OF_BREAST_ROWS:int = 3;
+		
 		private var player:Player;
 		private var cut:SavesForTest;
 
@@ -41,6 +44,7 @@ package classes{
 			player = new Player();
 		
 			createPlayerCocks();
+			createPlayerBreasts();
 			
 			kGAMECLASS.player = player;
 			kGAMECLASS.ver = TEST_VERSION;
@@ -74,6 +78,14 @@ package classes{
 			player.createCock(1, 1, CockTypesEnum.CAT);
 			player.createCock(2, 2, CockTypesEnum.DOG);
 			player.createCock(3, 3, CockTypesEnum.HORSE);
+		}
+		
+		private function createPlayerBreasts():void {
+			player.removeBreastRow(0, int.MAX_VALUE);
+			
+			player.createBreastRow(BreastCup.A);
+			player.createBreastRow(BreastCup.B);
+			player.createBreastRow(BreastCup.C);
 		}
 		
 		private function buildDummySaveForJojoTest():void
@@ -203,6 +215,28 @@ package classes{
 			cut.loadNPCstest(saveFile);
 
 			assertThat(kGAMECLASS.flags[kFLAGS.JOJO_STATUS], equalTo(6));
+		}
+		
+		[Test]
+		public function breastRowsAreStored():void
+		{
+			player.breastRows.length = 0;
+			assertThat(player.breastRows.length, equalTo(0));
+			
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.breastRows.length, equalTo(NUMBER_OF_BREAST_ROWS));
+		}
+		
+		[Test]
+		public function breastRowLoadOrder():void {
+			player.breastRows.length = 0;
+			assertThat(player.breastRows.length, equalTo(0));
+			
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.breastRows[0].breastRating, equalTo(BreastCup.A));
+			assertThat(kGAMECLASS.player.breastRows[2].breastRating, equalTo(BreastCup.C));
 		}
 	}
 }

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -239,6 +239,39 @@ package classes{
 			assertThat(kGAMECLASS.player.breastRows[0].breastRating, equalTo(BreastCup.A));
 			assertThat(kGAMECLASS.player.breastRows[2].breastRating, equalTo(BreastCup.C));
 		}
+		
+		[Test]
+		public function vaginaTypeReset():void {
+			player.createVagina(true, 1, 0);
+			player.vaginas[0].type = Vagina.EQUINE;
+			
+			cut.saveGame(TEST_SAVE_GAME);
+			cut.loadGame(TEST_SAVE_GAME);
+
+			assertThat(kGAMECLASS.player.vaginas[0].type, equalTo(Vagina.HUMAN));
+		}
+		
+		[Test]
+		public function humanVaginaIsOK():void {
+			player.createVagina(true, 1, 0);
+			player.vaginas[0].type = Vagina.HUMAN;
+			
+			cut.saveGame(TEST_SAVE_GAME);
+			cut.loadGame(TEST_SAVE_GAME);
+
+			assertThat(kGAMECLASS.player.vaginas[0].type, equalTo(Vagina.HUMAN));
+		}
+		
+		[Test]
+		public function sandTrapVaginaIsOK():void {
+			player.createVagina(true, 1, 0);
+			player.vaginas[0].type = Vagina.BLACK_SAND_TRAP;
+			
+			cut.saveGame(TEST_SAVE_GAME);
+			cut.loadGame(TEST_SAVE_GAME);
+
+			assertThat(kGAMECLASS.player.vaginas[0].type, equalTo(Vagina.BLACK_SAND_TRAP));
+		}
 	}
 }
 

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -1,4 +1,5 @@
 package classes{
+	import classes.internals.SerializationUtils;
 	import classes.lists.BreastCup;
 	import org.flexunit.asserts.*;
 	import org.hamcrest.assertThat;
@@ -108,12 +109,10 @@ package classes{
 		
 		private function buildDummySaveForJojoTest():void
 		{
+			SerializationUtils.serialize(saveFile.data, new Player());
+			saveFile.data.serializationVersion = undefined;
 			saveFile.data.npcs = [];
 			saveFile.data.npcs.jojo = [];
-			saveFile.data.cocks = [];
-			saveFile.data.vaginas = [];
-			saveFile.data.breastRows = [];
-			saveFile.data.ass = [];
 		}
 		
 		[Test]

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -31,6 +31,10 @@ package classes{
 		
 		private static const TEST_PLAYER_A:String = "foo";
 		private static const TEST_PLAYER_SHORT:String = "bar";
+		
+		private static const ASS_WETTNESS:int = 1;
+		private static const ASS_LOOSENESS:int = 2;
+		private static const ASS_FULLNESS:int = 3;
 
 		
 		private var player:Player;
@@ -51,6 +55,7 @@ package classes{
 		
 			createPlayerCocks();
 			createPlayerBreasts();
+			createPlayerAss();
 			
 			kGAMECLASS.player = player;
 			kGAMECLASS.ver = TEST_VERSION;
@@ -94,6 +99,13 @@ package classes{
 			player.createBreastRow(BreastCup.C);
 		}
 		
+		private function createPlayerAss():void
+		{
+			player.ass.analWetness = ASS_WETTNESS;
+			player.ass.analLooseness = ASS_LOOSENESS;
+			player.ass.fullness = ASS_FULLNESS;
+		}
+		
 		private function buildDummySaveForJojoTest():void
 		{
 			saveFile.data.npcs = [];
@@ -101,6 +113,7 @@ package classes{
 			saveFile.data.cocks = [];
 			saveFile.data.vaginas = [];
 			saveFile.data.breastRows = [];
+			saveFile.data.ass = [];
 		}
 		
 		[Test]
@@ -306,6 +319,30 @@ package classes{
 			cut.loadGame(TEST_SAVE_GAME);
 			
 			assertThat(kGAMECLASS.player.a, equalTo(TEST_PLAYER_A));
+		}
+		
+		[Test]
+		public function playerAssWetnessLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.ass.analWetness, equalTo(ASS_WETTNESS));
+		}
+		
+		[Test]
+		public function playerAssLoosenessLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.ass.analLooseness, equalTo(ASS_LOOSENESS));
+		}
+		
+		[Test]
+		public function playerAssFullnessLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.ass.fullness, equalTo(ASS_FULLNESS));
 		}
 	}
 }

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -76,6 +76,14 @@ package classes{
 			player.createCock(3, 3, CockTypesEnum.HORSE);
 		}
 		
+		private function buildDummySaveForJojoTest():void
+		{
+			saveFile.data.npcs = [];
+			saveFile.data.npcs.jojo = [];
+			saveFile.data.cocks = [];
+			saveFile.data.vaginas = [];
+		}
+		
 		[Test]
 		public function testClitLengthSaved():void {
 			player.createVagina();
@@ -148,6 +156,8 @@ package classes{
 
 		[Test]
 		public function jojoLegacyStatusLoadJojoIsSlave():void {
+			buildDummySaveForJojoTest();
+			
 			cut.loadNPCstest(saveFile);
 
 			assertThat(kGAMECLASS.flags[kFLAGS.JOJO_STATUS], equalTo(6));
@@ -155,6 +165,8 @@ package classes{
 
 		[Test]
 		public function jojoLegacyStatusLoadJojoEncountersInProgress():void {
+			buildDummySaveForJojoTest();
+			
 			var jojoStatus:int = 3;
 			kGAMECLASS.flags[kFLAGS.JOJO_STATUS] = jojoStatus;
 			
@@ -165,8 +177,7 @@ package classes{
 
 		[Test]
 		public function jojoNewStatusLoadUpdateSlaveStatus():void {
-			saveFile.data.npcs = [];
-			saveFile.data.npcs.jojo = [];
+			buildDummySaveForJojoTest();
 			saveFile.data.npcs.jojo.serializationVersion = 1;
 
 			cut.loadNPCstest(saveFile);
@@ -176,7 +187,8 @@ package classes{
 
 		[Test]
 		public function loadWithMissingNpcs():void {
-			saveFile.data = [];
+			buildDummySaveForJojoTest();
+			saveFile.data.npcs = undefined;
 
 			cut.loadNPCstest(saveFile);
 
@@ -185,6 +197,7 @@ package classes{
 
 		[Test]
 		public function loadWithMissingJojoNpc():void {
+			buildDummySaveForJojoTest();
 			saveFile.data.npcs = [];
 
 			cut.loadNPCstest(saveFile);

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -45,6 +45,8 @@ package classes{
 		private static const PLAYER_SENS:int = 47;
 		private static const PLAYER_COR:int = 48;
 		private static const PLAYER_FATIGUE:int = 49;
+		
+		private static const PLAYER_XP:int = 7;
 
 		private var player:Player;
 		private var cut:SavesForTest;
@@ -126,6 +128,8 @@ package classes{
 			player.sens = PLAYER_SENS;
 			player.cor = PLAYER_COR;
 			player.fatigue = PLAYER_FATIGUE;
+			
+			player.XP = PLAYER_XP;
 		}
 		
 		private function buildDummySaveForJojoTest():void
@@ -427,6 +431,36 @@ package classes{
 			cut.loadGame(TEST_SAVE_GAME);
 			
 			assertThat(kGAMECLASS.player.fatigue, equalTo(PLAYER_FATIGUE));
+		}
+		
+		[Test]
+		public function playerXPLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.XP, equalTo(PLAYER_XP));
+		}
+		
+		[Test]
+		public function undefinedGemsShouldBeZero():void
+		{
+			kGAMECLASS.player.gems = undefined;
+			
+			cut.saveGame(TEST_SAVE_GAME);
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.gems, equalTo(0));
+		}
+		
+		[Test]
+		public function negativeGemsShouldBeZero():void
+		{
+			kGAMECLASS.player.gems = -10;
+			
+			cut.saveGame(TEST_SAVE_GAME);
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.gems, equalTo(0));
 		}
 	}
 }

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -202,7 +202,7 @@ class SavesForTest extends Saves {
 	}
 
 	public function saveNPCstest(saveFile:*):void {
-		this.saveNPCs(saveFile);
+		this.saveWithSerializer(saveFile);
 	}
 
 	public function loadNPCstest(saveFile:*):void {

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -29,6 +29,10 @@ package classes{
 		
 		private static const NUMBER_OF_BREAST_ROWS:int = 3;
 		
+		private static const TEST_PLAYER_A:String = "foo";
+		private static const TEST_PLAYER_SHORT:String = "bar";
+
+		
 		private var player:Player;
 		private var cut:SavesForTest;
 
@@ -42,6 +46,8 @@ package classes{
 		[Before]
 		public function setUp():void {
 			player = new Player();
+			player.short = TEST_PLAYER_SHORT;
+			player.a = TEST_PLAYER_A;
 		
 			createPlayerCocks();
 			createPlayerBreasts();
@@ -282,6 +288,24 @@ package classes{
 			cut.loadGame(TEST_SAVE_GAME);
 			
 			assertThat(kGAMECLASS.player.breastRows.length, equalTo(1));
+		}
+		
+		[Test]
+		public function serializePlayerShortName():void {
+			kGAMECLASS.player.short = "";
+			
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.short, equalTo(TEST_PLAYER_SHORT));
+		}
+		
+		[Test]
+		public function serializePlayerA():void {
+			kGAMECLASS.player.a = "";
+			
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.a, equalTo(TEST_PLAYER_A));
 		}
 	}
 }

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -36,8 +36,16 @@ package classes{
 		private static const ASS_WETTNESS:int = 1;
 		private static const ASS_LOOSENESS:int = 2;
 		private static const ASS_FULLNESS:int = 3;
-
 		
+		private static const PLAYER_STR:int = 42;
+		private static const PLAYER_TOU:int = 43;
+		private static const PLAYER_SPE:int = 44;
+		private static const PLAYER_INT:int = 45;
+		private static const PLAYER_LIB:int = 46;
+		private static const PLAYER_SENS:int = 47;
+		private static const PLAYER_COR:int = 48;
+		private static const PLAYER_FATIGUE:int = 49;
+
 		private var player:Player;
 		private var cut:SavesForTest;
 
@@ -57,6 +65,7 @@ package classes{
 			createPlayerCocks();
 			createPlayerBreasts();
 			createPlayerAss();
+			setPlayerStats();
 			
 			kGAMECLASS.player = player;
 			kGAMECLASS.ver = TEST_VERSION;
@@ -105,6 +114,18 @@ package classes{
 			player.ass.analWetness = ASS_WETTNESS;
 			player.ass.analLooseness = ASS_LOOSENESS;
 			player.ass.fullness = ASS_FULLNESS;
+		}
+		
+		private function setPlayerStats():void
+		{
+			player.str = PLAYER_STR;
+			player.tou = PLAYER_TOU;
+			player.spe = PLAYER_SPE;
+			player.inte = PLAYER_INT;
+			player.lib = PLAYER_LIB;
+			player.sens = PLAYER_SENS;
+			player.cor = PLAYER_COR;
+			player.fatigue = PLAYER_FATIGUE;
 		}
 		
 		private function buildDummySaveForJojoTest():void
@@ -342,6 +363,70 @@ package classes{
 			cut.loadGame(TEST_SAVE_GAME);
 			
 			assertThat(kGAMECLASS.player.ass.fullness, equalTo(ASS_FULLNESS));
+		}
+		
+		[Test]
+		public function playerStrStatLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.str, equalTo(PLAYER_STR));
+		}
+		
+		[Test]
+		public function playerTouStatLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.tou, equalTo(PLAYER_TOU));
+		}
+		
+		[Test]
+		public function playerSpeStatLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.spe, equalTo(PLAYER_SPE));
+		}
+		
+		[Test]
+		public function playerIntStatLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.inte, equalTo(PLAYER_INT));
+		}
+		
+		[Test]
+		public function playerLibStatLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.lib, equalTo(PLAYER_LIB));
+		}
+		
+		[Test]
+		public function playerSensStatLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.sens, equalTo(PLAYER_SENS));
+		}
+		
+		[Test]
+		public function playerCorStatLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.cor, equalTo(PLAYER_COR));
+		}
+		
+		[Test]
+		public function playerFatigueStatLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.player.fatigue, equalTo(PLAYER_FATIGUE));
 		}
 	}
 }


### PR DESCRIPTION
This PR is part of my ongoing efforts to clean up the save code.
Will split the effort into multiple PRs due to the sheer size.

This particular PR:
- Makes `Player` serializable
- Makes `Creature` serializable
- Makes `Saves` serializable (Used for changes to save file structure to pave the way for serializable NPCs)
- Makes `BreastRow` serializable
- Makes `Ass` serializable
- Moves serialization for genitals, `BreastRow`, `Ass`, base stats, sexual stats and some appearance stats to `Creature` as they are shared with `Player`. This would allow for serializable NPCs and named monsters in the future

## TODO
Find a robust solution for serializing inheritance, as sub/super classes can have different versions, but they serialize to the same object.
Currently the issue is side stepped by performing upgrade operations on every load, as it was done in `Saves`