### PR TITLE
Fix Travis build (once more)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,13 @@ install:
   - Xvnc :1 &
  
 script:
-    # this is where the build happens. A separate build is started for every entry in the matrix element
-  - travis_wait ant test-$BUILD
+  # this is where the build happens. A separate build is started for every entry in the matrix element
+  # alternative to travis_wait from https://github.com/travis-ci/travis-ci/issues/4190#issuecomment-353342526
+  # Output something every 10 minutes or Travis kills the job
+  - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+  - ant test-$BUILD
+  # Killing background sleep loop
+  - kill %1
   - devTools/ci/update-sonar-version.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ after_failure:
 env:
   global:
     # tell the build file where to find the flex SDK
-    - FLEX_HOME=build-dep/bin/flex/"
+    - FLEX_HOME="build-dep/bin/flex/"
     # this is to trick the flash player into thinking it is running on a desktop
     - DISPLAY=":1"
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: trusty
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: trusty
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   # alternative to travis_wait from https://github.com/travis-ci/travis-ci/issues/4190#issuecomment-353342526
   # Output something every 10 minutes or Travis kills the job
   - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+  # this runs the actual build
   - ant test-$BUILD
   # Killing background sleep loop
   - kill %1


### PR DESCRIPTION
Fix failing Travis build.

The root cause was a incorrectly quoted environment variable. Previously the Travis parser seems to have been more lenient with errors and parsed them anyway, but that changed at some point and led to the build failures.

- Fix Travis env variable
- Fix build config warnings
- Use alternative to `travis_wait` command
  - Output to log at regular intervals to prevent build timeout, this allows normal log output (`travis_wait` buffers output and then prints it at the end).
