### PR TITLE
No more naga dreams for the naga dress, if already a full naga

### DIFF
--- a/classes/classes/DebugMenu.as
+++ b/classes/classes/DebugMenu.as
@@ -513,14 +513,15 @@ package classes
 			armourArray.push(armors.LTHRROB);
 			armourArray.push(armors.M_ROBES);
 			armourArray.push(armors.TBARMOR);
+			armourArray.push(armors.NAGASLK);
 			armourArray.push(armors.NURSECL);
 			armourArray.push(armors.OVERALL);
 			armourArray.push(armors.R_BDYST);
 			armourArray.push(armors.RBBRCLT);
 			armourArray.push(armors.S_SWMWR);
 			armourArray.push(armors.SAMUARM);
-			armourArray.push(armors.SCALEML);
 			//Page 4
+			armourArray.push(armors.SCALEML);
 			armourArray.push(armors.SEDUCTA);
 			armourArray.push(armors.SEDUCTU);
 			armourArray.push(armors.SS_ROBE);

--- a/classes/classes/Items/Armors/NagaSilkDress.as
+++ b/classes/classes/Items/Armors/NagaSilkDress.as
@@ -1,9 +1,11 @@
 //idea from liadri, added to by others
 package classes.Items.Armors {
+import classes.BodyParts.*;
 import classes.Items.Armor;
 import classes.TimeAwareInterface;
 import classes.Player;
 import classes.CoC;
+import classes.GlobalFlags.kFLAGS;
 import classes.GlobalFlags.kGAMECLASS;
 import classes.Items.ConsumableLib;
 
@@ -34,12 +36,25 @@ public class NagaSilkDress extends Armor implements TimeAwareInterface {
 		
 	public function timeChange():Boolean {
 		if (player.armor is NagaSilkDress && kGAMECLASS.time.hours == 5) { //only call function once per day as time change is called every hour
-			Progression(); 
-			return true;
+			if (player.spe100 < 70 ||
+				player.neck.type !== Neck.NORMAL ||
+				player.hasNonSharkRearBody() ||
+				(player.breastRows.length > 1 && !kGAMECLASS.flags[kFLAGS.HYPER_HAPPY]) ||
+				player.wings.type !== Wings.NONE ||
+				player.rearBody.type === RearBody.SHARK_FIN ||
+				player.antennae.type !== Antennae.NONE ||
+				player.tongue.type !== Tongue.SNAKE ||
+				player.face.type !== Face.SNAKE_FANGS ||
+				player.lowerBody.type !== LowerBody.NAGA ||
+				player.hasGills()
+			) {
+				progression();
+				return true;
+			}
 		}
 		return false; //stop if not wearing
 		}
-	public function Progression():void {
+	private function progression():void {
 
 		var dreams:Array = ["That night you have a strange dream. You are in the desert basking in the sun.   You look down and notice that there are not legs attached to your lower body. There is a large" +
 		" snake-like tail. Thinking about it seems to make your tail flip slightly.   \n\n"+
@@ -98,8 +113,9 @@ public class NagaSilkDress extends Armor implements TimeAwareInterface {
 		"As soon as you agree she hugs you tightly, enveloping your face with her voluptuous breasts.\n\n"+
 		"You awake wondering why you dream about nagas so often.\n\n"		];
 		clearOutput();
-		outputText("\n\n" + dreams[rand(dreams.length)] + "\n\n");
+		outputText("\n\n" + dreams[rand(dreams.length)]);
 		outputText("Lucky Day!   You find a vial of snake oil in your dress and quicky quaff it down.\n\n");
-		kGAMECLASS.consumables.SNAKOIL.useItem();
+		kGAMECLASS.consumables.NDRSOIL.useItem();
+		outputText("\n");
 	}
 }}

--- a/classes/classes/Items/ConsumableLib.as
+++ b/classes/classes/Items/ConsumableLib.as
@@ -174,6 +174,7 @@ package classes.Items
 		public const MOUSECO:Consumable = new MouseCocoa();
 		public const MINOBLO:Consumable = new MinotaurBlood();
 		public const MYSTJWL:Consumable = new FoxJewel(FoxJewel.MYSTIC);
+		public const NDRSOIL:Consumable = new SnakeOil(SnakeOil.NAGADRESS);
 		public const OCULUMA:Consumable = new OculumArachnae();
 		public const P_LBOVA:Consumable = new LaBova(LaBova.PURIFIED);
 		public const PIGTRUF:Consumable = new PigTruffle(false);

--- a/classes/classes/Items/Consumables/SnakeOil.as
+++ b/classes/classes/Items/Consumables/SnakeOil.as
@@ -34,17 +34,27 @@ package classes.Items.Consumables
 	 */
 	public class SnakeOil extends Consumable 
 	{
-		public function SnakeOil() 
+		public static const STANDARD:int = 0;
+		public static const NAGADRESS:int = 1;
+
+		private var type:int;
+
+		public function SnakeOil(_type:int = STANDARD) 
 		{
+			type = _type;
 			super("SnakOil", "SnakOil", "a vial of snake oil", ConsumableLib.DEFAULT_VALUE, "A vial the size of your fist made of dark brown glass. It contains what appears to be an oily, yellowish liquid. The odor is abominable.");
 		}
 		
 		override public function useItem():Boolean
 		{
 			var tfSource:String = "snakeOil";
+			var hasStatchange:Boolean = false;
 			player.slimeFeed();
 			mutations.initTransformation([2, 2]);
-			clearOutput();
+
+			if (type !== NAGADRESS) {
+				clearOutput();
+			}
 			//b) Description while used
 			outputText("Pinching your nose, you quickly uncork the vial and bring it to your mouth, determined to see what effects it might have on your body. Pouring in as much as you can take, you painfully swallow before going for another shot, emptying the bottle.");
 			//(if outside combat)
@@ -54,6 +64,7 @@ package classes.Items.Consumables
 				dynStats("spe", (2 - (player.spe / 10 / 5)));
 				outputText("\n\nYour muscles quiver, feeling ready to strike as fast as a snake!");
 				if (player.spe100 < 40) outputText("  Of course, you're nowhere near as fast as that.");
+				hasStatchange = true;
 			}
 			//Neck restore
 			if (player.neck.type != Neck.NORMAL && changes < changeLimit && rand(4) == 0) mutations.restoreNeck(tfSource);
@@ -140,7 +151,7 @@ package classes.Items.Consumables
 			}
 
 			//Default change - blah
-			if (changes === 0) outputText("\n\nRemakarbly, the snake-oil has no effect.  Should you really be surprised at snake-oil NOT doing anything?");
+			if (changes === 0 && !hasStatchange) outputText("\n\nRemakarbly, the snake-oil has no effect.  Should you really be surprised at snake-oil NOT doing anything?");
 			player.refillHunger(5);
 			game.flags[kFLAGS.TIMES_TRANSFORMED] += changes;
 			return false;


### PR DESCRIPTION
### Gameplay changes
- The player shouldn't dream of being a naga, if already fully TFed into
a naga.
- If the snake oil boosted your speed it won't display the 'it didn't do
anything'-message anymore
- The dreams of the naga dress should now show up properly (Supresses
the `clearOutput();`-call in `SnakeOil.as` when coming from the dress.
- Fixed the paragraph-breaks.
- Added the naga dress to the spawn armor section in the debug menu.

### Notes
- I've used a huge `if` to check, if the snake-oil could do any change
to the player. Maybe the TF-system should get a big revamp to check, if
any TF would do any change. But right now, that would be overkill.
- `NagaSilkDress.as` probably needs some code pretty ... later