### PR TITLE
Indefatigable Oversight Fix

### DIFF
--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1886,7 +1886,7 @@ package classes.Scenes.Combat
 				a[i].onCombatRound();
 			}
 			regeneration(true);
-			if (player.lust >= player.maxLust()) doNext(endLustLoss);
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable)) doNext(endLustLoss);
 			if (player.HP <= 0) doNext(endHpLoss);
 		}
 


### PR DESCRIPTION
Player could still lose via lust at the end of function combatStatusesUpdate() if they owned the Indefatigable perk. This should fix it.