### PR TITLE
Do not fail build if sonarcloud fails

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -69,6 +69,7 @@ jobs:
       run: devTools/ci/update-sonar-version.sh
 
     - name: SonarCloud Scan
+      continue-on-error: true
       uses: sonarsource/sonarcloud-github-action@master
       with:
         # The value for SONAR_ORG can be found in sonarcloud > my organisations > copy the key for the org you wish to use


### PR DESCRIPTION
This will allow builds to pass if the repo owner does not set the required secrets for sonarcloud.