### PR TITLE
Reorganize and Fix minoCumAddiction in Player.as

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -2282,38 +2282,48 @@ package classes
 		}
 
 		public function minoCumAddiction(raw:Number = 10):void {
-			//Increment minotaur cum intake count
+			//Increment minotaur cum intake count, and reset the counter
 			flags[kFLAGS.MINOTAUR_CUM_INTAKE_COUNT]++;
-			//Fix if variables go out of range.
-			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] < 0) flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = 0;
-			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] < 0) flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] = 0;
-			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] > 120) flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = 120;
-
-			//Turn off withdrawal
-			//if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] > 1) flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] = 1;
-			//Reset counter
 			flags[kFLAGS.TIME_SINCE_LAST_CONSUMED_MINOTAUR_CUM] = 0;
-			//If highly addicted, rises slower
+			
+			//Adjust out-of-range variables
+			flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = Math.max(flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER],0)
+			flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = Math.min(flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER],120)
+			flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] = Math.max(flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE],0)
+			
+			//if immune to addiction or disabled, set the state to 1 and tracker to 0, then stop the function before it does stuff
+			if (flags[kFLAGS.ADDICTIONS_ENABLED] <= 0 || hasPerk(PerkLib.MinotaurCumResistance)) {
+				flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] = 1;
+				flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = 0;
+				return;
+			}
+			
+			//If highly addicted, rises slower.
 			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] >= 60) raw /= 2;
 			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] >= 80) raw /= 2;
 			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] >= 90) raw /= 2;
-			if (hasPerk(PerkLib.MinotaurCumResistance)) raw *= 0;
-			//If in withdrawl, readdiction is potent!
-			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] == 3) raw += 10;
-			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] == 2) raw += 5;
-			raw = Math.round(raw * 100)/100;
-			//PUT SOME CAPS ON DAT' SHIT
-			if (raw > 50) raw = 50;
-			if (raw < -50) raw = -50;
-			if (flags[kFLAGS.ADDICTIONS_ENABLED] <= 0) { //Disables addiction if set to OFF.
-				flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] = 1;
-				raw = 0; 
+			
+			//If in withdrawl, changes are potent!
+			//This fixes Purified Minotaur Cum causing addiction to increase while in withdrawal
+			if (raw > 0) {
+				if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] == 3) raw += 10;
+				if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] == 2) raw += 5;
 			}
+			if (raw < 0) {
+				if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] == 3) raw -= 10;
+				if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] == 2) raw -= 5;
+			}
+			
+			raw = Math.round(raw * 100)/100; //round to 2 decimal places
+			raw = Math.max(raw, -50) //limit raw to between -50, 50
+			raw = Math.min(raw, 50)
+			
 			flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] += raw;
-			//Recheck to make sure shit didn't break
-			if (hasPerk(PerkLib.MinotaurCumResistance)) flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = 0; //Never get addicted!
-			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] > 120) flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = 120;
-			if (flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] < 0) flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = 0;
+			
+			//Adjust out-of-range variables again
+			flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = Math.max(flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER],0)
+			flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER] = Math.min(flags[kFLAGS.MINOTAUR_CUM_ADDICTION_TRACKER],120)
+			flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE] = Math.max(flags[kFLAGS.MINOTAUR_CUM_ADDICTION_STATE],0)
 		}
 		
 		public function hasSpells():Boolean


### PR DESCRIPTION
There is a bug where drinking Purified Minotaur Cum while in minotaur withdrawal causes addiction to *increase* instead of decrease. I fixed that, now instead of adding a flat 5 or 10 to a negative raw, it subtracts.

I also generally readjusted the whole function
- If the player is immune or disabled addiction, the function now exits before doing any math, instead of setting the raw to 0. (Fun fact, previously if the player was somehow both resistant and in withdrawal, it would add to the tracker.)
- I changed the if statements that limit how big or small a variable can be to Math.max and Math.min functions. (I see this in the code a lot, is there a reason if statements are used instead? Math.max/min are just easier to read, (though a clamp function would be preferable))
- I moved some stuff around to make it neater, and removed some commented-out code.