### PR TITLE
Fixed More Indefatigable Oversights

### DIFF
--- a/classes/classes/Scenes/Areas/Forest/BeeGirl.as
+++ b/classes/classes/Scenes/Areas/Forest/BeeGirl.as
@@ -78,7 +78,7 @@ import classes.internals.ChainedDrop;
 				}
 				paralyze.increase();
 			}
-			if (player.lust >= player.maxLust())
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable))
 				doNext(game.combat.endLustLoss);
 			else doNext(game.playerMenu);
 		}

--- a/classes/classes/Scenes/Areas/Forest/Dryad.as
+++ b/classes/classes/Scenes/Areas/Forest/Dryad.as
@@ -42,7 +42,7 @@ package classes.Scenes.Areas.Forest
 				outputText("You take a deep breath of the pollen!\n ");
 				outputText("Your mind becomes a haze as a hot wave of arousal washes over you.");
 				player.takeLustDamage(lustDmg, true);
-				if (player.lust >= player.maxLust())
+				if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable))
 					doNext(game.combat.endLustLoss);
 				else doNext(game.playerMenu);
 			}

--- a/classes/classes/Scenes/Areas/Lake/FetishCultist.as
+++ b/classes/classes/Scenes/Areas/Lake/FetishCultist.as
@@ -84,7 +84,7 @@ package classes.Scenes.Areas.Lake
 				outputText("She suddenly starts mauling her shapely breasts, her fingers nearly disappearing briefly in the soft, full flesh, while fingering herself eagerly, emitting a variety of lewd noises.  You are entranced by the scene, the sexual excitement she's experiencing penetrating your body in warm waves coming from your groin.");
 			}
 			player.takeLustDamage((player.lib/10 + player.cor/20) +4, true);
-			if (player.lust >= player.maxLust())
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable))
 				doNext(game.combat.endLustLoss);
 			else doNext(game.combat.combatMenu);
 		}
@@ -110,7 +110,7 @@ package classes.Scenes.Areas.Lake
 				lust -= 50;
 				if (lust < 0) lust = 10;
 			}
-			if (player.lust >= player.maxLust())
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable))
 				doNext(game.combat.endLustLoss);
 			else doNext(game.combat.combatMenu);
 		}

--- a/classes/classes/Scenes/Areas/Mountain/HellHound.as
+++ b/classes/classes/Scenes/Areas/Mountain/HellHound.as
@@ -41,7 +41,7 @@ package classes.Scenes.Areas.Mountain
 					doNext(game.combat.endHpLoss);
 					return;
 				}
-				if(player.lust >= player.maxLust()) {
+				if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable)) {
 					doNext(game.combat.endLustLoss);
 					return;
 				}		

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -429,7 +429,7 @@ package classes.Scenes.Combat
 			outputText("\n\n");
 			flags[kFLAGS.SPELLS_CAST]++;
 			spellPerkUnlock();
-			if (player.lust >= player.maxLust()) doNext(combat.endLustLoss);
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable)) doNext(combat.endLustLoss);
 			else getGame().combat.enemyTurn();
 			return;
 		}
@@ -473,7 +473,7 @@ package classes.Scenes.Combat
 			outputText("\n\n");
 			flags[kFLAGS.SPELLS_CAST]++;
 			spellPerkUnlock();
-			if (player.lust >= player.maxLust()) doNext(combat.endLustLoss);
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable)) doNext(combat.endLustLoss);
 			else getGame().combat.enemyTurn();
 			return;
 		}
@@ -541,7 +541,7 @@ package classes.Scenes.Combat
 				spellPerkUnlock();
 				monsterTarget.HP -= temp;
 			}
-			if (player.lust >= player.maxLust()) doNext(combat.endLustLoss);
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable)) doNext(combat.endLustLoss);
 			else if (combat.countMonstersLeft() <= 0) doNext(combat.endHpVictory);
 			else getGame().combat.enemyTurn();
 		}

--- a/classes/classes/Scenes/Dungeons/DeepCave/Zetaz.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/Zetaz.as
@@ -113,7 +113,7 @@ package classes.Scenes.Dungeons.DeepCave
 				if (player.lust100 >= 60 && player.vaginas[0].vaginalWetness == Vagina.WETNESS_DROOLING && player.vaginas.length > 0) outputText("Thick runners of girl-lube stream down the insides of your thighs as your crotch gives into the demonic magics.  You wonder what " + a + short + "'s cock would feel like inside you?  ");
 				if (player.lust100 >= 60 && player.vaginas[0].vaginalWetness == Vagina.WETNESS_SLAVERING && player.vaginas.length == 1) outputText("Your " + player.vaginaDescript() + " instantly soaks your groin with the heady proof of your need.  You wonder just how slippery you could " + a + short + "'s dick when it's rammed inside you?  ");
 			}
-			if (player.lust >= player.maxLust()) doNext(game.combat.endLustLoss)
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable)) doNext(game.combat.endLustLoss)
 			else combatRoundOver();
 		}
 

--- a/classes/classes/Scenes/Dungeons/LethicesKeep/Doppelganger.as
+++ b/classes/classes/Scenes/Dungeons/LethicesKeep/Doppelganger.as
@@ -1,5 +1,6 @@
 package classes.Scenes.Dungeons.LethicesKeep 
 {
+	import classes.*;
 	import classes.BodyParts.*;
 	import classes.BreastRow;
 	import classes.Cock;
@@ -85,7 +86,7 @@ package classes.Scenes.Dungeons.LethicesKeep
 				return;
 			}
 			
-			if (player.lust >= player.maxLust())
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable))
 			{
 				doNext(game.combat.endLustLoss);
 				return;

--- a/classes/classes/Scenes/Monsters/Imp.as
+++ b/classes/classes/Scenes/Monsters/Imp.as
@@ -67,7 +67,7 @@ package classes.Scenes.Monsters
 				}
 			}
 			player.takeLustDamage(lustDmg, true);
-			if (player.lust >= player.maxLust())
+			if (player.lust >= player.maxLust() && !player.hasPerk(PerkLib.Indefatigable))
 				doNext(game.combat.endLustLoss);
 			else doNext(game.playerMenu);
 		}


### PR DESCRIPTION
Fixed more instances where the Indefatigable perk was not considered when checking for Lust Loss in the following functions:
Beegirl's `beeStingAttack()`
Dryad's `pollen()`
Fetish Cultist's `cultistRaisePlayerLust()` and `cultistLustTransfer()`
Hellhound's `hellhoundFire()`
Spells `spellHeal()`, `spellMight()`, and `spellBlackFire()`
Zetaz's `gigaArouse()`
Doppelganger's `addTalkShit()`
Imp's `lustMagicAttack()`

Edit: Forgot to mention this DOES disable Doppelganger's time limit if the player has the perk, fyi in case that's undesirable