### PR TITLE
Edryn Initial Sex Offer Requirements Change

### DIFF
--- a/classes/classes/Scenes/Places/TelAdre/Edryn.as
+++ b/classes/classes/Scenes/Places/TelAdre/Edryn.as
@@ -207,7 +207,7 @@ public function edrynBarTalk():void {
 		//Non horsedick
 		else {
 			outputText("but the potent musky scent only reminds you of how different things are here.");
-			if (player.isCorruptEnough(50) || player.statusEffectv1(StatusEffects.Edryn) > 0 || flags[kFLAGS.LOW_STANDARDS_FOR_ALL]) {
+			if (player.lust < 33) {
 				outputText("  Unbidden, your mind wonders what her juicy horse-snatch would feel like, and your " + player.cockDescript(0) + " responds immediately, thickening with readiness.  You squirm uncomfortably from how constricting your " + player.armorName + " feels.\n\n");
 				outputText("You give the rapidly dissipating scent a sniff and note that it isn't unpleasant, just strong, and once again you find yourself imagining standing ");
 				if (player.tallness < 60) outputText("on a stool ");

--- a/classes/classes/Scenes/Places/TelAdre/Edryn.as
+++ b/classes/classes/Scenes/Places/TelAdre/Edryn.as
@@ -207,7 +207,7 @@ public function edrynBarTalk():void {
 		//Non horsedick
 		else {
 			outputText("but the potent musky scent only reminds you of how different things are here.");
-			if (player.lust < 33) {
+			if (player.lust >= 33) {
 				outputText("  Unbidden, your mind wonders what her juicy horse-snatch would feel like, and your " + player.cockDescript(0) + " responds immediately, thickening with readiness.  You squirm uncomfortably from how constricting your " + player.armorName + " feels.\n\n");
 				outputText("You give the rapidly dissipating scent a sniff and note that it isn't unpleasant, just strong, and once again you find yourself imagining standing ");
 				if (player.tallness < 60) outputText("on a stool ");


### PR DESCRIPTION
If the player has a dick, but none are horse-type, then they can't proposition Edryn for sex for the first time unless they have a corruption of 50 or turned on low standards. This is a bit silly. I've changed the requirements to instead require that the player has at least 33 lust (the same requirement as most sex scene options)