### PR TITLE
Serialization verison 2

### DIFF
--- a/classes/classes/Ass.as
+++ b/classes/classes/Ass.as
@@ -6,6 +6,7 @@ package classes
 	public class Ass implements Serializable
 	{
 		private static const SERIALIZATION_VERSION:int = 1;
+		private static const SERIALIZATION_UUID:String = "0a3bd267-6ce0-4fed-a81b-53a4ccd6c17d";
 		
 		public static const WETNESS_DRY:int            =   0;
 		public static const WETNESS_NORMAL:int         =   1;
@@ -67,6 +68,11 @@ package classes
 		public function currentSerializationVerison():int 
 		{
 			return SERIALIZATION_VERSION;
+		}
+		
+		public function serializationUUID():String 
+		{
+			return SERIALIZATION_UUID;
 		}
 	}
 }

--- a/classes/classes/BreastRow.as
+++ b/classes/classes/BreastRow.as
@@ -11,6 +11,7 @@ package classes
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(BreastRow);
 		
 		private static const SERIALIZATION_VERSION:int = 1;
+		private static const SERIALIZATION_UUID:String = "c862ee0a-5667-4fd3-a178-37a5e85c86d6";
 		
 		public var breasts:Number = 2;
 		public var nipplesPerBreast:Number = 1;
@@ -122,6 +123,11 @@ package classes
 		public function currentSerializationVerison():int 
 		{
 			return SERIALIZATION_VERSION;
+		}
+		
+		public function serializationUUID():String 
+		{
+			return SERIALIZATION_UUID;
 		}
 	}
 }

--- a/classes/classes/Cock.as
+++ b/classes/classes/Cock.as
@@ -12,6 +12,7 @@ package classes
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(Cock);
 		
 		private static const SERIALIZATION_VERSION:int = 1;
+		private static const SERIALIZATION_UUID:String = "98367a43-6bf4-4b5c-b509-abea7e416416";
 		
 		private static const OBJECT_NOT_FOUND:int = -1;
 
@@ -425,6 +426,11 @@ package classes
 		public function currentSerializationVerison():int 
 		{
 			return SERIALIZATION_VERSION;
+		}
+		
+		public function serializationUUID():String 
+		{
+			return SERIALIZATION_UUID;
 		}
 	}
 }

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -54,6 +54,7 @@ import flash.errors.IllegalOperationError;
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(Creature);
 
 		private static const SERIALIZATION_VERSION:int = 1;
+		private static const SERIALIZATION_UUID:String = "c9ae43aa-e353-472a-a691-010f6ab68191";
 		
 		public function get game():CoC {
 			return kGAMECLASS;
@@ -4392,6 +4393,10 @@ import flash.errors.IllegalOperationError;
 			return SERIALIZATION_VERSION;
 		}
 		
+		public function serializationUUID():String 
+		{
+			return SERIALIZATION_UUID;
+		}
 		
 		public function getKeyColor(layerName:String, keyColorName:String):String {
 			switch (layerName) {

--- a/classes/classes/ItemSlot.as
+++ b/classes/classes/ItemSlot.as
@@ -8,6 +8,7 @@ package classes
 	public class ItemSlot extends Object implements Serializable
 	{
 		private static const SERIALIZATION_VERSION:int = 2;
+		private static const SERIALIZATION_UUID:String = "6c697f95-8c00-4082-9d28-39c1d6c147cd";
 		
 		private static const LEGACY_SHORTNAME_GROPLUS:String = "Gro+";
 		private static const LEGACY_SHORTNAME_SPECIAL_HONEY:String = "Sp Honey";
@@ -178,6 +179,11 @@ package classes
 		public function currentSerializationVerison():int 
 		{
 			return SERIALIZATION_VERSION;
+		}
+		
+		public function serializationUUID():String 
+		{
+			return SERIALIZATION_UUID;
 		}
 		
 		/**

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -3771,6 +3771,16 @@ package classes
 		private function upgradeLegacyItemSlots(relativeRootObject:*):void
 		{
 			LOGGER.info("Upgrading legacy item slots...");
+			LOGGER.info("Checking if save contains new data structure...");
+			
+			// Fix issues that were created by version 1 serialization code
+			if (relativeRootObject.itemSlots !== undefined) {
+				LOGGER.warn("New itemslot data structure present, aborting upgrade!");
+				return;
+			} else {
+				LOGGER.info("New itemslot data structure not present, performing upgrade...");
+			}
+			
 			var slots:Vector.<ItemSlot> = new Vector.<classes.ItemSlot>();
 			
 			var slotname:String = "itemSlot";
@@ -3791,6 +3801,7 @@ package classes
 			
 			if (relativeRootObject[slotName] !== undefined) {
 				SerializationUtils.deserialize(relativeRootObject[slotName], itemSlot);
+				delete relativeRootObject[slotName];
 			}
 			
 			return itemSlot;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -7,6 +7,7 @@ package classes
 	import classes.Items.*;
 	import classes.Scenes.NPCs.Jojo;
 	import classes.internals.LoggerFactory;
+	import classes.internals.SaveGameUtils;
 	import classes.internals.Serializable;
 	import classes.internals.SerializationUtils;
 	import classes.lists.BreastCup;
@@ -35,7 +36,9 @@ public class Saves extends BaseContent implements Serializable {
 	private static const SAVE_FILE_CURRENT_INTEGER_FORMAT_VERSION:int		= 816;
 		//Didn't want to include something like this, but an integer is safer than depending on the text version number from the CoC class.
 		//Also, this way the save file version doesn't need updating unless an important structural change happens in the save file.
-
+		
+	private static const TEMP_SAVEGAME:String = "temp-savegame";
+		
 	private var gameStateGet:Function;
 	private var gameStateSet:Function;
 	private var gearStorageGet:Function;
@@ -557,7 +560,8 @@ public function loadGame(slot:String):void
 		{
 			outputText("Would you like to load the backup version of this slot?");
 			menu();
-			addButton(0, "Yes", loadGame, (slot + "_backup"));
+			SaveGameUtils.copySaveGame(slot + "_backup", TEMP_SAVEGAME);
+			addButton(0, "Yes", loadGame, TEMP_SAVEGAME);
 			addButton(1, "No", saveLoad);
 		}
 		else
@@ -573,7 +577,7 @@ public function loadGame(slot:String):void
 		// Therefore, we clear the display *before* calling loadGameObject
 		clearOutput();
 
-		loadGameObject(saveFile, slot);
+		loadGameObject(tempSharedObject(slot), slot);
 		loadPermObject();
 		outputText("Game Loaded");
 		temp = 0;
@@ -588,6 +592,16 @@ public function loadGame(slot:String):void
 	}
 }
 
+/**
+ * Create and return a copy of the given savegame slot.
+ * @param slot name of the savegame to load
+ * @return The object of a copy of the savegame
+ */
+private function tempSharedObject(slot:String):*
+{
+	SaveGameUtils.copySaveGame(slot, TEMP_SAVEGAME);
+	return SharedObject.getLocal(TEMP_SAVEGAME, "/");
+}
 /**
  * Set the filename that is used to save and load the perm object,
  * which permanently stores data accross games, e.g. achievments.

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -32,7 +32,7 @@ package classes
 
 public class Saves extends BaseContent implements Serializable {
 	private static const LOGGER:ILogger = LoggerFactory.getLogger(Saves);
-	private static const SERIALIZATION_VERSION:int = 2;
+	private static const SERIALIZATION_VERSION:int = 3;
 	private static const SERIALIZATION_UUID:String = "377de6d1-a593-43f8-a87c-61a51ab3e58e";
 	
 	
@@ -2461,6 +2461,9 @@ public function upgradeSerializationVersion(relativeRootObject:*, serializedData
 			upgradeUnversionedSave(relativeRootObject);
 		case 1:
 			moveItemStorageToInventory(relativeRootObject);
+		case 2:
+			addMissingVersionPlayer(relativeRootObject);
+			
 		default:
 		/*
 		 * The default block is left empty intentionally,
@@ -2490,6 +2493,14 @@ private function upgradeUnversionedSave(relativeRootObject:*): void
 	if (npcs.jojo === undefined) {
 		npcs.jojo = [];
 	}
+}
+
+private function addMissingVersionPlayer(relativeRootObject:*):void
+{
+	var player:Player = new Player();
+	
+	relativeRootObject["serializationVersionDictionary"] = [];
+	relativeRootObject["serializationVersionDictionary"][player.serializationUUID()] = 1;
 }
 
 /**

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -33,6 +33,9 @@ package classes
 public class Saves extends BaseContent implements Serializable {
 	private static const LOGGER:ILogger = LoggerFactory.getLogger(Saves);
 	private static const SERIALIZATION_VERSION:int = 2;
+	private static const SERIALIZATION_UUID:String = "377de6d1-a593-43f8-a87c-61a51ab3e58e";
+	
+	
 	private static const SAVE_FILE_CURRENT_INTEGER_FORMAT_VERSION:int		= 816;
 		//Didn't want to include something like this, but an integer is safer than depending on the text version number from the CoC class.
 		//Also, this way the save file version doesn't need updating unless an important structural change happens in the save file.
@@ -2469,6 +2472,11 @@ public function upgradeSerializationVersion(relativeRootObject:*, serializedData
 public function currentSerializationVerison():int
 {
 	return SERIALIZATION_VERSION;
+}
+
+public function serializationUUID():String 
+{
+	return SERIALIZATION_UUID;
 }
 
 private function upgradeUnversionedSave(relativeRootObject:*): void

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -30,6 +30,8 @@ package classes.Scenes
 
 	public class Inventory extends BaseContent implements Serializable {
 		private static const SERIALIZATION_VERSION:int = 1;
+		private static const SERIALIZATION_UUID:String = "230d7e43-bbc6-4c25-bd76-1f1175a0c58e";
+		
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(Inventory);
 		
 		private static const inventorySlotName:Array = ["first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth"];
@@ -980,6 +982,11 @@ package classes.Scenes
 		public function currentSerializationVerison():int 
 		{
 			return SERIALIZATION_VERSION;
+		}
+		
+		public function serializationUUID():String 
+		{
+			return SERIALIZATION_UUID;
 		}
 	}
 }

--- a/classes/classes/Vagina.as
+++ b/classes/classes/Vagina.as
@@ -8,6 +8,7 @@
 	public class Vagina implements Serializable
 	{
 		private static const SERIALIZATION_VERSION:int = 1;
+		private static const SERIALIZATION_UUID:String = "cfe61f89-7ab6-4e4b-83aa-33f738dd2f05";
 		
 		public static const HUMAN:int                     =   0;
 		public static const EQUINE:int                    =   1;
@@ -232,6 +233,11 @@
 		public function currentSerializationVerison():int 
 		{
 			return SERIALIZATION_VERSION;
+		}
+		
+		public function serializationUUID():String 
+		{
+			return SERIALIZATION_UUID;
 		}
 	}
 }

--- a/classes/classes/internals/Serializable.as
+++ b/classes/classes/internals/Serializable.as
@@ -47,5 +47,14 @@ package classes.internals
 		 * @return the current serialization version
 		 */
 		function currentSerializationVerison():int;
+		
+		/**
+		 * A string that is unique among all serializable classes, used to identify the serialization version  for
+		 * this class.
+		 * The ID remains the same if the class is moved or renamed. Once used it should never be changed.
+		 * 
+		 * @return the unique id for this class
+		 */
+		function serializationUUID():String;
 	}
 }

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -96,6 +96,16 @@ package classes.internals
 		}
 		
 		/**
+		 * Get the serialization version from the object for the matching ID, if any.
+		 * @param	relativeRootObject that possibly contains a serialization version
+		 * @param	serialized the class for which the version should be queried
+		 * @return the serialization version, or 0 if no version is found
+		 */
+		public static function serializationVersion(relativeRootObject:*, serialized:Serializable):int {
+			return relativeRootObject[SERIALIZATION_VERSION2_PROPERTY][serialized.serializationUUID()];
+		}
+		
+		/**
 		 * Check the version of the serialized data and compare it with the current version.
 		 * @param	relativeRootObject object that contains serialized data
 		 * @return true if the serialized version is compatible with the current verison

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -102,6 +102,10 @@ package classes.internals
 		 * @return the serialization version, or 0 if no version is found
 		 */
 		public static function serializationVersion(relativeRootObject:*, serialized:Serializable):int {
+			if (relativeRootObject[SERIALIZATION_VERSION2_PROPERTY] === undefined) {
+				return 0;
+			}
+			
 			return relativeRootObject[SERIALIZATION_VERSION2_PROPERTY][serialized.serializationUUID()];
 		}
 		
@@ -110,8 +114,8 @@ package classes.internals
 		 * @param	relativeRootObject object that contains serialized data
 		 * @return true if the serialized version is compatible with the current verison
 		 */
-		public static function serializedVersionCheck(relativeRootObject:*, expectedVersion:int):Boolean {
-			var version:int = SerializationUtils.legacySerializationVersion(relativeRootObject);
+		public static function serializedVersionCheck(relativeRootObject:*, expectedVersion:int, serialized:Serializable):Boolean {
+			var version:int = SerializationUtils.serializationVersion(relativeRootObject, serialized);
 			
 			if (version > expectedVersion) {
 				LOGGER.error("Serialized version is {0}, but the current version is {1}. Backward compatibility is not guaranteed!", version, expectedVersion);
@@ -127,10 +131,11 @@ package classes.internals
 		 * Check the version of the serialized data and compare it with the current version. Throws a Exception
 		 * if the version is newer.
 		 * @param	relativeRootObject object that contains serialized data
+		 * @param	serialized class instance that should have it's state restored
 		 * @throws RangeError if the stored version is newer than the current version
 		 */
-		public static function serializedVersionCheckThrowError(relativeRootObject:*, expectedVersion:int):void {
-			if (!SerializationUtils.serializedVersionCheck(relativeRootObject, expectedVersion)) {
+		public static function serializedVersionCheckThrowError(relativeRootObject:*, expectedVersion:int, serialized:Serializable):void {
+			if (!SerializationUtils.serializedVersionCheck(relativeRootObject, expectedVersion, serialized)) {
 				throw new RangeError("Stored version is newer than the current version");
 			}
 		}
@@ -147,11 +152,24 @@ package classes.internals
 			objectDefinedCheck(relativeRootObject, "Object passed for deserialization must be defined. Does the loaded property exist?")
 			objectDefinedCheck(serialized, "Instance of class to load is not defined. Did you call the class constructor?");
 			
-			SerializationUtils.serializedVersionCheckThrowError(relativeRootObject, serialized.currentSerializationVerison());
-			var serializedObjectVersion:int = SerializationUtils.legacySerializationVersion(relativeRootObject);
+			if (isUsingV1Serialization(relativeRootObject)) {
+				upgradeSerializationVersionToV2(relativeRootObject, serialized);
+			}
+			
+			SerializationUtils.serializedVersionCheckThrowError(relativeRootObject, serialized.currentSerializationVerison(), serialized);
+			var serializedObjectVersion:int = SerializationUtils.serializationVersion(relativeRootObject, serialized);
 			
 			serialized.upgradeSerializationVersion(relativeRootObject, serializedObjectVersion);
 			serialized.deserialize(relativeRootObject);
+		}
+		
+		private static function upgradeSerializationVersionToV2(relativeRootObject:*, serialized:Serializable):void
+		{
+			LOGGER.info("Upgrading serialization for {0}", serialized);
+			
+			relativeRootObject[SERIALIZATION_VERSION2_PROPERTY] = [];
+			relativeRootObject[SERIALIZATION_VERSION2_PROPERTY][serialized.serializationUUID()] = relativeRootObject[SERIALIZATION_VERSION_PROPERTY];
+			delete relativeRootObject[SERIALIZATION_VERSION_PROPERTY];
 		}
 		
 		/**
@@ -167,7 +185,8 @@ package classes.internals
 			objectDefinedCheck(relativeRootObject, "Object used for storage must be defined. Did you forget to initialize e.g. foo = []; ?");
 			objectDefinedCheck(toSerialize, "Instance of class to store is not defined. Did you call the class constructor?");
 			
-			relativeRootObject[SERIALIZATION_VERSION_PROPERTY] = toSerialize.currentSerializationVerison();
+			relativeRootObject[SERIALIZATION_VERSION2_PROPERTY] = [];
+			relativeRootObject[SERIALIZATION_VERSION2_PROPERTY][toSerialize.serializationUUID()] = toSerialize.currentSerializationVerison();
 			
 			toSerialize.serialize(relativeRootObject);
 		}

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -166,5 +166,15 @@ package classes.internals
 				throw new ArgumentError(message);
 			}
 		}
+		
+		/**
+		 * Check if the object is using version 1 serialization.
+		 * @param	relativeRootObject the object to check
+		 * @return true if using version 1
+		 */
+		public static function isUsingV1Serialization(relativeRootObject:*):Boolean
+		{
+			return serializationVersion(relativeRootObject) !== 0;
+		}
 	}
 }

--- a/classes/classes/internals/SerializationUtils.as
+++ b/classes/classes/internals/SerializationUtils.as
@@ -15,6 +15,7 @@ package classes.internals
 		private static const LOGGER:ILogger = LoggerFactory.getLogger(SerializationUtils);
 		
 		private static const SERIALIZATION_VERSION_PROPERTY:String = "serializationVersion";
+		private static const SERIALIZATION_VERSION2_PROPERTY:String = "serializationVersionDictionary";
 		
 		public function SerializationUtils() 
 		{
@@ -85,11 +86,12 @@ package classes.internals
 		}
 		
 		/**
+		 * Legacy method, do not use for new code
 		 * Get the serialization version from the object, if any.
 		 * @param	relativeRootObject that possibly contains a serialization version
 		 * @return the serialization version, or 0 if no version is found
 		 */
-		public static function serializationVersion(relativeRootObject:*):int {
+		public static function legacySerializationVersion(relativeRootObject:*):int {
 			return relativeRootObject[SERIALIZATION_VERSION_PROPERTY];
 		}
 		
@@ -99,7 +101,7 @@ package classes.internals
 		 * @return true if the serialized version is compatible with the current verison
 		 */
 		public static function serializedVersionCheck(relativeRootObject:*, expectedVersion:int):Boolean {
-			var version:int = SerializationUtils.serializationVersion(relativeRootObject);
+			var version:int = SerializationUtils.legacySerializationVersion(relativeRootObject);
 			
 			if (version > expectedVersion) {
 				LOGGER.error("Serialized version is {0}, but the current version is {1}. Backward compatibility is not guaranteed!", version, expectedVersion);
@@ -136,7 +138,7 @@ package classes.internals
 			objectDefinedCheck(serialized, "Instance of class to load is not defined. Did you call the class constructor?");
 			
 			SerializationUtils.serializedVersionCheckThrowError(relativeRootObject, serialized.currentSerializationVerison());
-			var serializedObjectVersion:int = SerializationUtils.serializationVersion(relativeRootObject);
+			var serializedObjectVersion:int = SerializationUtils.legacySerializationVersion(relativeRootObject);
 			
 			serialized.upgradeSerializationVersion(relativeRootObject, serializedObjectVersion);
 			serialized.deserialize(relativeRootObject);
@@ -174,7 +176,7 @@ package classes.internals
 		 */
 		public static function isUsingV1Serialization(relativeRootObject:*):Boolean
 		{
-			return serializationVersion(relativeRootObject) !== 0;
+			return legacySerializationVersion(relativeRootObject) !== 0;
 		}
 	}
 }

--- a/test/classes/BreastRowTest.as
+++ b/test/classes/BreastRowTest.as
@@ -218,7 +218,7 @@ package classes{
 		[Test]
 		public function breastRowFixNoNipples():void
 		{
-			serializedClass.serializationVersion = 0;
+			serializedClass.serializationVersionDictionary = [];
 			serializedClass.nipplesPerBreast = 0;
 			
 			SerializationUtils.deserialize(serializedClass, deserialized);
@@ -229,7 +229,7 @@ package classes{
 		[Test]
 		public function breastRowFixNegativeLactationMultiplier():void
 		{
-			serializedClass.serializationVersion = 0;
+			serializedClass.serializationVersionDictionary = [];
 			serializedClass.lactationMultiplier = -42;
 			
 			SerializationUtils.deserialize(serializedClass, deserialized);
@@ -240,7 +240,7 @@ package classes{
 		[Test]
 		public function breastRowFixNegativeBreastRating():void
 		{
-			serializedClass.serializationVersion = 0;
+			serializedClass.serializationVersionDictionary = [];
 			serializedClass.breastRating = -42;
 			
 			SerializationUtils.deserialize(serializedClass, deserialized);

--- a/test/classes/ItemSlotTest.as
+++ b/test/classes/ItemSlotTest.as
@@ -76,7 +76,7 @@ package classes
 		[Test]
 		public function deserializeItypeWithLegacyShortName():void
 		{
-			delete serializedClass["serializationVersion"];
+			delete serializedClass["serializationVersionDictionary"];
 			delete serializedClass["id"];
 			serializedClass.shortName = ITYPE.shortName;
 			
@@ -98,7 +98,7 @@ package classes
 		[Test]
 		public function upgradeLegacyGroPlusShortName():void
 		{
-			delete serializedClass["serializationVersion"];
+			delete serializedClass["serializationVersionDictionary"];
 			delete serializedClass["id"];
 			serializedClass.shortName = "Gro+";
 			
@@ -110,7 +110,7 @@ package classes
 		[Test]
 		public function upgradeLegacySpecialHoneyShortName():void
 		{
-			delete serializedClass["serializationVersion"];
+			delete serializedClass["serializationVersionDictionary"];
 			delete serializedClass["id"];
 			serializedClass.shortName = "Sp Honey";
 			

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -1036,6 +1036,7 @@ package classes
 		{
 			delete serializedClass["serializationVersionDictionary"];
 			delete serializedClass["serializationVersion"];
+			delete serializedClass["itemSlots"];
 			
 			buildLegacySaveSlots(serializedClass);
 			SerializationUtils.deserialize(serializedClass, deserialized);
@@ -1048,6 +1049,7 @@ package classes
 		{
 			delete serializedClass["serializationVersionDictionary"];
 			delete serializedClass["serializationVersion"];
+			delete serializedClass["itemSlots"];
 			
 			buildLegacySaveSlots(serializedClass);
 			SerializationUtils.deserialize(serializedClass, deserialized);
@@ -1055,11 +1057,37 @@ package classes
 			assertThat(deserialized.itemSlot(1).unlocked, equalTo(true));
 		}
 		
+		[Test]
+		public function upgradeExisitingItemSlotsUnlocked():void
+		{
+			delete serializedClass["serializationVersionDictionary"];
+			delete serializedClass["serializationVersion"];
+			
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(deserialized.itemSlot(1).unlocked, equalTo(true));
+		}
+		
+		[Test]
+		public function upgradeDeletesLegacyItemSlots():void
+		{
+			delete serializedClass["serializationVersionDictionary"];
+			delete serializedClass["serializationVersion"];
+			delete serializedClass["itemSlots"];
+			
+			buildLegacySaveSlots(serializedClass);
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(serializedClass, not(hasProperty("itemSlot1")));
+			assertThat(serializedClass, not(hasProperty("itemSlot5")));
+		}
+		
 		[Test(description="Vanilla only has slots 1 to 5")]
 		public function upgradeLegacyItemSlotsFromVanilla():void
 		{
 			delete serializedClass["itemSlots"];
 			delete serializedClass["serializationVersionDictionary"];
+			delete serializedClass["itemSlots"];
 			
 			buildLegacySaveSlots(serializedClass);
 			

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -1032,7 +1032,7 @@ package classes
 		}
 		
 		[Test]
-		public function upgradeLegacyItemSlots():void
+		public function upgradeLegacyItemSlotsType():void
 		{
 			delete serializedClass["serializationVersionDictionary"];
 			delete serializedClass["serializationVersion"];
@@ -1041,6 +1041,18 @@ package classes
 			SerializationUtils.deserialize(serializedClass, deserialized);
 			
 			assertThat(deserialized.itemSlot(1).itype.id, equalTo(new ConsumableLib().W_FRUIT.id));
+		}
+		
+		[Test]
+		public function upgradeLegacyItemSlotsUnlocked():void
+		{
+			delete serializedClass["serializationVersionDictionary"];
+			delete serializedClass["serializationVersion"];
+			
+			buildLegacySaveSlots(serializedClass);
+			SerializationUtils.deserialize(serializedClass, deserialized);
+			
+			assertThat(deserialized.itemSlot(1).unlocked, equalTo(true));
 		}
 		
 		[Test(description="Vanilla only has slots 1 to 5")]

--- a/test/classes/PlayerTest.as
+++ b/test/classes/PlayerTest.as
@@ -1034,7 +1034,7 @@ package classes
 		[Test]
 		public function upgradeLegacyItemSlots():void
 		{
-			delete serializedClass["itemSlots"];
+			delete serializedClass["serializationVersionDictionary"];
 			delete serializedClass["serializationVersion"];
 			
 			buildLegacySaveSlots(serializedClass);
@@ -1047,7 +1047,7 @@ package classes
 		public function upgradeLegacyItemSlotsFromVanilla():void
 		{
 			delete serializedClass["itemSlots"];
-			delete serializedClass["serializationVersion"];
+			delete serializedClass["serializationVersionDictionary"];
 			
 			buildLegacySaveSlots(serializedClass);
 			

--- a/test/classes/SavesTest.as
+++ b/test/classes/SavesTest.as
@@ -652,6 +652,14 @@ package classes{
 		}
 		
 		[Test]
+		public function upgradeAddsVersionForPlayer():void
+		{	
+			cut.upgradeSerializationVersion(serializedSave, 2);
+			
+			assertThat(serializedSave.serializationVersionDictionary, hasProperty(new Player().serializationUUID()));
+		}
+		
+		[Test]
 		public function inventoryMustBeValid():void
 		{
 			assertThat(kGAMECLASS.inventory, notNullValue());

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -130,13 +130,13 @@ package classes.internals
 		public function serializationVersionWithNoProperty():void {
 			serializedObject = [];
 			
-			assertThat(SerializationUtils.serializationVersion(serializedObject), equalTo(0));
+			assertThat(SerializationUtils.legacySerializationVersion(serializedObject), equalTo(0));
 		}
 		
 				
 		[Test]
 		public function serializationVersionWithProperty():void {
-			assertThat(SerializationUtils.serializationVersion(serializedObject), equalTo(SERIAL_VERSION));
+			assertThat(SerializationUtils.legacySerializationVersion(serializedObject), equalTo(SERIAL_VERSION));
 		}
 				
 		[Test]

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -14,6 +14,7 @@ package classes.internals
 	{
 		private static const TEST_INSTANCES:int = 5;
 		private static const SERIAL_VERSION:int = 2;
+		private static const SERIAL_UUID:String = "11111111-2222-3333-4444-555555555555";
 		
 		private var testObject:Array;
 		private var testVector:Vector.<Serializable>;
@@ -267,5 +268,10 @@ class SerializationDummy implements Serializable
 	public function currentSerializationVerison():int 
 	{
 		return 2;
+	}
+	
+	public function serializationUUID():String 
+	{
+		return "11111111-2222-3333-4444-555555555555"
 	}
 }

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -44,6 +44,8 @@ package classes.internals
 			
 			serializedObject = [];
 			serializedObject.serializationVersion = SERIAL_VERSION;
+			serializedObject.serializationVersionDictionary = [];
+			serializedObject.serializationVersionDictionary[SERIAL_UUID] = SERIAL_VERSION_V2;
 			
 			dummy = new SerializationDummy();
 			
@@ -129,46 +131,57 @@ package classes.internals
 		}
 		
 		[Test]
-		public function serializationVersionWithNoProperty():void {
+		public function legacySerializationVersionWithNoProperty():void {
 			serializedObject = [];
 			
 			assertThat(SerializationUtils.legacySerializationVersion(serializedObject), equalTo(0));
 		}
 		
-				
 		[Test]
-		public function serializationVersionWithProperty():void {
+		public function legacySerializationVersionWithProperty():void {
 			assertThat(SerializationUtils.legacySerializationVersion(serializedObject), equalTo(SERIAL_VERSION));
 		}
-				
+		
+		[Test]
+		public function serializationVersionWithNoProperty():void {
+			serializedObject = [];
+			
+			assertThat(SerializationUtils.serializationVersion(serializedObject, dummy), equalTo(0));
+		}
+		
+		[Test]
+		public function serializationVersionWithProperty():void {
+			assertThat(SerializationUtils.serializationVersion(serializedObject, dummy), equalTo(SERIAL_VERSION_V2));
+			}
+		
 		[Test]
 		public function serializedVersionCheckSerializedGreater():void {
-			assertThat(SerializationUtils.serializedVersionCheck(serializedObject, 1), equalTo(false));
+			assertThat(SerializationUtils.serializedVersionCheck(serializedObject, 1, dummy), equalTo(false));
 		}
 		
 		[Test]
 		public function serializedVersionCheckSerializedEqual():void {
-			assertThat(SerializationUtils.serializedVersionCheck(serializedObject, 2), equalTo(true));
+			assertThat(SerializationUtils.serializedVersionCheck(serializedObject, 7, dummy), equalTo(true));
 		}
 		
 		[Test]
 		public function serializedVersionCheckSerializedLess():void {
-			assertThat(SerializationUtils.serializedVersionCheck(serializedObject, 3), equalTo(true));
+			assertThat(SerializationUtils.serializedVersionCheck(serializedObject, 8, dummy), equalTo(true));
 		}
 		
 		[Test(expected="RangeError")]
 		public function serializedVersionCheckThrowErrorGreater():void {
-			SerializationUtils.serializedVersionCheckThrowError(serializedObject, 1);
+			SerializationUtils.serializedVersionCheckThrowError(serializedObject, 1, dummy);
 		}
 		
 		[Test]
 		public function serializedVersionCheckThrowErrorEqual():void {
-			SerializationUtils.serializedVersionCheckThrowError(serializedObject, 2);
+			SerializationUtils.serializedVersionCheckThrowError(serializedObject, 7, dummy);
 		}
 		
 		[Test]
 		public function serializedVersionCheckThrowErrorLess():void {
-			SerializationUtils.serializedVersionCheckThrowError(serializedObject, 3);
+			SerializationUtils.serializedVersionCheckThrowError(serializedObject, 8, dummy);
 		}
 		
 		[Test]

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -14,6 +14,7 @@ package classes.internals
 	{
 		private static const TEST_INSTANCES:int = 5;
 		private static const SERIAL_VERSION:int = 2;
+		private static const SERIAL_VERSION_V2:int = 7;
 		private static const SERIAL_UUID:String = "11111111-2222-3333-4444-555555555555";
 		
 		private var testObject:Array;
@@ -223,6 +224,26 @@ package classes.internals
 		[Test]
 		public function objectIsNotUsingV1Serialization():void {
 			assertThat(SerializationUtils.isUsingV1Serialization([]), false);
+		}
+		
+		[Test]
+		public function serializationVersionV2WithEntry():void {
+			serializedObject = [];
+			serializedObject.serializationVersionDictionary = [];
+			serializedObject.serializationVersionDictionary[SERIAL_UUID] = SERIAL_VERSION_V2;
+			
+			
+			assertThat(SerializationUtils.serializationVersion(serializedObject,dummy), SERIAL_VERSION_V2);
+		}
+		
+		[Test]
+		public function serializationVersionV2WithoutEntry():void {
+			serializedObject = [];
+			serializedObject.serializationVersionDictionary = [];
+			serializedObject.serializationVersionDictionary["abc"] = SERIAL_VERSION_V2;
+			
+			
+			assertThat(SerializationUtils.serializationVersion(serializedObject,dummy), 0);
 		}
 	}
 }

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -213,6 +213,16 @@ package classes.internals
 			
 			assertThat(serializedObject, hasProperties({foo: -1, bar: -1, serializationVersion: SERIAL_VERSION}));
 		}
+		
+		[Test]
+		public function objectIsUsingV1Serialization():void {
+			assertThat(SerializationUtils.isUsingV1Serialization(serializedObject), true);
+		}
+		
+		[Test]
+		public function objectIsNotUsingV1Serialization():void {
+			assertThat(SerializationUtils.isUsingV1Serialization([]), false);
+		}
 	}
 }
 

--- a/test/classes/internals/SerializationUtilTest.as
+++ b/test/classes/internals/SerializationUtilTest.as
@@ -258,6 +258,27 @@ package classes.internals
 			
 			assertThat(SerializationUtils.serializationVersion(serializedObject,dummy), 0);
 		}
+		
+		[Test]
+		public function serializationVersionUpgradeCopiesVersion():void {
+			serializedObject['foo'] = 1;
+			serializedObject['bar'] = 2;
+			
+			SerializationUtils.deserialize(serializedObject, dummy);
+			
+			//TODO using the UUID variable gets interpreted as literal, is there a way to use variables?
+			assertThat(serializedObject.serializationVersionDictionary, hasProperties({"11111111-2222-3333-4444-555555555555": 2}));
+		}
+		
+		[Test]
+		public function serializationVersionUpgradeRemovesV1SerializationVersion():void {
+			serializedObject['foo'] = 1;
+			serializedObject['bar'] = 2;
+			
+			SerializationUtils.deserialize(serializedObject, dummy);
+			
+			assertThat(serializedObject, not(hasProperty("serializationVersion")));
+		}
 	}
 }
 


### PR DESCRIPTION
### **Depends on #1414**

The existing serialization caused issues because multiple classes were serialized to the same object and there was no way to tell them apart - this led to classes loading with the incorrect serialization version.

V2 uses a dictionary / map per object so version for multiple classes can be tracked.
V1 versions are upgraded to V2.