### PR TITLE
Fix permed ninetails perks

### DIFF
--- a/classes/classes/Items/Consumables/FoxJewel.as
+++ b/classes/classes/Items/Consumables/FoxJewel.as
@@ -225,11 +225,16 @@ package classes.Items.Consumables
 				changes++;
 			}
 			//[Grow 9th tail and gain Corrupted Nine-tails perk]
-			else if (mystic && rand(4) === 0 && changes < changeLimit && player.tail.type == Tail.FOX && player.tail.venom == 8 && player.level >= 9 && player.ears.type == Ears.FOX && player.inte >= 90 && player.findPerk(PerkLib.CorruptedNinetails) < 0 && (player.findPerk(PerkLib.EnlightenedNinetails) < 0 || player.perkv4(PerkLib.EnlightenedNinetails) > 0)) {
-				outputText("Your bushy tails begin to glow with an eerie, ghostly light, and with a crackle of electrical energy, split into nine tails.  <b>You are now a nine-tails!  But something is wrong...  The cosmic power radiating from your body feels...  tainted somehow.  The corruption pouring off your body feels...  good.</b>");
-				outputText("\n\nYou have the inexplicable urge to set fire to the world, just to watch it burn.  With your newfound power, it's a goal that is well within reach.");
-				outputText("\n\n(Perk Gained: Corrupted Nine-tails - Grants two magical special attacks.)");
-				player.createPerk(PerkLib.CorruptedNinetails, 0, 0, 0, 0);
+			else if (mystic && rand(4) === 0 && changes < changeLimit && player.tail.type == Tail.FOX && player.tail.venom == 8 && player.level >= 9 && player.ears.type == Ears.FOX && player.inte >= 90) {
+				outputText("Your bushy tails begin to glow with an eerie, ghostly light, and with a crackle of electrical energy, split into nine tails. <b>You are now a nine-tails!</b>");
+				if (!player.hasPerk(PerkLib.CorruptedNinetails) && (!player.hasPerk(PerkLib.EnlightenedNinetails) || player.perkv4(PerkLib.EnlightenedNinetails) > 0)) {
+					outputText("<b>  But something is wrong... The cosmic power radiating from your body feels... tainted somehow."
+					          +" The corruption pouring off your body feels... good.</b>"
+					          +"\n\nYou have the inexplicable urge to set fire to the world, just to watch it burn."
+					          +" With your newfound power, it's a goal that is well within reach."
+					          +"\n\n(Perk Gained: Corrupted Nine-tails - Grants two magical special attacks.)");
+					player.createPerk(PerkLib.CorruptedNinetails);
+				}
 				dynStats("lib", 2, "lus", 10, "cor", 10);
 				player.tail.venom = 9;
 				changes++;

--- a/classes/classes/Scenes/Areas/Forest/KitsuneScene.as
+++ b/classes/classes/Scenes/Areas/Forest/KitsuneScene.as
@@ -2360,11 +2360,24 @@ package classes.Scenes.Areas.Forest
 			}
 		}
 
+		private function meditatePerkChecks():Boolean
+		{
+			if (player.hasPerk(PerkLib.EnlightenedNinetails) && player.perkv4(PerkLib.EnlightenedNinetails) <= 0) {
+				return false;
+			}
+
+			if (player.hasPerk(PerkLib.CorruptedNinetails) && player.perkv4(PerkLib.CorruptedNinetails) <= 0) {
+				return false;
+			}
+
+			return true;
+		}
+
 		//[Meditate]
 		private function meditateLikeAKitsuneEhQuestionMark():void
 		{
 			clearOutput();
-			if (player.hasItem(consumables.FOXJEWL) && player.tail.type == Tail.FOX && player.tail.venom < 9 && player.tail.venom + 1 <= player.level && player.tail.venom + 1 <= player.inte / 10 && player.ears.type == Ears.FOX && (player.findPerk(PerkLib.CorruptedNinetails) < 0 || player.perkv4(PerkLib.CorruptedNinetails) > 0) && player.findPerk(PerkLib.EnlightenedNinetails) < 0) {
+			if (player.hasItem(consumables.FOXJEWL) && player.tail.type == Tail.FOX && player.tail.venom < 9 && player.tail.venom + 1 <= player.level && player.tail.venom + 1 <= player.inte / 10 && player.ears.type == Ears.FOX && meditatePerkChecks()) {
 				//20% chance if PC has fox ears, 1 or more fox tails, carries a Fox Jewel, and meets level & INT requirements for the next tail:
 				outputText("You sit down carefully on a small mat in front of the shrine and clear your mind.  Closing your eyes, you meditate on the things you've learned in your journey thus far, and resolve to continue fighting against the forces of corruption that permeate the land.\n\n");
 
@@ -2380,7 +2393,7 @@ package classes.Scenes.Areas.Forest
 					//Increment tail by 1, consume Fox Jewel, -2 COR, -20 LUST, +2 INT, Advance 1 hr and return to camp.
 					//Apply Nine-Tails perk if applicable.
 					player.tail.venom = 9;
-					player.createPerk(PerkLib.EnlightenedNinetails, 0, 0, 0, 0);
+					player.createPerkIfNotHasPerk(PerkLib.EnlightenedNinetails);
 					
 					// Nine tail kitsunes have their fur/hair color golden, silver or pure white
 					if (!InCollection(player.hair.color, ColorLists.ELDER_KITSUNE)) // wrong hair color


### PR DESCRIPTION
Fixes #1387

If you had both ninetails-perks (Corrupted and Enlightened Nine-Tails) made permanent, there was no chance to get the ninth tail after that. This should fix that. Having both perks permanent, now meditating at the kitsune-shrine and/or using the mystic jewel with eight tails should now still give you the ninth tail..