### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 
 addons:
   # service for code quality analysis


### PR DESCRIPTION
This PR tells Travis CI to use the old Trusty distribution.

Fixes #1440