### PR TITLE
Serialize item storage

### DIFF
--- a/classes/classes/ItemSlot.as
+++ b/classes/classes/ItemSlot.as
@@ -7,7 +7,7 @@ package classes
 	 */
 	public class ItemSlot extends Object implements Serializable
 	{
-		private static const SERIALIZATION_VERSION:int = 1;
+		private static const SERIALIZATION_VERSION:int = 2;
 		
 		private static const LEGACY_SHORTNAME_GROPLUS:String = "Gro+";
 		private static const LEGACY_SHORTNAME_SPECIAL_HONEY:String = "Sp Honey";
@@ -141,6 +141,9 @@ package classes
 			switch (serializedDataVersion) {
 				case 0:
 					convertLegacyShortNameToId(relativeRootObject);
+				
+				case 1:
+					setZeroQuantitySlotToEmpty(relativeRootObject);
 					
 				default:
 					/*
@@ -162,6 +165,13 @@ package classes
 				relativeRootObject.id = "SpHoney";
 			} else {
 				relativeRootObject.id = ItemType.lookupItemByShort(relativeRootObject.shortName).id;
+			}
+		}
+		
+		private function setZeroQuantitySlotToEmpty(relativeRootObject:*):void
+		{
+			if (relativeRootObject.quantity === 0) {
+				relativeRootObject.id = "NOTHING!";
 			}
 		}
 		

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1000,6 +1000,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 			saveFile.data.keyItems[i].value4 = player.keyItems[i].value4;
 		}
 		
+		saveFile.data.inventory = [];
 		SerializationUtils.serialize(saveFile.data.inventory, inventory);
 		
 		//Set gear slot array

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1970,24 +1970,15 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			//Populate storage slot array
 			for (i = 0; i < saveFile.data.itemStorage.length; i++)
 			{
-				//trace("Populating a storage slot save with data");
 				inventory.createStorage();
 				var storage:ItemSlot = itemStorageGet()[i];
 				var savedIS:* = saveFile.data.itemStorage[i];
-				if (savedIS.shortName)
-				{
-					if (savedIS.shortName.indexOf("Gro+") != -1)
-						savedIS.id = "GroPlus";
-					else if (savedIS.shortName.indexOf("Sp Honey") != -1)
-						savedIS.id = "SpHoney";
-				}
+				
 				if (savedIS.quantity>0) {
-					storage.setItemAndQty(ItemType.lookupItem(savedIS.id || savedIS.shortName), savedIS.quantity);
-					storage.damage = savedIS.damage != undefined ? savedIS.damage : 0;
-				}
-				else
+					SerializationUtils.deserialize(savedIS, storage);
+				} else {
 					storage.emptySlot();
-				storage.unlocked = savedIS.unlocked;
+				}
 			}
 		}
 

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1959,6 +1959,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 					//trace("KeyItem " + player.keyItems[i].keyName + " loaded.");
 			}
 		}
+
 		//Set storage slot array
 		if (saveFile.data.itemStorage == undefined)
 		{
@@ -1989,6 +1990,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 				storage.unlocked = savedIS.unlocked;
 			}
 		}
+
 		//Set gear slot array
 		if (saveFile.data.gearStorage == undefined)
 		{

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1003,21 +1003,21 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 			saveFile.data.keyItems[i].value3 = player.keyItems[i].value3;
 			saveFile.data.keyItems[i].value4 = player.keyItems[i].value4;
 		}
-		//Set storage slot array
-		for (i = 0; i < itemStorageGet().length; i++)
-		{
-			saveFile.data.itemStorage.push([]);
-		}
+		
+		// because a function reference is not helpful for debugging, I want to see values!
+		var itemStorage:Array = itemStorageGet();
 
 		//Populate storage slot array
-		for (i = 0; i < itemStorageGet().length; i++)
+		for (i = 0; i < itemStorage.length; i++)
 		{
-			//saveFile.data.itemStorage[i].shortName = itemStorage[i].itype.id;// For backward compatibility
-			saveFile.data.itemStorage[i].id = (itemStorageGet()[i].itype == null) ? null : itemStorageGet()[i].itype.id;
-			saveFile.data.itemStorage[i].quantity = itemStorageGet()[i].quantity;
-			saveFile.data.itemStorage[i].unlocked = itemStorageGet()[i].unlocked;
-			saveFile.data.itemStorage[i].damage = itemStorageGet()[i].damage;
+			if (itemStorage[i].itype == null) {
+				saveFile.data.itemStorage.push(null);
+			} else {
+				saveFile.data.itemStorage.push([]);
+				SerializationUtils.serialize(saveFile.data.itemStorage[i], itemStorage[i]);
+			}
 		}
+		
 		//Set gear slot array
 		for (i = 0; i < gearStorageGet().length; i++)
 		{

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -39,7 +39,6 @@ public class Saves extends BaseContent implements Serializable {
 
 	private var gameStateGet:Function;
 	private var gameStateSet:Function;
-	private var itemStorageGet:Function;
 	private var gearStorageGet:Function;
 	private var permObjectFileName:String = "CoC_Main";
 
@@ -48,8 +47,7 @@ public class Saves extends BaseContent implements Serializable {
 		gameStateSet = gameStateDirectSet;
 	}
 
-	public function linkToInventory(itemStorageDirectGet:Function, gearStorageDirectGet:Function):void {
-		itemStorageGet = itemStorageDirectGet;
+	public function linkToInventory(gearStorageDirectGet:Function):void {
 		gearStorageGet = gearStorageDirectGet;
 	}
 
@@ -949,7 +947,6 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		saveFile.data.perks = [];
 		saveFile.data.statusAffects = [];
 		saveFile.data.keyItems = [];
-		saveFile.data.itemStorage = [];
 		saveFile.data.gearStorage = [];
 
 		//Set Perk Array
@@ -1004,19 +1001,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 			saveFile.data.keyItems[i].value4 = player.keyItems[i].value4;
 		}
 		
-		// because a function reference is not helpful for debugging, I want to see values!
-		var itemStorage:Array = itemStorageGet();
-
-		//Populate storage slot array
-		for (i = 0; i < itemStorage.length; i++)
-		{
-			if (itemStorage[i].itype == null) {
-				saveFile.data.itemStorage.push(null);
-			} else {
-				saveFile.data.itemStorage.push([]);
-				SerializationUtils.serialize(saveFile.data.itemStorage[i], itemStorage[i]);
-			}
-		}
+		SerializationUtils.serialize(saveFile.data, inventory);
 		
 		//Set gear slot array
 		for (i = 0; i < gearStorageGet().length; i++)
@@ -1960,28 +1945,10 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			}
 		}
 
-		//Set storage slot array
-		if (saveFile.data.itemStorage == undefined)
-		{
-			//trace("OLD SAVES DO NOT CONTAIN ITEM STORAGE ARRAY");
-		}
-		else
-		{
-			//Populate storage slot array
-			for (i = 0; i < saveFile.data.itemStorage.length; i++)
-			{
-				inventory.createStorage();
-				var storage:ItemSlot = itemStorageGet()[i];
-				var savedIS:* = saveFile.data.itemStorage[i];
-				
-				if (savedIS.quantity>0) {
-					SerializationUtils.deserialize(savedIS, storage);
-				} else {
-					storage.emptySlot();
-				}
-			}
-		}
+		SerializationUtils.deserialize(saveFile.data, inventory);
 
+		var storage:ItemSlot;
+		
 		//Set gear slot array
 		if (saveFile.data.gearStorage == undefined)
 		{

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Created by aimozg on 12.01.14.
  */
 package classes.Scenes

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -36,12 +36,30 @@ package classes.Scenes
 		//TODO refactor storage into own type?
 		public static const STORAGE_JEWELRY_BOX:String = "Equipment Storage - Jewelry Box";
 		
+		/**
+		 * Stores items that are not gear, using chests?
+		 */
 		private var itemStorage:Array;
+		/**
+		 * Stores various gear, such as armor, weapons, shields, etc. Used with different types of racks.
+		 */
 		private var gearStorage:Array;
+		/**
+		 * Stores items when in prison?
+		 */
 		private var prisonStorage:Array;
-		private var callNext:Function;		//These are used so that we know what has to happen once the player finishes with an item
-		private var callOnAbandon:Function;	//They simplify dealing with items that have a sub menu. Set in inventoryMenu and in takeItem
-		private var currentItemSlot:ItemSlot;	//The slot previously occupied by the current item - only needed for stashes and items with a sub menu.
+		/**
+		 * These are used so that we know what has to happen once the player finishes with an item
+		 */
+		private var callNext:Function;
+		/**
+		 * They simplify dealing with items that have a sub menu. Set in inventoryMenu and in takeItem
+		 */
+		private var callOnAbandon:Function;
+		/**
+		 * The slot previously occupied by the current item - only needed for stashes and items with a sub menu.
+		 */
+		private var currentItemSlot:ItemSlot;
 		
 		public function Inventory(saveSystem:Saves) {
 			itemStorage = [];

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -920,6 +920,7 @@ package classes.Scenes
 		
 		private function serializeItemStorage(saveFileItemStorage:*):void
 		{
+			LOGGER.debug("Serializing {0} slots in itemStorage...", itemStorage.length);
 			for (var i:int = 0; i < itemStorage.length; i++)
 			{
 				if (itemStorage[i].itype == null) {
@@ -938,6 +939,7 @@ package classes.Scenes
 		
 		private function deserializeItemStorage(saveFileItemStorage:*):void
 		{
+			LOGGER.debug("Deserializing {0} slots from itemStorage...", saveFileItemStorage.length);
 			for (var i:int = 0; i < saveFileItemStorage.length; i++)
 			{
 				createStorage();
@@ -968,7 +970,7 @@ package classes.Scenes
 		
 		private function upgradeLegacyItemStorage(relativeRootObject:*):void
 		{
-			LOGGER.debug("Upgrading legacy item storage");
+			LOGGER.info("Upgrading legacy item storage");
 			
 			if (relativeRootObject.itemStorage === undefined) {
 				relativeRootObject.itemStorage  = [];

--- a/test/classes/ItemSlotTest.as
+++ b/test/classes/ItemSlotTest.as
@@ -130,5 +130,15 @@ package classes
 		{
 			assertThat(deserialized.damage, equalTo(DAMAGE));
 		}
+		
+		[Test]
+		public function missingDamageShouldBeZero():void
+		{
+			delete serializedClass['damage'];
+			
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(deserialized.damage, equalTo(0));
+		}
 	}
 }

--- a/test/classes/ItemSlotTest.as
+++ b/test/classes/ItemSlotTest.as
@@ -140,5 +140,16 @@ package classes
 			
 			assertThat(deserialized.damage, equalTo(0));
 		}
+		
+		[Test]
+		public function zeroQuantityShouldLoadAsEmpty():void
+		{
+			serializedClass['serializationVersion'] = 1;
+			serializedClass['quantity'] = 0;
+			
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(deserialized.itype.id, equalTo(ItemType.NOTHING.id));
+		}
 	}
 }

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -54,6 +54,7 @@ package classes{
 		private static var consumables:ConsumableLib;
 		
 		private var saveFile:*;
+		private var serializedSave:* = [];
 		
 		[BeforeClass]
 		public static function setUpClass():void {
@@ -71,6 +72,7 @@ package classes{
 			createPlayerBreasts();
 			createPlayerAss();
 			setPlayerStats();
+			createDummySerializedObject();
 			
 			kGAMECLASS.player = player;
 			kGAMECLASS.ver = TEST_VERSION;
@@ -151,6 +153,22 @@ package classes{
 			saveFile.data.serializationVersion = undefined;
 			saveFile.data.npcs = [];
 			saveFile.data.npcs.jojo = [];
+		}
+		
+		private function createDummySerializedObject():void
+		{
+			serializedSave["serializationVersion"] = 1;
+			serializedSave.itemStorage = [];
+			
+			var slot1:ItemSlot = new ItemSlot();
+			slot1.setItemAndQty(consumables.CANINEP, 2);
+			
+			var slot2:ItemSlot = new ItemSlot();
+			slot2.setItemAndQty(consumables.EQUINUM, 3);
+			
+			
+			serializedSave.itemStorage.push(slot1);
+			serializedSave.itemStorage.push(slot2);
 		}
 		
 		private function initInventory():void
@@ -590,6 +608,39 @@ package classes{
 			assertThat(kGAMECLASS.player.itemSlot1.itype, equalTo(consumables.CANINEP));
 			assertThat(kGAMECLASS.player.itemSlot2.itype, equalTo(ItemType.NOTHING));
 			assertThat(kGAMECLASS.player.itemSlot3.itype, equalTo(consumables.EQUINUM));
+		}
+		
+		[Test]
+		public function upgradeCreatesInventory():void
+		{	
+			cut.upgradeSerializationVersion(serializedSave, 1);
+			
+			assertThat(serializedSave, hasProperty("inventory"));
+		}
+		
+		[Test]
+		public function upgradeCreatesItemStorageInInventory():void
+		{	
+			cut.upgradeSerializationVersion(serializedSave, 1);
+			
+			assertThat(serializedSave.inventory, hasProperty("itemStorage"));
+		}
+		
+		[Test]
+		public function upgradeCopiesItemStorageData():void
+		{	
+			cut.upgradeSerializationVersion(serializedSave, 1);
+			
+			assertThat(serializedSave.inventory.itemStorage[0].itype.id, equalTo(consumables.CANINEP.id));
+			assertThat(serializedSave.inventory.itemStorage[1].itype.id, equalTo(consumables.EQUINUM.id));
+		}
+		
+		[Test]
+		public function upgradeDeletesItemStorageFromSaveRoot():void
+		{	
+			cut.upgradeSerializationVersion(serializedSave, 1);
+			
+			assertThat(serializedSave, not(hasProperty("itemStorage")));
 		}
 		
 		[Test]

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -85,11 +85,15 @@ package classes{
 			player.itemSlot(2).setItemAndQty(consumables.EQUINUM, 8);
 			player.itemSlot(2).damage = 9;
 			
+			initInventory();
+			
 			saveGame();
 
 			kGAMECLASS.flags[kFLAGS.JOJO_STATUS] = 5;
 			saveFile = [];
 			saveFile.data = [];
+			
+			kGAMECLASS.inventory.clearStorage();
 		}
 		
 		private function saveGame():void {
@@ -147,6 +151,19 @@ package classes{
 			saveFile.data.serializationVersion = undefined;
 			saveFile.data.npcs = [];
 			saveFile.data.npcs.jojo = [];
+		}
+		
+		private function initInventory():void
+		{
+			//TODO remove after inventory tests are moved
+			var items:Array = kGAMECLASS.inventory.itemStorageDirectGet();
+			
+			kGAMECLASS.inventory.createStorage();
+			kGAMECLASS.inventory.createStorage();
+			
+			// this is completely safe, trust me!  /s
+			(items[0] as ItemSlot).setItemAndQty(consumables.PURPDYE, 3);
+			(items[1] as ItemSlot).setItemAndQty(consumables.PURHONY, 5);
 		}
 		
 		[Test]
@@ -569,6 +586,45 @@ package classes{
 			assertThat(kGAMECLASS.player.itemSlot2.itype, equalTo(ItemType.NOTHING));
 			assertThat(kGAMECLASS.player.itemSlot3.itype, equalTo(consumables.EQUINUM));
 		}
+		
+		// GEAR STORAGE TESTS START
+		// TODO remove most tests once code and tests have been moved to inventory
+		
+		[Test]
+		public function itemStorageLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.inventory.hasItemInStorage(consumables.PURPDYE), equalTo(true));
+			assertThat(kGAMECLASS.inventory.hasItemInStorage(consumables.PURHONY), equalTo(true));
+		}
+		
+		[Test]
+		public function itemStorageQuantityLoaded():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[0].quantity, equalTo(3));
+			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[1].quantity, equalTo(5));
+		}
+		
+		[Test]
+		public function emptyItemStorageSlotIsNull():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[2], nullValue());
+		}
+		
+		[Test]
+		public function itemStorageMustBeInitializedAfterLoad():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.inventory.itemStorageDirectGet(), notNullValue());
+		}
+		
+		// GEAR STORAGE TESTS END
 	}
 }
 

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -155,7 +155,7 @@ package classes{
 		
 		private function initInventory():void
 		{
-			//TODO remove after inventory tests are moved
+			//TODO remove this once the saves serialization has been completed
 			var items:Array = kGAMECLASS.inventory.itemStorageDirectGet();
 			
 			kGAMECLASS.inventory.createStorage();
@@ -592,52 +592,21 @@ package classes{
 			assertThat(kGAMECLASS.player.itemSlot3.itype, equalTo(consumables.EQUINUM));
 		}
 		
-		// GEAR STORAGE TESTS START
-		// TODO remove most tests once code and tests have been moved to inventory
-		
 		[Test]
+		public function inventoryMustBeValid():void
+		{
+			assertThat(kGAMECLASS.inventory, notNullValue());
+		}
+		
+		[Test(description="This is to test that the inventory is correctly serialized")]
 		public function itemStorageLoaded():void
 		{
+			//TODO remove this once the saves serialization has been completed
 			cut.loadGame(TEST_SAVE_GAME);
 			
 			assertThat(kGAMECLASS.inventory.hasItemInStorage(consumables.PURPDYE), equalTo(true));
 			assertThat(kGAMECLASS.inventory.hasItemInStorage(consumables.PURHONY), equalTo(true));
 		}
-		
-		[Test]
-		public function itemStorageQuantityLoaded():void
-		{
-			cut.loadGame(TEST_SAVE_GAME);
-			
-			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[0].quantity, equalTo(3));
-			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[1].quantity, equalTo(5));
-		}
-		
-		[Test]
-		public function emptyItemStorageSlotIsNull():void
-		{
-			cut.loadGame(TEST_SAVE_GAME);
-			
-			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[5], nullValue());
-		}
-		
-		[Test]
-		public function itemStorageMustBeInitializedAfterLoad():void
-		{
-			cut.loadGame(TEST_SAVE_GAME);
-			
-			assertThat(kGAMECLASS.inventory.itemStorageDirectGet(), notNullValue());
-		}
-		
-		[Test]
-		public function itemStorageSlotIsLocked():void
-		{
-			cut.loadGame(TEST_SAVE_GAME);
-			
-			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[2].unlocked, equalTo(false));
-		}
-		
-		// GEAR STORAGE TESTS END
 	}
 }
 

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -160,10 +160,15 @@ package classes{
 			
 			kGAMECLASS.inventory.createStorage();
 			kGAMECLASS.inventory.createStorage();
+			kGAMECLASS.inventory.createStorage();
+			kGAMECLASS.inventory.createStorage();
+			kGAMECLASS.inventory.createStorage();
 			
 			// this is completely safe, trust me!  /s
 			(items[0] as ItemSlot).setItemAndQty(consumables.PURPDYE, 3);
 			(items[1] as ItemSlot).setItemAndQty(consumables.PURHONY, 5);
+			(items[2] as ItemSlot).setItemAndQty(ItemType.NOTHING, 0);
+			(items[2] as ItemSlot).unlocked = false;
 		}
 		
 		[Test]
@@ -613,7 +618,7 @@ package classes{
 		{
 			cut.loadGame(TEST_SAVE_GAME);
 			
-			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[2], nullValue());
+			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[5], nullValue());
 		}
 		
 		[Test]
@@ -622,6 +627,14 @@ package classes{
 			cut.loadGame(TEST_SAVE_GAME);
 			
 			assertThat(kGAMECLASS.inventory.itemStorageDirectGet(), notNullValue());
+		}
+		
+		[Test]
+		public function itemStorageSlotIsLocked():void
+		{
+			cut.loadGame(TEST_SAVE_GAME);
+			
+			assertThat(kGAMECLASS.inventory.itemStorageDirectGet()[2].unlocked, equalTo(false));
 		}
 		
 		// GEAR STORAGE TESTS END

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -10,6 +10,7 @@ package classes{
 	import org.hamcrest.text.*;
 	
 	import flash.display.Stage;
+	import mx.utils.UIDUtil;
 	
 	import classes.CoC;
 	import classes.Scenes.Inventory;
@@ -20,7 +21,7 @@ package classes{
 	
 	public class SavesTest {
 		private static const TEST_VERSION:String = "test";
-		private static const TEST_SAVE_GAME:String = "test";
+		private static const TEST_SAVE_GAME_PREFIX:String = "savesTest-";
 		
 		private static const CLIT_LENGTH:Number = 5;
 		private static const VAGINA_RECOVERY_PROGRESS:int = 6;
@@ -55,6 +56,7 @@ package classes{
 		
 		private var saveFile:*;
 		private var serializedSave:* = [];
+		private var TEST_SAVE_GAME:String;
 		
 		[BeforeClass]
 		public static function setUpClass():void {
@@ -64,6 +66,8 @@ package classes{
 		
 		[Before]
 		public function setUp():void {
+			TEST_SAVE_GAME = TEST_SAVE_GAME_PREFIX + UIDUtil.createUID();
+			
 			player = new Player();
 			player.short = TEST_PLAYER_SHORT;
 			player.a = TEST_PLAYER_A;
@@ -96,6 +100,16 @@ package classes{
 			saveFile.data = [];
 			
 			kGAMECLASS.inventory.clearStorage();
+		}
+		
+		[After]
+		public function tearDown():void
+		{
+			kGAMECLASS.flags[kFLAGS.TEMP_STORAGE_SAVE_DELETION] = TEST_SAVE_GAME;
+			cut.purgeTheMutant();
+			
+			kGAMECLASS.flags[kFLAGS.TEMP_STORAGE_SAVE_DELETION] = TEST_SAVE_GAME + "_backup";
+			cut.purgeTheMutant();
 		}
 		
 		private function saveGame():void {

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -655,8 +655,8 @@ package classes{
 			//TODO remove this once the saves serialization has been completed
 			cut.loadGame(TEST_SAVE_GAME);
 			
-			assertThat(kGAMECLASS.inventory.hasItemInStorage(consumables.PURPDYE), equalTo(true));
-			assertThat(kGAMECLASS.inventory.hasItemInStorage(consumables.PURHONY), equalTo(true));
+			assertThat("Item storage did not contain purple dye", kGAMECLASS.inventory.hasItemInStorage(consumables.PURPDYE), equalTo(true));
+			assertThat("Item storage did not contain pure honey", kGAMECLASS.inventory.hasItemInStorage(consumables.PURHONY), equalTo(true));
 		}
 	}
 }

--- a/test/classes/Scenes/InventoryTest.as
+++ b/test/classes/Scenes/InventoryTest.as
@@ -1,0 +1,117 @@
+package classes.Scenes 
+{
+	import classes.ItemSlot;
+	import classes.ItemType;
+	import classes.Items.ConsumableLib;
+	import classes.Saves;
+	import classes.internals.SerializationUtils;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.object.equalTo;
+	import org.hamcrest.object.notNullValue;
+	import org.hamcrest.object.nullValue;
+	public class InventoryTest 
+	{
+		private var cut:Inventory;
+		
+		private var serializedClass:*;
+		private var deserialized:Inventory;
+		
+		private static var consumables:ConsumableLib;
+		
+		private var saveFile:*;
+		
+		[BeforeClass]
+		public static function setUpClass():void {
+			consumables = new ConsumableLib();
+		}
+		
+		[Before]
+		public function setUp():void
+		{
+			var dummySaves:Saves = new DummySaves();
+			cut = new Inventory(dummySaves);
+			
+			serializedClass = [];
+			deserialized = new Inventory(dummySaves);
+			
+			initInventory();
+			
+			SerializationUtils.serialize(serializedClass, cut);
+			SerializationUtils.deserialize(serializedClass, deserialized);
+		}
+		
+		private function initInventory():void
+		{
+			var items:Array = cut.itemStorageDirectGet();
+			
+			cut.createStorage();
+			cut.createStorage();
+			cut.createStorage();
+			cut.createStorage();
+			cut.createStorage();
+			
+			// this is completely safe, trust me!  /s
+			(items[0] as ItemSlot).setItemAndQty(consumables.PURPDYE, 3);
+			(items[1] as ItemSlot).setItemAndQty(consumables.PURHONY, 5);
+			(items[2] as ItemSlot).setItemAndQty(ItemType.NOTHING, 0);
+			(items[2] as ItemSlot).unlocked = false;
+		}
+		
+		[Test]
+		public function instanceIsCreated():void
+		{
+			assertThat(cut, notNullValue());
+		}
+
+		[Test]
+		public function itemStorageLoaded():void
+		{
+			assertThat(deserialized.hasItemInStorage(consumables.PURPDYE), equalTo(true));
+			assertThat(deserialized.hasItemInStorage(consumables.PURHONY), equalTo(true));
+		}
+		
+		[Test]
+		public function itemStorageQuantityLoaded():void
+		{
+			assertThat(deserialized.itemStorageDirectGet()[0].quantity, equalTo(3));
+			assertThat(deserialized.itemStorageDirectGet()[1].quantity, equalTo(5));
+		}
+		
+		[Test]
+		public function emptyItemStorageSlotIsNull():void
+		{
+			assertThat(deserialized.itemStorageDirectGet()[5], nullValue());
+		}
+		
+		[Test]
+		public function itemStorageMustBeInitializedAfterLoad():void
+		{
+			assertThat(deserialized.itemStorageDirectGet(), notNullValue());
+		}
+		
+		[Test]
+		public function itemStorageSlotIsLocked():void
+		{
+			assertThat(deserialized.itemStorageDirectGet()[2].unlocked, equalTo(false));
+		}
+	}
+}
+
+import classes.Saves;
+
+/**
+ * A minimalistic dummy to satisfy the constructor.
+ */
+class DummySaves extends Saves
+{
+	public function DummySaves()
+	{
+		var noop:Function = new Function();
+		
+		super(noop, noop);
+	}
+	
+	override public function linkToInventory(gearStorageDirectGet:Function):void {
+		// do nothing, this is just to satisfy the dependency
+	}
+}

--- a/test/classes/ScenesSuite.as
+++ b/test/classes/ScenesSuite.as
@@ -1,4 +1,5 @@
 package classes {
+	import classes.Scenes.InventoryTest;
 	import classes.Scenes.NPCsSuite;
 	import classes.Scenes.PlacesSuite;
 	import classes.Scenes.AreasSuite;
@@ -16,5 +17,6 @@ package classes {
 		 public var pregnancyProgressionTest:PregnancyProgressionTest
 		 public var pregnancyProgressionVagBirthTest:PregnancyProgressionVagBirthTest
 		 public var pregnancyProgressionAnalBirthTest:PregnancyProgressionAnalBirthTest;
+		 public var inventoryTest:InventoryTest;
 	}
 }


### PR DESCRIPTION
Use serialization for items stored in the PC's inventory.

- `ItemSlot` is now serializable
- Moved item slots to `Inventory`
- Cleaned up `itemSlot` save / load code 
- Added some documentation to `Inventory`